### PR TITLE
[ES-901] added heading message wrt purpose

### DIFF
--- a/oidc-ui/public/locales/ar.json
+++ b/oidc-ui/public/locales/ar.json
@@ -177,6 +177,8 @@
   },
   "header": {
     "login_heading": "تسجيل الدخول باستخدام eSignet",
+    "verify_heading": "التحقق باستخدام eSignet",
+    "link_heading": "الربط باستخدام eSignet",
     "login_subheading": "الرجاء إدخال اسم المستخدم وكلمة المرور المسجلين لديك",
     "login_linkName": "التسجيل المسبق",
     "more_ways_to_sign_in": "المزيد من الطرق لتسجيل الدخول",

--- a/oidc-ui/public/locales/en.json
+++ b/oidc-ui/public/locales/en.json
@@ -176,7 +176,9 @@
     "wellknown_api": ".wellknown API"
   },
   "header": {
-    "login_heading": "Login with eSignet",
+    "login_heading": "Login using eSignet",
+    "verify_heading": "Verify using eSignet",
+    "link_heading": "Link using eSignet",
     "login_subheading": "Please enter your registered username and password",
     "login_linkName": "Preregister",
     "more_ways_to_sign_in": "More Ways to Login",

--- a/oidc-ui/public/locales/hi.json
+++ b/oidc-ui/public/locales/hi.json
@@ -176,7 +176,9 @@
     "wellknown_api": ".सुप्रसिद्ध एपीआई"
   },
   "header": {
-    "login_heading": "ई-सिग्नेट से लॉगिन करें",
+    "login_heading": "eSignet का उपयोग करके लॉग इन करें",
+    "verify_heading": "eSignet का उपयोग करके सत्यापित करें",
+    "link_heading": "eSignet का उपयोग करके लिंक करें",
     "login_subheading": "कृपया अपना पंजीकृत उपयोगकर्ता नाम और पासवर्ड दर्ज करें",
     "login_linkName": "पूर्वपंजीकरण",
     "more_ways_to_sign_in": "लॉगिन करने के और भी तरीके",

--- a/oidc-ui/public/locales/km.json
+++ b/oidc-ui/public/locales/km.json
@@ -176,7 +176,9 @@
     "wellknown_api": ".ល្បី API"
   },
   "header": {
-    "login_heading": "ចូលជាមួយ eSignet",
+    "login_heading": "ចូលដោយប្រើ eSignet",
+    "verify_heading": "ផ្ទៀងផ្ទាត់ដោយប្រើ eSignet",
+    "link_heading": "ភ្ជាប់ដោយប្រើ eSignet",
     "login_subheading": "សូមបញ្ចូលឈ្មោះអ្នកប្រើប្រាស់ និងពាក្យសម្ងាត់ដែលបានចុះឈ្មោះរបស់អ្នក។",
     "login_linkName": "ចុះឈ្មោះជាមុន",
     "more_ways_to_sign_in": "វិធីច្រើនទៀតដើម្បីចូល",

--- a/oidc-ui/public/locales/kn.json
+++ b/oidc-ui/public/locales/kn.json
@@ -176,7 +176,9 @@
     "wellknown_api": "ಪ್ರಸಿದ್ಧ API"
   },
   "header": {
-    "login_heading": "eSignet ನೊಂದಿಗೆ ಲಾಗಿನ್ ಮಾಡಿ",
+    "login_heading": "eSignet ಬಳಸಿ ಲಾಗಿನ್ ಮಾಡಿ",
+    "verify_heading": "eSignet ಬಳಸಿ ಪರಿಶೀಲಿಸಿ",
+    "link_heading": "eSignet ಬಳಸಿ ಲಿಂಕ್ ಮಾಡಿ",
     "login_subheading": "ದಯವಿಟ್ಟು ನಿಮ್ಮ ನೋಂದಾಯಿತ ಬಳಕೆದಾರಹೆಸರು ಮತ್ತು ಪಾಸ್‌ವರ್ಡ್ ಅನ್ನು ನಮೂದಿಸಿ",
     "login_linkName": "ಮುಂಚಿತವಾಗಿ ನೋಂದಾಯಿಸಿ",
     "more_ways_to_sign_in": "ಲಾಗಿನ್ ಮಾಡಲು ಹೆಚ್ಚಿನ ಮಾರ್ಗಗಳು",

--- a/oidc-ui/public/locales/ta.json
+++ b/oidc-ui/public/locales/ta.json
@@ -176,7 +176,9 @@
     "wellknown_api": "நன்கு அறியப்பட்ட API"
   },
   "header": {
-    "login_heading": "eSignet மூலம் உள்நுழைக",
+    "login_heading": "eSignet-ஐப் பயன்படுத்தி உள்நுழைக",
+    "verify_heading": "eSignet-ஐப் பயன்படுத்தி சரிபார்க்கவும்",
+    "link_heading": "eSignet-ஐப் பயன்படுத்தி இணைக்கவும்",
     "login_subheading": "உங்கள் பதிவு செய்யப்பட்ட பயனர்பெயர் மற்றும் கடவுச்சொல்லை உள்ளிடவும்",
     "login_linkName": "முன்பதிவு",
     "more_ways_to_sign_in": "உள்நுழைவதற்கான கூடுதல் வழிகள்",

--- a/oidc-ui/src/constants/clientConstants.js
+++ b/oidc-ui/src/constants/clientConstants.js
@@ -114,6 +114,12 @@ const errorCodeObj = {
   no_ekyc_provider: "no_ekyc_provider"
 };
 
+const purposeObj = {
+  login: "login_heading",
+  verify: "verify_heading",
+  link: "link_heading"
+}
+
 export {
   deviceType,
   challengeTypes,
@@ -124,5 +130,6 @@ export {
   challengeFormats,
   walletConfigKeys,
   modalityIconPath,
-  errorCodeObj
+  errorCodeObj,
+  purposeObj
 };

--- a/oidc-ui/src/pages/Login.js
+++ b/oidc-ui/src/pages/Login.js
@@ -18,6 +18,7 @@ import openIDConnectService from "../services/openIDConnectService";
 import DefaultError from "../components/DefaultError";
 import Password from "../components/Password";
 import Form from "../components/Form";
+import { purposeObj } from "../constants/clientConstants";
 
 function InitiateL1Biometrics(openIDConnectService, backButtonDiv) {
   return React.createElement(L1Biometrics, {
@@ -135,6 +136,7 @@ export default function LoginPage({ i18nKeyPrefix = "header" }) {
   const [clientLogoURL, setClientLogoURL] = useState(null);
   const [clientName, setClientName] = useState(null);
   const [authFactorType, setAuthFactorType] = useState(null);
+  const [heading, setHeading] = useState(purposeObj.login);
   const [searchParams] = useSearchParams();
   const location = useLocation();
 
@@ -231,6 +233,11 @@ export default function LoginPage({ i18nKeyPrefix = "header" }) {
 
   const loadComponent = () => {
     let oAuthDetailResponse = oidcService.getOAuthDetails();
+    // set dynamic heading according the purpose from oauth details
+    // otherwise default heading will be login
+    if (oAuthDetailResponse?.purpose && (oAuthDetailResponse.purpose in purposeObj)) {
+      setHeading(purposeObj[oAuthDetailResponse.purpose]);
+    }
     setClientLogoURL(oAuthDetailResponse?.logoUrl);
     setClientName(oAuthDetailResponse?.clientName);
     handleBackButtonClick();
@@ -253,7 +260,7 @@ export default function LoginPage({ i18nKeyPrefix = "header" }) {
     <>
       {!checkForIDT(JSON.parse(decodeOAuth).authFactors) && (
         <Background
-          heading={t("login_heading", {
+          heading={t(heading, {
             idProviderName: window._env_.DEFAULT_ID_PROVIDER_NAME,
           })}
           subheading={clientName}


### PR DESCRIPTION
Checking purpose

- if purpose is not present, null or undefined using `Login using eSignet`
- if purpose = `login` then `Login using eSignet`
- if purpose = `link` then `Link using eSignet`
- if purpose = `verify` then `Verify using eSignet`


Added additional key in i18n bundle of all 6 languages

- link_heading
- verify_heading