### PR TITLE
MOSIP-41597 - remove authmanager dependency from esignet module

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testscripts/PostWithBodyWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testscripts/PostWithBodyWithOtpGenerate.java
@@ -114,8 +114,15 @@ public class PostWithBodyWithOtpGenerate extends EsignetUtil implements ITest {
 		
 		Response otpResponse = null;
 		if (testCaseName.contains("ESignet_WalletBinding")) {
-			otpResponse = postRequestWithCookieAuthHeader(tempUrl + sendOtpEndPoint, inputJson, COOKIENAME,
-					testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
+			if (EsignetUtil.getIdentityPluginNameFromEsignetActuator().toLowerCase()
+					.contains("mockauthenticationservice") == true) {
+				inputJson = inputJsonKeyWordHandeler(inputJson, testCaseName);
+				otpResponse = EsignetUtil.postRequestWithCookieAndAuthHeader(tempUrl + sendOtpEndPoint, inputJson,
+						COOKIENAME, testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
+			} else {
+				otpResponse = postRequestWithCookieAuthHeader(tempUrl + sendOtpEndPoint, inputJson, COOKIENAME,
+						testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
+			}
 		} else {
 			otpResponse = postWithBodyAndCookie(ApplnURI + sendOtpEndPoint, inputJson, COOKIENAME,
 					GlobalConstants.RESIDENT, testCaseDTO.getTestCaseName());
@@ -157,8 +164,15 @@ public class PostWithBodyWithOtpGenerate extends EsignetUtil implements ITest {
 		reqJson = EsignetUtil.inputstringKeyWordHandeler(reqJson, testCaseName);
 
 		if (testCaseName.contains("ESignet_WalletBinding")) {
-			response = postRequestWithCookieAuthHeader(tempUrl + testCaseDTO.getEndPoint(), reqJson, COOKIENAME,
-					testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
+			if (EsignetUtil.getIdentityPluginNameFromEsignetActuator().toLowerCase()
+					.contains("mockauthenticationservice") == true) {
+				reqJson = inputJsonKeyWordHandeler(reqJson, testCaseName);
+				response = EsignetUtil.postRequestWithCookieAndAuthHeader(tempUrl + testCaseDTO.getEndPoint(), reqJson,
+						COOKIENAME, testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
+			} else {
+				response = postRequestWithCookieAuthHeader(tempUrl + testCaseDTO.getEndPoint(), reqJson, COOKIENAME,
+						testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
+			}
 		} else {
 			response = postRequestWithCookieAndHeader(ApplnURI + testCaseDTO.getEndPoint(), reqJson, COOKIENAME,
 					testCaseDTO.getRole(), testCaseDTO.getTestCaseName(), sendEsignetToken);

--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetUtil.java
@@ -1437,7 +1437,13 @@ public class EsignetUtil extends AdminTestUtil {
 			String role, String testCaseName, String idKeyName) {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
-		token = kernelAuthLib.getTokenByRole(role);
+		token = "";
+		if (EsignetUtil.getIdentityPluginNameFromEsignetActuator().toLowerCase()
+				.contains("mockauthenticationservice") == true) {
+			token = getAuthTokenByRole(role);
+		}else {
+			token = kernelAuthLib.getTokenByRole(role);
+		}
 		String apiKey = null;
 		String partnerId = null;
 		JSONObject req = new JSONObject(inputJson);


### PR DESCRIPTION
- Updated logic to retrieve the auth token from Keycloak instead of using the AuthManager API.