### PR TITLE
[ES-1601] Captcha validation support during send-binding-otp (#961)

### DIFF
--- a/binding-service-impl/pom.xml
+++ b/binding-service-impl/pom.xml
@@ -29,5 +29,5 @@
 			<artifactId>esignet-core</artifactId>
 			<version>${esignet.core.version}</version>
 		</dependency>
-	</dependencies>
+    </dependencies>
 </project>

--- a/binding-service-impl/src/test/java/io/mosip/esignet/KeyBindingServiceTest.java
+++ b/binding-service-impl/src/test/java/io/mosip/esignet/KeyBindingServiceTest.java
@@ -5,21 +5,9 @@
  */
 package io.mosip.esignet;
 
-import static io.mosip.esignet.api.util.ErrorConstants.SEND_OTP_FAILED;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
-import java.time.LocalDateTime;
-import java.util.*;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import io.mosip.esignet.api.dto.AuthChallenge;
@@ -28,10 +16,14 @@ import io.mosip.esignet.api.dto.SendOtpResult;
 import io.mosip.esignet.api.exception.KeyBindingException;
 import io.mosip.esignet.api.exception.SendOtpException;
 import io.mosip.esignet.api.spi.KeyBinder;
-import io.mosip.esignet.entity.PublicKeyRegistry;
-import io.mosip.esignet.core.dto.*;
-import io.mosip.esignet.core.exception.EsignetException;
 import io.mosip.esignet.core.constants.ErrorConstants;
+import io.mosip.esignet.core.dto.BindingOtpRequest;
+import io.mosip.esignet.core.dto.BindingOtpRequestV2;
+import io.mosip.esignet.core.dto.BindingOtpResponse;
+import io.mosip.esignet.core.dto.WalletBindingRequest;
+import io.mosip.esignet.core.exception.EsignetException;
+import io.mosip.esignet.core.util.CaptchaHelper;
+import io.mosip.esignet.entity.PublicKeyRegistry;
 import io.mosip.esignet.repository.PublicKeyRegistryRepository;
 import io.mosip.esignet.services.KeyBindingHelperService;
 import io.mosip.esignet.services.KeyBindingServiceImpl;
@@ -47,9 +39,21 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jose.jwk.JWK;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static io.mosip.esignet.api.util.ErrorConstants.SEND_OTP_FAILED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Slf4j
 @RunWith(MockitoJUnitRunner.class)
@@ -70,9 +74,15 @@ public class KeyBindingServiceTest {
 	@Mock
 	KeymanagerUtil keymanagerUtil;
 
+	CaptchaHelper captchaHelper;
+
+	@Mock
+	RestTemplate restTemplate;
+
 	private JWK clientJWK = generateJWK_RSA();
 
 	private ObjectMapper objectMapper = new ObjectMapper();
+
 
 	@Before
 	public void setUp() {
@@ -82,13 +92,17 @@ public class KeyBindingServiceTest {
 		mockKeyBindingWrapperService = mock(KeyBinder.class);
 		when(mockKeyBindingWrapperService.getSupportedChallengeFormats(Mockito.anyString()))
 				.thenReturn(Arrays.asList("jwt", "alpha-numeric"));
+
+		captchaHelper = new CaptchaHelper(restTemplate, "https://api-internal.camdgc-dev1.mosip.net/v1/captcha/validatecaptcha",
+				"esignet", List.of("binding-otp"));
+
 		ReflectionTestUtils.setField(keyBindingService, "keyBindingWrapper", mockKeyBindingWrapperService);
 
 		keyBindingHelperService = mock(KeyBindingHelperService.class);
 		ReflectionTestUtils.setField(keyBindingHelperService, "saltLength", 10);
 		ReflectionTestUtils.setField(keyBindingHelperService, "publicKeyRegistryRepository", publicKeyRegistryRepository);
 		ReflectionTestUtils.setField(keyBindingHelperService, "keymanagerUtil", keymanagerUtil);
-
+		ReflectionTestUtils.setField(keyBindingService, "captchaHelper", captchaHelper);
 		ReflectionTestUtils.setField(keyBindingService, "keyBindingHelperService", keyBindingHelperService);
 	}
 
@@ -106,7 +120,8 @@ public class KeyBindingServiceTest {
 		BindingOtpResponse otpResponse = keyBindingService.sendBindingOtp(otpRequest, headers);
 		Assert.assertNotNull(otpResponse);
 	}
-	
+
+
 	@Test(expected = EsignetException.class)
 	public void sendBindingOtp_withInvalidRequest_thenFail() throws SendOtpException {
 		BindingOtpRequest otpRequest = new BindingOtpRequest();
@@ -117,6 +132,41 @@ public class KeyBindingServiceTest {
 		when(mockKeyBindingWrapperService.sendBindingOtp(anyString(), any(), any())).thenThrow(SendOtpException.class);
 
 		keyBindingService.sendBindingOtp(otpRequest, headers);
+	}
+
+
+	@Test
+	public void sendBindingOtpV2_withInvalidCaptcha_thenFail() throws SendOtpException {
+
+		BindingOtpRequestV2 otpRequest = new BindingOtpRequestV2();
+		otpRequest.setIndividualId("8267411571");
+		otpRequest.setOtpChannels(Arrays.asList("OTP"));
+		otpRequest.setCaptchaToken("qwerty");
+
+		Map<String, String> headers = new HashMap<>();
+
+		try {
+			keyBindingService.sendBindingOtpV2(otpRequest, headers);
+		} catch (EsignetException e) {
+			Assert.assertTrue(e.getErrorCode().equals(ErrorConstants.INVALID_CAPTCHA));
+		}
+	}
+
+	@Test
+	public void sendBindingOtpV2_withEmptyCaptcha_thenFail() throws SendOtpException {
+
+		BindingOtpRequestV2 otpRequest = new BindingOtpRequestV2();
+		otpRequest.setIndividualId("8267411571");
+		otpRequest.setOtpChannels(Arrays.asList("OTP"));
+		otpRequest.setCaptchaToken("");
+
+		Map<String, String> headers = new HashMap<>();
+
+		try {
+			keyBindingService.sendBindingOtpV2(otpRequest, headers);
+		} catch (EsignetException e) {
+			Assert.assertTrue(e.getErrorCode().equals(ErrorConstants.INVALID_CAPTCHA));
+		}
 	}
 
 	@Test
@@ -368,4 +418,5 @@ public class KeyBindingServiceTest {
 		}
 		return null;
 	}
+
 }

--- a/docs/esignet-openapi.yaml
+++ b/docs/esignet-openapi.yaml
@@ -4428,6 +4428,112 @@ paths:
         - url: 'https://esignet.collab.mosip.net/v1/esignet'
       x-stoplight:
         id: t315hcecaulyy
+  /binding/v2/binding-otp:
+    post:
+      tags:
+        - WALLET BACKEND
+      summary: Send Binding OTP Endpoint
+      description: Send wallet binding OTP endpoint is invoked by Mimoto server.
+      operationId: post-binding-otp
+      parameters:
+        - name: partner-api-key
+          in: header
+          description: 'API key of the binding partner, this will be passed to binder implementation to interact with authentication system.'
+          schema:
+            type: string
+        - name: partner-id
+          in: header
+          description: 'Binding partner Identifier, this will be passed to binder implementation to interact with authentication system.'
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestTime:
+                  type: string
+                request:
+                  type: object
+                  properties:
+                    individualId:
+                      type: string
+                      description: User Id (UIN/VID)
+                    otpChannels:
+                      type: array
+                      description: Channels to which OTP should be delivered.
+                      items:
+                        type: string
+                    captchaToken:
+                      type: string
+                      description: 'Captcha token, if enabled.'
+                  required:
+                    - individualId
+                    - otpChannels
+              required:
+                - requestTime
+                - request
+            examples:
+              Example 1:
+                value:
+                  requestTime: '2023-09-22T08:01:13.000Z'
+                  request:
+                    individualId: '24554655645'
+                    otpChannels:
+                      - sms
+                      - email
+                    captchaToken: ALSKDJFURIEOQPZMKFURHFVBH
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  responseTIme:
+                    type: string
+                  response:
+                    type: object
+                    properties:
+                      maskedEmail:
+                        type: string
+                        description: Masked email id of the individualId user.
+                      maskedMobile:
+                        type: string
+                        description: Masked mobile number of the individualId user.
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        errorCode:
+                          type: string
+                          enum:
+                            - invalid_otp_channel
+                            - unknown_error
+                            - invalid_individual_id
+                            - send_otp_failed
+                            - invalid_captcha
+                        errorMessage:
+                          type: string
+                required:
+                  - responseTIme
+              examples:
+                Example 1:
+                  value:
+                    responseTIme: '2023-09-22T08:01:16.000Z'
+                    response:
+                      maskedEmail: XXdXXaXXhXXkX@gmail.com
+                      maskedMobile: XXXXXXX357934
+                    errors: [ ]
+      security:
+        - Authorization-send_binding_otp: [ ]
+      servers:
+        - url: 'https://esignet.collab.mosip.net/v1/esignet'
+      x-stoplight:
+        id: xnl3gyq4v4bh4
   /binding/wallet-binding:
     post:
       tags:
@@ -5272,8 +5378,6 @@ components:
                     x-stoplight:
                       id: 5q6luh9khretn
                     description: |2-
-
-
 
 
 

--- a/esignet-core/src/main/java/io/mosip/esignet/core/config/SharedComponentConfig.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/config/SharedComponentConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+
 @Configuration
 public class SharedComponentConfig {
 
@@ -15,7 +17,8 @@ public class SharedComponentConfig {
 
     @Bean
     public CaptchaHelper captchaHelper(@Value("${mosip.esignet.captcha.validator-url}") String validatorUrl,
-                                        @Value("${mosip.esignet.captcha.module-name}") String moduleName) {
-        return new CaptchaHelper(restTemplate, validatorUrl, moduleName);
+                                       @Value("${mosip.esignet.captcha.module-name}") String moduleName,
+                                       @Value("#{'${mosip.esignet.captcha.required}'}")List<String> captchaRequired) {
+        return new CaptchaHelper(restTemplate, validatorUrl, moduleName, captchaRequired);
     }
 }

--- a/esignet-core/src/main/java/io/mosip/esignet/core/dto/BindingOtpRequest.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/dto/BindingOtpRequest.java
@@ -24,4 +24,5 @@ public class BindingOtpRequest {
     @NotNull(message = ErrorConstants.INVALID_OTP_CHANNEL)
     @Size(min = 1, message = ErrorConstants.INVALID_OTP_CHANNEL)
     private List<@OtpChannel String> otpChannels;
+
 }

--- a/esignet-core/src/main/java/io/mosip/esignet/core/dto/BindingOtpRequestV2.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/dto/BindingOtpRequestV2.java
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.esignet.core.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class BindingOtpRequestV2 extends BindingOtpRequest{
+    private String captchaToken;
+}

--- a/esignet-core/src/main/java/io/mosip/esignet/core/spi/KeyBindingService.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/spi/KeyBindingService.java
@@ -5,17 +5,16 @@
  */
 package io.mosip.esignet.core.spi;
 
-import io.mosip.esignet.core.dto.BindingOtpResponse;
+import io.mosip.esignet.core.dto.*;
 import io.mosip.esignet.core.exception.EsignetException;
-import io.mosip.esignet.core.dto.BindingOtpRequest;
-import io.mosip.esignet.core.dto.WalletBindingRequest;
-import io.mosip.esignet.core.dto.WalletBindingResponse;
 
 import java.util.Map;
 
 public interface KeyBindingService {
 
     BindingOtpResponse sendBindingOtp(BindingOtpRequest otpRequest, Map<String, String> requestHeaders) throws EsignetException;
+
+    BindingOtpResponse sendBindingOtpV2(BindingOtpRequestV2 otpRequest, Map<String, String> requestHeaders) throws EsignetException;
 
     WalletBindingResponse bindWallet(WalletBindingRequest walletBindingRequest, Map<String, String> requestHeaders) throws EsignetException;
 }

--- a/esignet-service/src/main/java/io/mosip/esignet/controllers/KeyBindingController.java
+++ b/esignet-service/src/main/java/io/mosip/esignet/controllers/KeyBindingController.java
@@ -50,7 +50,27 @@ public class KeyBindingController {
         }
         return responseWrapper;
     }
-    
+
+
+    @PostMapping(value = "/v2/binding-otp", consumes = {MediaType.APPLICATION_JSON_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseWrapper<OtpResponse> sendBindingOtpV2(@Valid @RequestBody RequestWrapper<BindingOtpRequestV2> requestWrapper,
+                                                       @RequestHeader Map<String, String> headers)
+            throws EsignetException {
+        ResponseWrapper responseWrapper = new ResponseWrapper();
+        try {
+            responseWrapper.setResponse(keyBindingService.sendBindingOtpV2(requestWrapper.getRequest(), headers));
+            responseWrapper.setResponseTime(IdentityProviderUtil.getUTCDateTime());
+            auditPlugin.logAudit(Action.SEND_BINDING_OTP, ActionStatus.SUCCESS,
+                    AuditHelper.buildAuditDto("individualId", null), null);
+        } catch (EsignetException ex) {
+            auditPlugin.logAudit(Action.SEND_BINDING_OTP, ActionStatus.ERROR,
+                    AuditHelper.buildAuditDto("individualId", null), ex);
+            throw ex;
+        }
+        return responseWrapper;
+    }
+
     @PostMapping(value = "wallet-binding", consumes = {MediaType.APPLICATION_JSON_VALUE},
             produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseWrapper<WalletBindingResponse> bindWallet(@Valid @RequestBody RequestWrapper<WalletBindingRequest> requestWrapper,

--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -60,7 +60,7 @@ mosip.esignet.header-filter.paths-to-validate={'${server.servlet.path}/authoriza
   '${server.servlet.path}/authorization/complete-signup-redirect' }
 
 ## captcha validation is enabled for the auth-factors - otp, pwd, bio and pin.
-mosip.esignet.captcha.required=send-otp,pwd,kbi
+mosip.esignet.captcha.required=send-otp,pwd,kbi,binding-otp
 mosip.esignet.captcha.validator-url=http://captcha.captcha/v1/captcha/validatecaptcha
 mosip.esignet.captcha.module-name=esignet
 mosip.esignet.captcha.site-key=${esignet.captcha.site.key}

--- a/esignet-service/src/test/java/io/mosip/esignet/controllers/KeyBindingControllerTest.java
+++ b/esignet-service/src/test/java/io/mosip/esignet/controllers/KeyBindingControllerTest.java
@@ -142,6 +142,72 @@ public class KeyBindingControllerTest {
 	}
 
 	@Test
+	public void sendBindingOtpV2_withValidRequest_thenPass() throws Exception {
+		BindingOtpRequest otpRequest = new BindingOtpRequest();
+		otpRequest.setIndividualId("8267411571");
+		otpRequest.setOtpChannels(Arrays.asList("email"));
+		ZonedDateTime requestTime = ZonedDateTime.now(ZoneOffset.UTC);
+		RequestWrapper wrapper = new RequestWrapper<>();
+		wrapper.setRequestTime(requestTime.format(DateTimeFormatter.ofPattern(UTC_DATETIME_PATTERN)));
+		wrapper.setRequest(otpRequest);
+
+		BindingOtpResponse otpResponse = new BindingOtpResponse();
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Content-Type", "application/json;charset=UTF-8");
+		headers.put("Content-Length", "106");
+		when(keyBindingService.sendBindingOtp(otpRequest, headers)).thenReturn(otpResponse);
+		when(authenticationWrapper.isSupportedOtpChannel(Mockito.anyString())).thenReturn(true);
+
+		mockMvc.perform(post("/binding/v2/binding-otp").content(objectMapper.writeValueAsString(wrapper))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+	}
+
+	@Test
+	public void sendBindingOtpV2_withInvalidIndividualId_thenFail() throws Exception {
+		BindingOtpRequest otpRequest = new BindingOtpRequest();
+		otpRequest.setIndividualId("");
+		otpRequest.setOtpChannels(Arrays.asList("email"));
+		ZonedDateTime requestTime = ZonedDateTime.now(ZoneOffset.UTC);
+		RequestWrapper wrapper = new RequestWrapper<>();
+		wrapper.setRequestTime(requestTime.format(DateTimeFormatter.ofPattern(UTC_DATETIME_PATTERN)));
+		wrapper.setRequest(otpRequest);
+
+		BindingOtpResponse otpResponse = new BindingOtpResponse();
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Content-Type", "application/json;charset=UTF-8");
+		headers.put("Content-Length", "106");
+		when(keyBindingService.sendBindingOtp(otpRequest, headers)).thenReturn(otpResponse);
+		when(authenticationWrapper.isSupportedOtpChannel(Mockito.anyString())).thenReturn(true);
+
+		mockMvc.perform(post("/binding/v2/binding-otp").content(objectMapper.writeValueAsString(wrapper))
+						.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors").isNotEmpty())
+				.andExpect(jsonPath("$.errors[0].errorCode").value(INVALID_IDENTIFIER));
+	}
+
+	@Test
+	public void sendBindingOtpV2_withInvalidChannel_thenPass() throws Exception {
+		BindingOtpRequest otpRequest = new BindingOtpRequest();
+		otpRequest.setIndividualId("121323123s");
+		otpRequest.setOtpChannels(Arrays.asList());
+		ZonedDateTime requestTime = ZonedDateTime.now(ZoneOffset.UTC);
+		RequestWrapper wrapper = new RequestWrapper<>();
+		wrapper.setRequestTime(requestTime.format(DateTimeFormatter.ofPattern(UTC_DATETIME_PATTERN)));
+		wrapper.setRequest(otpRequest);
+
+		BindingOtpResponse otpResponse = new BindingOtpResponse();
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Content-Type", "application/json;charset=UTF-8");
+		headers.put("Content-Length", "106");
+		when(keyBindingService.sendBindingOtp(otpRequest, headers)).thenReturn(otpResponse);
+
+		mockMvc.perform(post("/binding/v2/binding-otp").content(objectMapper.writeValueAsString(wrapper))
+						.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors").isNotEmpty())
+				.andExpect(jsonPath("$.errors[0].errorCode").value(ErrorConstants.INVALID_OTP_CHANNEL));
+	}
+
+	@Test
 	public void bindWallet_withValidDetails_thenPass() throws Exception {
 		WalletBindingRequest walletBindingRequest = getWalletBindingRequest();
 		RequestWrapper wrapper = new RequestWrapper<>();


### PR DESCRIPTION
* capcha validation



* organized imports



* reverted maven mirror changes



* already changed earlier



* added property tag for oidc



* Removed API rate limit changes



* fixed test case issues



* changed binding otp to v2 flow



* addressed review comments



* removed unwanted variable



* review comments fixed



* review comments fixed



* review fixes



* correct the test case



* review comments fixed



---------