### PR TITLE
[ES-2374] [ES-2341] modified max-length property to 16, end-user-guide url

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -31,7 +31,7 @@ This is the docker compose setup to run esignet UI and esignet-service with mock
    b. `redirect_uri` -> As updated in step 5
 
 8. Add a user in the mock-identity-system. Invoke `Creat User` request under `User Mgmt` -> `Mock` folder in the postman. 
-9. Now the setup is completely ready to start the OIDC flow. [Refer eSignet user guides](https://docs.esignet.io/end-user-guide) for more information.
+9. Now the setup is completely ready to start the OIDC flow. [Refer eSignet user guides](https://docs.esignet.io/test/end-user-guide) for more information.
 
 `Note: To know more about the relying party onboard and query parameters used in the eSignet authorize URL `[refer eSignet docs](https://docs.esignet.io/integration/relying-party)
 

--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -387,7 +387,7 @@ mosip.esignet.ui.config.username.regex=.*
 mosip.esignet.ui.config.username.prefix=
 mosip.esignet.ui.config.username.postfix=
 
-mosip.esignet.ui.config.username.max-length=12
+mosip.esignet.ui.config.username.max-length=16
 mosip.esignet.ui.config.username.input-type=text
 
 ## This configuration offers a structured approach to supporting multiple login ID types, providing customization options such as prefixes (e.g., country codes for mobile numbers), associated icons, and validation rules (e.g., regex patterns or length constraints). Each login ID type is configurable, ensuring flexibility and consistency across the UI. If no value is provided for the configuration, it defaults to the VID login type as a fallback.


### PR DESCRIPTION
- Modified `esignet.config.ui.username.max-length` property from 12 to 16, because vid length is 16
- Modified esignet end use guide gitbook url in docker-compose readme file