### PR TITLE
[ES-1113] pwd to kba for kba authentication

### DIFF
--- a/oidc-ui/src/components/Form.js
+++ b/oidc-ui/src/components/Form.js
@@ -79,7 +79,7 @@ export default function Form({
     .map((x) => x.trim().toLowerCase());
 
   const [showCaptcha, setShowCaptcha] = useState(
-    captchaEnableComponentsList.indexOf("pwd") !== -1
+    captchaEnableComponentsList.indexOf("kba") !== -1
   );
 
   const captchaSiteKey =


### PR DESCRIPTION
previously `pwd` has been used for kba authentication page to showing captcha, now we are using `kba` to show the captcha in login page