### PR TITLE
[ES-326] default wellknown endpoint in helm charts & env-config

### DIFF
--- a/helm/oidc-ui/values.yaml
+++ b/helm/oidc-ui/values.yaml
@@ -426,6 +426,12 @@ oidc_ui:
       REACT_APP_SBI_DOMAIN_URI: 'http://esignet.$NS'
       OIDC_UI_PUBLIC_URL: ''
       SIGN_IN_WITH_ESIGNET_PLUGIN_URL: 'http://artifactory.artifactory:80/artifactory/libs-release-local/mosip-plugins/sign-in-with-esignet.zip'
+      DEFAULT_WELLKNOWN: '%5B%7B%22name%22%3A%22OpenID%20Configuration%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-configuration%22%7D%2C%7B%22name%22%3A%22Jwks%20Json%22%2C%22value%22%3A%22%2F.well-known%2Fjwks.json%22%7D%2C%7B%22name%22%3A%22Authorization%20Server%22%2C%22value%22%3A%22%2F.well-known%2Foauth-authorization-server%22%7D%2C%7B%22name%22%3A%22OpenID%20Credential%20Issuer%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-credential-issuer%22%7D%5D'
+      DEFAULT_THEME: ''
+      DEFAULT_LANG: 'en'
+      DEFAULT_FEVICON: 'favicon.ico'
+      DEFAULT_TITLE: 'e-Signet'
+      DEFAULT_ID_PROVIDER_NAME: 'e-Signet'
 
 ## OIDC UI swagger should have only internal access. Hence linked to internal gateway
 ## We create a gateway for esignet specific URL(s) listed under `hosts`

--- a/oidc-ui/public/env-config.js
+++ b/oidc-ui/public/env-config.js
@@ -1,20 +1,6 @@
 window._env_ = {
   DEFAULT_LANG: "en",
-  DEFAULT_WELLKNOWN: [
-    {
-      name: "OpenID Configuration",
-      value: "/.well-known/openid-configuration",
-    },
-    { name: "Jwks Json", value: "/.well-known/jwks.json" },
-    {
-      name: "Authorization Server",
-      value: "/.well-known/oauth-authorization-server",
-    },
-    {
-      name: "OpenID Credential Issuer",
-      value: "/.well-known/openid-credential-issuer",
-    },
-  ],
+  DEFAULT_WELLKNOWN: "%5B%7B%22name%22%3A%22OpenID%20Configuration%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-configuration%22%7D%2C%7B%22name%22%3A%22Jwks%20Json%22%2C%22value%22%3A%22%2F.well-known%2Fjwks.json%22%7D%2C%7B%22name%22%3A%22Authorization%20Server%22%2C%22value%22%3A%22%2F.well-known%2Foauth-authorization-server%22%7D%2C%7B%22name%22%3A%22OpenID%20Credential%20Issuer%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-credential-issuer%22%7D%5D",
   DEFAULT_THEME: '',
   DEFAULT_FEVICON: 'favicon.ico',
   DEFAULT_TITLE: 'e-Signet',

--- a/oidc-ui/src/components/EsignetDetails.js
+++ b/oidc-ui/src/components/EsignetDetails.js
@@ -12,8 +12,13 @@ export default function EsignetDetails({ i18nKeyPrefix = "esignetDetails" }) {
     setStatus({ state: states.LOADING, msg: t("loading_msg") });
 
     // if the environment is not passed then this will assigned as empty list
-    let detailList = window._env_.DEFAULT_WELLKNOWN ?? [];
-
+    let detailList = [];
+    try {
+      detailList = JSON.parse(decodeURIComponent(window._env_.DEFAULT_WELLKNOWN));
+    } catch (error) {
+      console.error("Default Wellknown Endpoint is not a valid JSON");
+    }
+    
     setDetails(detailList);
     setStatus({ state: states.LOADED, msg: "" });
   }, []);


### PR DESCRIPTION
Adding default wellknown endpoints in env-config file as well as in helm charts, so that it can be configure without changing any code