### PR TITLE
[ES-2411] Added the compute public key jwk method

### DIFF
--- a/esignet-core/src/main/java/io/mosip/esignet/core/util/SecurityHelperService.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/util/SecurityHelperService.java
@@ -5,15 +5,78 @@
  */
 package io.mosip.esignet.core.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64URL;
+import io.mosip.esignet.core.constants.ErrorConstants;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Slf4j
 @Component
 public class SecurityHelperService {
 
+    public static final String ALGO_SHA_256 = "SHA-256";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
     public String generateSecureRandomString(int length) {
         //TODO
         return IdentityProviderUtil.generateRandomAlphaNumeric(length);
     }
+
+    public String computeJwkThumbprint(JWK jwk) throws Exception {
+        if (jwk == null) {
+            throw new IllegalArgumentException(ErrorConstants.INVALID_ALGORITHM);
+        }
+
+        if (jwk.isPrivate()) {
+            throw new IllegalArgumentException(ErrorConstants.INVALID_PUBLIC_KEY);
+        }
+
+        Map<String, Object> thumbprintInput = new LinkedHashMap<>();
+
+        switch (jwk.getKeyType().getValue()) {
+            case "RSA":
+                if (!(jwk instanceof RSAKey)) {
+                    throw new IllegalArgumentException(ErrorConstants.INVALID_ALGORITHM);
+                }
+                RSAKey rsaKey = (RSAKey) jwk;
+                thumbprintInput.put("e", rsaKey.getPublicExponent().toString());
+                thumbprintInput.put("kty", "RSA");
+                thumbprintInput.put("n", rsaKey.getModulus().toString());
+                break;
+
+            case "EC":
+                if (!(jwk instanceof ECKey)) {
+                    throw new IllegalArgumentException(ErrorConstants.INVALID_ALGORITHM);
+                }
+                ECKey ecKey = (ECKey) jwk;
+                thumbprintInput.put("crv", ecKey.getCurve().getName());
+                thumbprintInput.put("kty", "EC");
+                thumbprintInput.put("x", ecKey.getX().toString());
+                thumbprintInput.put("y", ecKey.getY().toString());
+                break;
+
+            default:
+                throw new IllegalArgumentException(ErrorConstants.INVALID_ALGORITHM);
+        }
+
+        // Canonical JSON: no whitespace, ordered keys
+        String canonicalJson = objectMapper.writeValueAsString(thumbprintInput);
+
+        MessageDigest digest = MessageDigest.getInstance(ALGO_SHA_256);
+        byte[] hash = digest.digest(canonicalJson.getBytes(StandardCharsets.UTF_8));
+        return Base64URL.encode(hash).toString();
+    }
+
 }

--- a/esignet-core/src/main/java/io/mosip/esignet/core/util/SecurityHelperService.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/util/SecurityHelperService.java
@@ -36,7 +36,7 @@ public class SecurityHelperService {
 
     public String computeJwkThumbprint(JWK jwk) throws Exception {
         if (jwk == null) {
-            throw new IllegalArgumentException(ErrorConstants.INVALID_ALGORITHM);
+            throw new IllegalArgumentException(ErrorConstants.INVALID_PUBLIC_KEY);
         }
 
         if (jwk.isPrivate()) {

--- a/esignet-core/src/test/java/io/mosip/esignet/core/SecurityHelperServiceTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/SecurityHelperServiceTest.java
@@ -33,7 +33,7 @@ public class SecurityHelperServiceTest {
         try {
             securityHelperService.computeJwkThumbprint(null);
         }catch (IllegalArgumentException e){
-            org.junit.Assert.assertEquals( ErrorConstants.INVALID_ALGORITHM,e.getMessage());
+            org.junit.Assert.assertEquals( ErrorConstants.INVALID_PUBLIC_KEY,e.getMessage());
         }
     }
 
@@ -98,6 +98,24 @@ public class SecurityHelperServiceTest {
         String expectedThumbprint = "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs";
 
         org.junit.Assert.assertEquals(expectedThumbprint, thumbprint);
+    }
+
+    @Test
+    public void computeJwkThumbprint_withValidEC_thenPass() throws Exception {
+        ReflectionTestUtils.setField(securityHelperService, "objectMapper", new ObjectMapper());
+        ECKey ecJwk = ECKey.parse(
+                "{" +
+                        "\"kty\":\"EC\"," +
+                        "\"crv\":\"P-256\"," +
+                        "\"x\":\"CtFRxfPrv4fh4c8gGzBveGvk8VkJIQLwMuEBPh81xnk\"," +
+                        "\"y\":\"uAyPt9YJWwqaaQEYkHS1KIGvzVe3T5NGDqM3Bm4qLUs\"" +
+                        "}"
+        );
+
+        String thumbprint = securityHelperService.computeJwkThumbprint(ecJwk);
+        String expected = "7BWWOB0woOhbkjAvfme5xwdOsehUXM_dZsy8ZLPEvss";
+
+        org.junit.Assert.assertEquals(expected, thumbprint);
     }
 
 }

--- a/esignet-core/src/test/java/io/mosip/esignet/core/SecurityHelperServiceTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/SecurityHelperServiceTest.java
@@ -5,11 +5,21 @@
  */
 package io.mosip.esignet.core;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jose.util.Base64URL;
+import io.mosip.esignet.core.constants.ErrorConstants;
 import io.mosip.esignet.core.util.SecurityHelperService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.Assert;
+
+import java.math.BigInteger;
+import java.security.interfaces.RSAPublicKey;
+
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SecurityHelperServiceTest {
@@ -21,4 +31,77 @@ public class SecurityHelperServiceTest {
     public void test_generateSecureRandomString_thenPass() {
         Assert.notNull(securityHelperService.generateSecureRandomString(20));
     }
+
+    @Test
+    public void computeJwkThumbprint_withNullKey_thenFail() throws Exception {
+        try {
+            securityHelperService.computeJwkThumbprint(null);
+        }catch (IllegalArgumentException e){
+            org.junit.Assert.assertEquals( ErrorConstants.INVALID_ALGORITHM,e.getMessage());
+        }
+    }
+
+    @Test
+    public void computeJwkThumbprint_withPrivateKey_thenFail() throws Exception {
+        // Provide private key to simulate the private key rejection
+        RSAKey privateRsaKey = new RSAKey.Builder(new TestRSAPublicKey())
+                .privateExponent(Base64URL.encode(BigInteger.TEN)) // Simulate private key
+                .build();
+        try {
+            securityHelperService.computeJwkThumbprint(privateRsaKey);
+        }catch (IllegalArgumentException e){
+            org.junit.Assert.assertEquals( ErrorConstants.INVALID_PUBLIC_KEY,e.getMessage());
+        }
+    }
+
+    @Test
+    public void computeJwkThumbprint_withValidRSA_thenPass() throws Exception {
+        ReflectionTestUtils.setField(securityHelperService, "objectMapper", new ObjectMapper());
+        RSAKey rsaKey = new RSAKey.Builder(new TestRSAPublicKey()).build();
+        String thumbprint = securityHelperService.computeJwkThumbprint(rsaKey);
+        assertNotNull(thumbprint);
+    }
+
+
+    @Test
+    public void computeJwkThumbprint_withInvalidRSA_thenFail() throws Exception {
+        JWK fakeKey = new OctetSequenceKey.Builder(new Base64URL("AQAB")).build();
+        try {
+            securityHelperService.computeJwkThumbprint(fakeKey);
+        }catch (IllegalArgumentException e){
+            org.junit.Assert.assertEquals(ErrorConstants.INVALID_PUBLIC_KEY,e.getMessage());
+        }
+    }
+
+    @Test
+    public void computeJwkThumbprint_withSymmetricKey_thenFail() throws Exception {
+        String octJwkJson = "{ \"kty\": \"oct\", \"k\": \"secret\" }";
+        JWK jwk = JWK.parse(octJwkJson);
+        try {
+            securityHelperService.computeJwkThumbprint(jwk);
+        }catch (IllegalArgumentException e){
+            org.junit.Assert.assertEquals(ErrorConstants.INVALID_PUBLIC_KEY,e.getMessage());
+        }
+    }
+
+    @Test
+    public void computeJwkThumbprint_withUnsupportedKey_thenFail() throws Exception {
+        String unsupportedJwkJson = "{ \"kty\": \"OKP\", \"crv\": \"Ed25519\", \"x\": \"testx\" }";
+        JWK jwk = JWK.parse(unsupportedJwkJson);
+        try {
+            securityHelperService.computeJwkThumbprint(jwk);
+        }catch (IllegalArgumentException e){
+            org.junit.Assert.assertEquals(ErrorConstants.INVALID_ALGORITHM,e.getMessage());
+        }
+    }
+
+    // Minimal RSA public key for testing
+    static class TestRSAPublicKey implements RSAPublicKey {
+        public BigInteger getPublicExponent() { return BigInteger.valueOf(65537); }
+        public BigInteger getModulus() { return new BigInteger("1234567890"); }
+        public String getAlgorithm() { return "RSA"; }
+        public String getFormat() { return "X.509"; }
+        public byte[] getEncoded() { return new byte[0]; }
+    }
+
 }


### PR DESCRIPTION
The computeJwkThumbprint functionality in the SecurityHelperService :

1.Enforcing strict validation against public-only key input (private key usage triggers clear rejection).
2.Extending support to EC (Elliptic Curve) keys, with curve-specific validation (e.g., P‑256) ensuring coordinate integrity.
3.Standardizing base64url encoding and canonical JSON serialization to comply with RFC 7638 thumbprint requirements.