### PR TITLE
[MOSIP-35593] adde error message on oauth-detail failure

### DIFF
--- a/oidc-ui/src/components/Authorize.js
+++ b/oidc-ui/src/components/Authorize.js
@@ -160,6 +160,11 @@ export default function Authorize({ authService }) {
             } else {
               setStatus(states.LOADED);
             }
+          } else {
+            setStatus(states.LOADED);
+            setOAuthDetailResponse(null);
+            setError(oAuthDetailsResponse.errors[0].errorCode);
+            setStatus(states.ERROR);
           }
         };
 


### PR DESCRIPTION
- when there is a failure in oauth-details successful response, there is no error message path for that