### PR TITLE
[ES-1688] removed withError from resume api

### DIFF
--- a/oidc-ui/src/pages/Consent.js
+++ b/oidc-ui/src/pages/Consent.js
@@ -91,7 +91,6 @@ export default function ConsentPage() {
         } else {
           const { errors } = await authServices.resume(
             transactionId,
-            params.has("error"),
             oAuthDetailsHash
           );
 

--- a/oidc-ui/src/services/authService.js
+++ b/oidc-ui/src/services/authService.js
@@ -277,11 +277,11 @@ class authService {
     return response.data;
   };
 
-  resume = async (transactionId, withError, oAuthDetailsHash) => {
+  resume = async (transactionId, oAuthDetailsHash) => {
     const requestTime = new Date().toISOString();
     const request = {
       requestTime,
-      request: { transactionId, withError },
+      request: { transactionId },
     };
 
     const oauthDetailsHash =


### PR DESCRIPTION
removing of withError parameter, due to changes in complete-signup-redirect api