### PR TITLE
[ES-1023] input with numpad number & copy paste keycode

### DIFF
--- a/oidc-ui/src/components/InputWithImage.js
+++ b/oidc-ui/src/components/InputWithImage.js
@@ -51,50 +51,50 @@ export default function InputWithImage({
 
     var keyCode = e.keyCode || e.which;
 
+    // number checking function checks if the key is a number or not
+    // restricting with shift + number key
+    const numberChecking = (key, shift) =>
+      (key >= 48 && key <= 57 && !shift) || (key >= 96 && key <= 105);
+
+    // letter checking function checks if the key is a letter or not
+    const letterChecking = (key) =>
+      (key >= 65 && key <= 90);
+
+    // multiKeyChecking function checks if the key is
+    // ctrl + a, ctrl + c, ctrl + v
+    const multiKeyChecking = (key, ctrl) =>
+      ctrl && (key === 65 || key === 67 || key === 86);
+
+    // checking max length for the input
     const checkMaxLength = (maxLength) =>
       maxLength === "" ? true : e.target.value.length < parseInt(maxLength);
 
     // Allow some special keys like Backspace, Tab, Home, End, Left Arrow, Right Arrow, Delete.
-    const allowedKeyCodes = [8, 9, 35, 36, 37, 39, 46];
+    const allowedKeyCodes = [8, 9, 17, 35, 36, 37, 39, 46];
 
-    if (!allowedKeyCodes.includes(keyCode)) {
-
+    if (!allowedKeyCodes.includes(keyCode) && !multiKeyChecking(keyCode, e.ctrlKey)) {
       // checking max length for the input
-      // if greater than the maxlength then prevent the default action
+      // if greater than the max length then prevent the default action
       if (!checkMaxLength(maxLength)) {
         e.preventDefault();
       }
 
-      if (type === "number") {
-
+      if (type === "number" && !numberChecking(keyCode, e.shiftKey)) {
         // Check if the pressed key is a number
-        if (keyCode < 48 || keyCode > 57) {
-          // Prevent the default action (typing the letter or specified character)
-          e.preventDefault();
-        }
-      }
-
-      else if (type === "letter") {
-
+        e.preventDefault();
+      } else if (type === "letter" && !letterChecking(keyCode)) {
         // Check if the pressed key is a letter (a-zA-Z)
-        if (!((keyCode >= 65 && keyCode <= 90) ||     // Uppercase letters A-Z
-          (keyCode >= 97 && keyCode <= 122))) {         // Lowercase letters a-z
-
-          // Prevent input of other characters
-          e.preventDefault();
-        }
-      }
-
-      else if (type === "alpha-numeric") {
-
+        // Lower & upper case letters a-z
+        // Prevent input of other characters
+        e.preventDefault();
+      } else if (
+        type === "alpha-numeric" &&
+        !(numberChecking(keyCode, e.shiftKey) || letterChecking(keyCode))
+      ) {
         // Check if the pressed key is a number (0-9) or a letter (a-zA-Z)
-        if (!((keyCode >= 48 && keyCode <= 57) ||     // Numbers 0-9
-          (keyCode >= 65 && keyCode <= 90) ||           // Uppercase letters A-Z
-          (keyCode >= 97 && keyCode <= 122))) {         // Lowercase letters a-z  
-
-          // Prevent input of other characters
-          e.preventDefault();
-        }
+        // Numpad numbers 0-9
+        // Prevent input of other characters
+        e.preventDefault();
       }
     }
   }


### PR DESCRIPTION
- Added numpad inclusion for number input
- Restricted combination of shift key with number in type number
- allowing ctrl+a, ctrl+c & ctrl+v in the input