### PR TITLE
MOSIP-35628: API - Capture info in the report whether Captcha is enabled on the target env or not.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testrunner/MosipTestRunner.java
@@ -60,6 +60,7 @@ public class MosipTestRunner {
 	public static String jarUrl = MosipTestRunner.class.getProtectionDomain().getCodeSource().getLocation().getPath();
 	public static List<String> languageList = new ArrayList<>();
 	public static boolean skipAll = false;
+	public static String pluginName = null;
 
 	/**
 	 * C Main method to start mosip test execution
@@ -203,6 +204,7 @@ public class MosipTestRunner {
 	 * @throws IOException
 	 */
 	public static void startTestRunner() {
+		pluginName = EsignetUtil.getPluginName();
 		File homeDir = null;
 		String os = System.getProperty("os.name");
 		LOGGER.info(os);
@@ -222,7 +224,11 @@ public class MosipTestRunner {
 				List<String> suitefiles = new ArrayList<>();
 
 				if (file.getName().toLowerCase().contains("mastertestsuite")) {
-					BaseTestCase.setReportName(GlobalConstants.ESIGNET);
+					if (pluginName != null) {
+				        BaseTestCase.setReportName(GlobalConstants.ESIGNET + "-" + pluginName);
+				    } else {
+				        BaseTestCase.setReportName(GlobalConstants.ESIGNET);
+				    }
 					suitefiles.add(file.getAbsolutePath());
 					runner.setTestSuites(suitefiles);
 					System.getProperties().setProperty("testng.outpur.dir", "testng-report");

--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetConstants.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetConstants.java
@@ -14,6 +14,8 @@ public class EsignetConstants {
 	
 	public static final String CLASS_PATH_APPLICATION_PROPERTIES = "classpath:/application.properties";
 	
+	public static final String MOSIP_ESIGNET_CAPTCHA_REQUIRED = "mosip.esignet.captcha.required";
+	
 	public static final String CLASS_PATH_APPLICATION_DEFAULT_PROPERTIES = "classpath:/application-default.properties";
 
 	public static final String DEFAULT_STRING = "default";

--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetUtil.java
@@ -110,6 +110,30 @@ public class EsignetUtil extends AdminTestUtil {
 		return pluginName;
 	}
 	
+	public static String getPluginName() {
+		try {
+			String pluginServiceName = EsignetUtil.getIdentityPluginNameFromEsignetActuator().toLowerCase();
+		    if (pluginServiceName.contains("mockauthenticationservice")) {
+		        return "mock";
+		    } else if (pluginServiceName.contains("sunbirdrcauthenticationservice")) {
+		        return "sunbirdrc";
+		    } else {
+		        return "mosip-id";
+		    }
+		} catch(Exception e) {
+			logger.error("Failed to get plugin name from actuator", e);			
+		}
+		return "null";
+	}
+	public static boolean isCaptchaEnabled() {
+		String temp = getValueFromEsignetActuator(EsignetConstants.CLASS_PATH_APPLICATION_PROPERTIES,
+				EsignetConstants.MOSIP_ESIGNET_CAPTCHA_REQUIRED);
+		if(temp.isEmpty()) {
+			return false;
+		}
+		return true;	
+	}
+	
 	public static JSONArray getActiveProfilesFromActuator(String url, String key) {
 		JSONArray activeProfiles = null;
 
@@ -260,8 +284,15 @@ public class EsignetUtil extends AdminTestUtil {
 	
 	public static String isTestCaseValidForExecution(TestCaseDTO testCaseDTO) {
 		String testCaseName = testCaseDTO.getTestCaseName();
-		
-		
+
+		// When the captcha is enabled we cannot execute the test case as we can not generate the captcha token
+		if (isCaptchaEnabled() == true) {
+			GlobalMethods.reportCaptchaStatus(GlobalConstants.CAPTCHA_ENABLED, true);
+			throw new SkipException(GlobalConstants.CAPTCHA_ENABLED_MESSAGE);
+		} else {
+			GlobalMethods.reportCaptchaStatus(GlobalConstants.CAPTCHA_ENABLED, false);
+		}
+
 		if (MosipTestRunner.skipAll == true) {
 			throw new SkipException(GlobalConstants.PRE_REQUISITE_FAILED_MESSAGE);
 		}


### PR DESCRIPTION
Added constant MOSIP_ESIGNET_CAPTCHA_REQUIRED in EsignetConstants.java for captcha config. Introduced isCaptchaEnabled() method in EsignetUtil.java to check captcha status via actuator. Added logic to skip test execution using SkipException when captcha is enabled.