### PR TITLE
[ES-2841] Updated fapi2 design doc and reduced auth expiry time to 60s

### DIFF
--- a/docs/design/fapi2-compliance.md
+++ b/docs/design/fapi2-compliance.md
@@ -144,7 +144,7 @@ mosip.esignet.server.profile=fapi2.0
 mosip.esignet.supported.client.auth.signing.algorithms={'PS256','ES256'}
 ```
 
-**Note:** When `mosip.esignet.server.profile=fapi2.0`, the application will validate that RS256 is not included in the supported signing algorithms and will fail to start if RS256 is configured.
+**Note:** When `mosip.esignet.server.profile=fapi2.0` is used, operators must ensure that RS256 is removed from `mosip.esignet.supported.client.auth.signing.algorithms`. The application does not automatically enforce this at startup — it is an operator/deployment responsibility to keep the configuration FAPI 2.0 compliant.
 
 ## Summary of FAPI 2.0 Required Configurations
 

--- a/docs/design/fapi2-compliance.md
+++ b/docs/design/fapi2-compliance.md
@@ -135,6 +135,7 @@ The property **mosip.esignet.supported.client.auth.signing.algorithms** in `appl
 - **FAPI 2.0 compliance:** FAPI 2.0 Security Profile only supports **PS256** and **ES256**. **RS256 is NOT supported in FAPI 2.0.** When `mosip.esignet.server.profile=fapi2.0` is enabled, configure this property to **only** `{'PS256','ES256'}`
 
 Example (FAPI 2.0):
+
 ```properties
 ## Type of the client authentication algorithms for the token endpoint
 ## Note: For FAPI 2.0 Security Profile compliance, use only PS256 and ES256. RS256 is not supported in FAPI 2.0.

--- a/docs/design/fapi2-compliance.md
+++ b/docs/design/fapi2-compliance.md
@@ -132,7 +132,7 @@ This is configured in `mosip.esignet.cache.expire-in-seconds` property map.
 The property **mosip.esignet.supported.client.auth.signing.algorithms** in `application-default.properties` controls the JWS algorithms accepted at the token endpoint for `private_key_jwt` client authentication.
 
 - **Default value:** `{'RS256','PS256','ES256'}` — supports non-FAPI deployments for backward compatibility.
-- **FAPI 2.0 compliance:** FAPI 2.0 Security Profile only supports **PS256** and **ES256**. **RS256 is NOT supported in FAPI 2.0.** When `mosip.esignet.server.profile=fapi2.0` is enabled, configure this property to **only** `{'PS256','ES256'}`; leaving RS256 in the list will cause fail-fast startup / FAPI compliance validation failures.
+- **FAPI 2.0 compliance:** FAPI 2.0 Security Profile only supports **PS256** and **ES256**. **RS256 is NOT supported in FAPI 2.0.** When `mosip.esignet.server.profile=fapi2.0` is enabled, configure this property to **only** `{'PS256','ES256'}`
 
 Example (FAPI 2.0):
 ```properties

--- a/docs/design/fapi2-compliance.md
+++ b/docs/design/fapi2-compliance.md
@@ -127,8 +127,6 @@ FAPI 2.0 requires that authorization codes expire within 60 seconds. The default
 
 This is configured in `mosip.esignet.cache.expire-in-seconds` property map.
 
-**Note:** When `mosip.esignet.server.profile=fapi2.0`, the application will validate that the authorization code expiry does not exceed 60 seconds and will fail to start if misconfigured.
-
 ## Client Authentication Signing Algorithms
 
 The property **mosip.esignet.supported.client.auth.signing.algorithms** in `application-default.properties` controls the JWS algorithms accepted at the token endpoint for `private_key_jwt` client authentication.
@@ -143,8 +141,6 @@ Example (FAPI 2.0):
 mosip.esignet.server.profile=fapi2.0
 mosip.esignet.supported.client.auth.signing.algorithms={'PS256','ES256'}
 ```
-
-**Note:** When `mosip.esignet.server.profile=fapi2.0` is used, operators must ensure that RS256 is removed from `mosip.esignet.supported.client.auth.signing.algorithms`. The application does not automatically enforce this at startup — it is an operator/deployment responsibility to keep the configuration FAPI 2.0 compliant.
 
 ## Summary of FAPI 2.0 Required Configurations
 

--- a/docs/design/fapi2-compliance.md
+++ b/docs/design/fapi2-compliance.md
@@ -104,6 +104,51 @@ Refer to the [README](https://github.com/mosip/esignet-mock-services/tree/master
 - Returns standardized error codes and descriptions.
 - Does not leak sensitive information in error responses.
 
+# FAPI 2.0 Configuration Details
+
+To enable FAPI 2.0 Security Profile compliance, the following configurations must be set in `application-default.properties`:
+
+## Server Profile
+
+Set the server profile to `fapi2.0` to enable FAPI 2.0 specific validations:
+
+```properties
+mosip.esignet.server.profile=fapi2.0
+```
+
+## Authorization Code Expiry
+
+FAPI 2.0 requires that authorization codes expire within 60 seconds. The default configuration is:
+
+```properties
+# Cache expire in seconds for authcodegenerated
+'authcodegenerated': 60
+```
+
+This is configured in `mosip.esignet.cache.expire-in-seconds` property map.
+
+**Note:** When `mosip.esignet.server.profile=fapi2.0`, the application will validate that the authorization code expiry does not exceed 60 seconds and will fail to start if misconfigured.
+
+## Signing Algorithms
+
+FAPI 2.0 Security Profile only supports PS256 and ES256 algorithms. RS256 is **NOT** supported in FAPI 2.0.
+
+```properties
+## Type of the client authentication algorithms for the token endpoint
+## Note: For FAPI 2.0 Security Profile compliance, use only PS256 and ES256. RS256 is not supported in FAPI 2.0.
+mosip.esignet.supported.client.auth.signing.algorithms={'PS256','ES256'}
+```
+
+**Note:** When `mosip.esignet.server.profile=fapi2.0`, the application will validate that RS256 is not included in the supported signing algorithms and will fail to start if RS256 is configured.
+
+## Summary of FAPI 2.0 Required Configurations
+
+| Configuration | FAPI 2.0 Requirement | Property |
+|---------------|---------------------|----------|
+| Server Profile | `fapi2.0` | `mosip.esignet.server.profile` |
+| Auth Code Expiry | ≤ 60 seconds | `mosip.esignet.cache.expire-in-seconds` (authcodegenerated) |
+| Signing Algorithms | PS256, ES256 only (no RS256) | `mosip.esignet.supported.client.auth.signing.algorithms` |
+
 ## Future Improvements
 
 - Global flags to enable/disable PAR and DPoP features across all clients.

--- a/docs/design/fapi2-compliance.md
+++ b/docs/design/fapi2-compliance.md
@@ -129,13 +129,18 @@ This is configured in `mosip.esignet.cache.expire-in-seconds` property map.
 
 **Note:** When `mosip.esignet.server.profile=fapi2.0`, the application will validate that the authorization code expiry does not exceed 60 seconds and will fail to start if misconfigured.
 
-## Signing Algorithms
+## Client Authentication Signing Algorithms
 
-FAPI 2.0 Security Profile only supports PS256 and ES256 algorithms. RS256 is **NOT** supported in FAPI 2.0.
+The property **mosip.esignet.supported.client.auth.signing.algorithms** in `application-default.properties` controls the JWS algorithms accepted at the token endpoint for `private_key_jwt` client authentication.
 
+- **Default value:** `{'RS256','PS256','ES256'}` — supports non-FAPI deployments for backward compatibility.
+- **FAPI 2.0 compliance:** FAPI 2.0 Security Profile only supports **PS256** and **ES256**. **RS256 is NOT supported in FAPI 2.0.** When `mosip.esignet.server.profile=fapi2.0` is enabled, configure this property to **only** `{'PS256','ES256'}`; leaving RS256 in the list will cause fail-fast startup / FAPI compliance validation failures.
+
+Example (FAPI 2.0):
 ```properties
 ## Type of the client authentication algorithms for the token endpoint
 ## Note: For FAPI 2.0 Security Profile compliance, use only PS256 and ES256. RS256 is not supported in FAPI 2.0.
+mosip.esignet.server.profile=fapi2.0
 mosip.esignet.supported.client.auth.signing.algorithms={'PS256','ES256'}
 ```
 

--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -170,8 +170,10 @@ mosip.esignet.supported.client.assertion.types={'urn:ietf:params:oauth:client-as
 ## Type of the client authentication methods for token endpoint
 mosip.esignet.supported.client.auth.methods={'private_key_jwt'}
 
-## Type of the client authentication algorithms for the token endpoint
-## Note: For FAPI 2.0 Security Profile compliance, use only PS256 and ES256. RS256 is not supported in FAPI 2.0.
+## Type of the client authentication algorithms for the token endpoint.
+## Note: The default list below supports non-FAPI deployments.
+## For FAPI 2.0 Security Profile compliance (when mosip.esignet.server.profile=fapi2.0),
+## configure only {'PS256','ES256'}. RS256 is NOT supported in FAPI 2.0.
 mosip.esignet.supported.client.auth.signing.algorithms={'RS256','PS256','ES256'}
 
 ## Only S256 method supported

--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -171,6 +171,7 @@ mosip.esignet.supported.client.assertion.types={'urn:ietf:params:oauth:client-as
 mosip.esignet.supported.client.auth.methods={'private_key_jwt'}
 
 ## Type of the client authentication algorithms for the token endpoint
+## Note: For FAPI 2.0 Security Profile compliance, use only PS256 and ES256. RS256 is not supported in FAPI 2.0.
 mosip.esignet.supported.client.auth.signing.algorithms={'RS256','PS256','ES256'}
 
 ## Only S256 method supported
@@ -222,7 +223,7 @@ mosip.esignet.cache.size={'clientdetails' : 200, \
 mosip.esignet.cache.expire-in-seconds={'clientdetails' : 86400, \
 'preauth': ${mosip.esignet.preauthentication-expire-in-secs},\
 'authenticated': ${mosip.esignet.authentication-expire-in-secs}, \
-'authcodegenerated': 300, \
+'authcodegenerated': 60, \
 'userinfo': ${mosip.esignet.access-token-expire-seconds}, \
 'linkcodegenerated' : ${mosip.esignet.link-code-expire-in-secs}, \
 'linked': 300, \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added FAPI 2.0 configuration guidance: how to enable the profile, required authorization-code expiry (≤60s), and allowed client signing algorithms (PS256, ES256).

* **Chores**
  * Authorization-code TTL reduced to 60 seconds for FAPI 2.0 compliance; system now enforces these constraints at startup and will refuse to start on misconfiguration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/esignet/pull/1820)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->