### PR TITLE
[ES-2375] added apikey authentication, double qoutes in relying_party_id

### DIFF
--- a/postman-collection/eSignet.postman_collection.json
+++ b/postman-collection/eSignet.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "0d75592a-b451-4ba0-9601-e06a6faa3c66",
+		"_postman_id": "8a60a883-28a8-4816-b0b9-229f7a89191a",
 		"name": "eSignet",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "20579541",
-		"_collection_link": "https://mosip-idp.postman.co/workspace/MOSIP-Team-Workspace~76ac5ada-d630-4817-8d7b-25f499b093d4/collection/20579541-0d75592a-b451-4ba0-9601-e06a6faa3c66?action=share&source=collection_link&creator=20579541"
+		"_exporter_id": "10897321"
 	},
 	"item": [
 		{
@@ -78,7 +77,7 @@
 									"script": {
 										"exec": [
 											"",
-											"eval(pm.globals.get('pmlib_code'))",
+											"eval(pm.environment.get('pmlib_code'))",
 											"keyPair = pmlib.rs.KEYUTIL.generateKeypair(\"RSA\", 2048);",
 											"jwkPrivateKey = pmlib.rs.KEYUTIL.getJWK(keyPair.prvKeyObj);",
 											"jwkPublicKey  = pmlib.rs.KEYUTIL.getJWK(keyPair.pubKeyObj);",
@@ -113,11 +112,26 @@
 								}
 							],
 							"request": {
+								"auth": {
+									"type": "apikey",
+									"apikey": [
+										{
+											"key": "value",
+											"value": "Authorization={{authtoken}}",
+											"type": "string"
+										},
+										{
+											"key": "key",
+											"value": "Cookie",
+											"type": "string"
+										}
+									]
+								},
 								"method": "POST",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"id\": \"string\",\r\n  \"version\": \"string\",\r\n  \"requesttime\": \"{{$isoTimestamp}}\",\r\n  \"metadata\": {},\r\n  \"request\": {\r\n    \"name\": \"{{$randomCompanyName}}\",\r\n    \"policyId\": \"26123\",\r\n    \"publicKey\": {{client_public_key}},\r\n    \"authPartnerId\": {{relying_party_id}},\r\n    \"logoUri\": \"{{$randomImageUrl}}\",\r\n    \"redirectUris\": [\r\n      \"{{redirection_url}}\"\r\n    ],\r\n    \"grantTypes\": [\r\n      \"authorization_code\"\r\n    ],\r\n    \"clientAuthMethods\": [\r\n      \"private_key_jwt\"\r\n    ]\r\n  }\r\n}",
+									"raw": "{\r\n  \"id\": \"string\",\r\n  \"version\": \"string\",\r\n  \"requesttime\": \"{{$isoTimestamp}}\",\r\n  \"metadata\": {},\r\n  \"request\": {\r\n    \"name\": \"{{$randomCompanyName}}\",\r\n    \"policyId\": \"93482\",\r\n    \"publicKey\": {{client_public_key}},\r\n    \"authPartnerId\": \"{{relying_party_id}}\",\r\n    \"logoUri\": \"{{$randomImageUrl}}\",\r\n    \"redirectUris\": [\r\n      \"{{redirection_url}}\"\r\n    ],\r\n    \"grantTypes\": [\r\n      \"authorization_code\"\r\n    ],\r\n    \"clientAuthMethods\": [\r\n      \"private_key_jwt\"\r\n    ]\r\n  }\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"


### PR DESCRIPTION
- Added apikey authorization, so that after `PMS Authentication` we don't have to manually put cookie detail for authorization
- Double qoutes are missing from `relying_party_id`, due to which it is throwing error