### PR TITLE
added format in test cases

### DIFF
--- a/binding-service-impl/src/test/java/io/mosip/esignet/KeyBindingServiceTest.java
+++ b/binding-service-impl/src/test/java/io/mosip/esignet/KeyBindingServiceTest.java
@@ -201,6 +201,7 @@ public class KeyBindingServiceTest {
 		AuthChallenge authChallenge = new AuthChallenge();
 		authChallenge.setAuthFactorType("OTP");
 		authChallenge.setChallenge("111111");
+		authChallenge.setFormat("alpha-numeric");
 		List<AuthChallenge> authChallengeList = new ArrayList();
 		authChallengeList.add(authChallenge);
 		walletBindingRequest.setChallengeList(authChallengeList);


### PR DESCRIPTION
Added format in keyBindingServiceTest in the method bindWallet_withUnsupportedFormat_thenFail to verify the unsupported challenge format