### PR TITLE
[ES-927] added reset captcha after api failure

### DIFF
--- a/oidc-ui/src/components/Form.js
+++ b/oidc-ui/src/components/Form.js
@@ -122,7 +122,8 @@ export default function Form({
           setError({
             errorCode: `${errors[0].errorCode}`
           });
-        }        
+        }
+        _reCaptchaRef.current.reset();        
         return;
       } else {
         setError(null);
@@ -148,6 +149,7 @@ export default function Form({
         defaultMsg: error.message,
       });
       setStatus(states.ERROR);
+      _reCaptchaRef.current.reset();        
     }
   };
 

--- a/oidc-ui/src/components/OtpGet.js
+++ b/oidc-ui/src/components/OtpGet.js
@@ -124,6 +124,7 @@ export default function OtpGet({
             show: true
           });
         }
+        _reCaptchaRef.current.reset();
         return;
       } else {
         onOtpSent(loginState["Otp_mosip-vid"], response);
@@ -135,6 +136,7 @@ export default function OtpGet({
         show: true
       });
       setStatus({ state: states.ERROR, msg: "" });
+      _reCaptchaRef.current.reset();
     }
   };
 

--- a/oidc-ui/src/components/Password.js
+++ b/oidc-ui/src/components/Password.js
@@ -177,6 +177,7 @@ export default function Password({
             show: true
           });
         }
+        _reCaptchaRef.current.reset();
         return;
       } else {
         setErrorBanner(null);
@@ -201,6 +202,7 @@ export default function Password({
         show: true
       });
       setStatus(states.ERROR);
+      _reCaptchaRef.current.reset();
     }
   };
 


### PR DESCRIPTION
After api failing in the password page, if we again reuse the previous captcha token.
It is throwing invalid captcha token.

Due to this, we are resetting the captcha token, if any api failure occur while login.