### PR TITLE
ES-209

### DIFF
--- a/esignet-service/src/main/java/io/mosip/esignet/advice/HeaderValidationFilter.java
+++ b/esignet-service/src/main/java/io/mosip/esignet/advice/HeaderValidationFilter.java
@@ -49,13 +49,14 @@ public class HeaderValidationFilter extends OncePerRequestFilter {
     private MessageSource messageSource;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        final String path = request.getRequestURI();
+        return !pathsToValidate.contains(path);
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         final String path = request.getRequestURI();
-
-        if(!pathsToValidate.contains(path)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
 
         try {
             log.info("Started to validate {} for oauth-details headers", path);

--- a/esignet-service/src/main/java/io/mosip/esignet/config/SecurityConfig.java
+++ b/esignet-service/src/main/java/io/mosip/esignet/config/SecurityConfig.java
@@ -104,6 +104,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         //Even though oidc/** is part of ignore-auth-urls, bearer token is getting validated in the security filters and fails with 401 error.
         //Bearer token of the userinfo endpoint is signed with IDP keys.
         //We currently donot have a way to set 2 different authentication providers in spring security.
-        webSecurity.ignoring().antMatchers(servletPath+"/oidc/userinfo");
+        webSecurity.ignoring().antMatchers(servletPath+"/oidc/userinfo", servletPath+"/vci/credential");
     }
 }

--- a/vci-service-impl/src/main/java/io/mosip/esignet/vci/config/VCIConfig.java
+++ b/vci-service-impl/src/main/java/io/mosip/esignet/vci/config/VCIConfig.java
@@ -22,23 +22,11 @@ import org.springframework.web.context.annotation.RequestScope;
 @ComponentScan(basePackages = {"io.mosip.esignet.vci"})
 public class VCIConfig {
 
-    @Value("#{${mosip.esignet.vci.authn.filter-urls}}")
-    private String[] urlPatterns;
-
-    @Autowired
-    private AccessTokenValidationFilter accessTokenValidationFilter;
-
     @Bean
     @RequestScope
     public ParsedAccessToken parsedAccessToken() {
         return new ParsedAccessToken();
     }
 
-    @Bean
-    public FilterRegistrationBean<AccessTokenValidationFilter> accessTokenValidationFilterBean() {
-        FilterRegistrationBean<AccessTokenValidationFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(accessTokenValidationFilter);
-        registrationBean.addUrlPatterns(urlPatterns); // Specify the URL patterns to filter
-        return registrationBean;
-    }
+
 }


### PR DESCRIPTION
1. As filter is component, there is no need to register the filter bean.
2. using shouldNotFilter overriden method instead of custom logic inside filter method to match url patterns.
3. Nullified spring's default security filter chain on /vci/credential endpoint