### PR TITLE
[ES 2924] Prompt Validation before id token hint to propogate right error code

### DIFF
--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationHelperService.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationHelperService.java
@@ -441,13 +441,13 @@ public class AuthorizationHelperService {
                 JsonNode payload = objectMapper.readTree(payloadString);
                 String audience = payload.get(TokenService.AUD).textValue();
                 if(!signupIDTokenAudience.equals(audience) || !signupIDTokenAudience.equals(clientId))
-                    throw new EsignetException(ErrorConstants.INVALID_ID_TOKEN_HINT);
+                    throw new EsignetException(ErrorConstants.LOGIN_REQUIRED);
                 return Pair.of(payload.get(TokenService.SUB).textValue(), payload.get(TokenService.NONCE).textValue());
             }
         } catch (Exception e) {
             log.error("Failed to parse the given IDTokenHint as JWT", e);
         }
-        throw new EsignetException(ErrorConstants.INVALID_ID_TOKEN_HINT);
+        throw new EsignetException(ErrorConstants.LOGIN_REQUIRED);
     }
 
     protected void validateNonce(String nonce) {

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
@@ -516,10 +516,10 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         OIDCTransaction oidcTransaction = pair.getSecond();
 
         if (idTokenHint != null) {
-            OAuthDetailRequestV3 v3 = (OAuthDetailRequestV3) oauthDetailReqDto;
-            handleIdTokenHint(v3, httpServletRequest);
-            oidcTransaction.setNonce(v3.getNonce());
-            oidcTransaction.setState(v3.getState());
+            OAuthDetailRequestV3 oauthDetailRequestV3 = (OAuthDetailRequestV3) oauthDetailReqDto;
+            handleIdTokenHint(oauthDetailRequestV3, httpServletRequest);
+            oidcTransaction.setNonce(oauthDetailRequestV3.getNonce());
+            oidcTransaction.setState(oauthDetailRequestV3.getState());
         }
 
         //TODO - Need to check to persist credential scopes in consent registry

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
@@ -624,10 +624,10 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         if (oauthDetailReqDto.getIdTokenHint() != null) {
             Pair<String, String> pair = authorizationHelperService.validateAndGetSubjectAndNonce(oauthDetailReqDto.getClientId(), oauthDetailReqDto.getIdTokenHint());
             if(httpServletRequest.getCookies() == null)
-                throw new EsignetException(ErrorConstants.INVALID_ID_TOKEN_HINT);
+                throw new EsignetException(ErrorConstants.LOGIN_REQUIRED);
             Optional<Cookie> result = Arrays.stream(httpServletRequest.getCookies()).filter(x -> x.getName().equals(pair.getFirst())).findFirst();
             if (result.isEmpty()) {
-                throw new EsignetException(ErrorConstants.INVALID_ID_TOKEN_HINT);
+                throw new EsignetException(ErrorConstants.LOGIN_REQUIRED);
             }
             String[] parts = result.get().getValue().split(SERVER_NONCE_SEPARATOR);
             oauthDetailReqDto.setNonce(pair.getSecond());

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
@@ -146,14 +146,17 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         assertPARRequiredIsFalse(clientDetailDto);
         validateRedirectURIAndNonce(oauthDetailReqDto, clientDetailDto);
         OAuthDetailResponseV2 oAuthDetailResponseV2 = new OAuthDetailResponseV2();
-        return buildTransactionAndOAuthDetailResponse(oauthDetailReqDto, clientDetailDto, oAuthDetailResponseV2);
+        // V2 path does not validate id_token_hint -> pass null for HttpServletRequest
+        return buildTransactionAndOAuthDetailResponse(oauthDetailReqDto, clientDetailDto, oAuthDetailResponseV2, null, null);
     }
 
     @Override
     public OAuthDetailResponseV2 getOauthDetailsV3(OAuthDetailRequestV3 oauthDetailReqDto, HttpServletRequest httpServletRequest) throws EsignetException {
-        //id_token_hint is an optional parameter, if provided then it is expected to be a valid JWT
-        handleIdTokenHint(oauthDetailReqDto, httpServletRequest);
-        return getOauthDetailsV2(oauthDetailReqDto);
+        ClientDetail clientDetailDto = clientManagementService.getClientDetails(oauthDetailReqDto.getClientId());
+        assertPARRequiredIsFalse(clientDetailDto);
+        validateRedirectURIAndNonce(oauthDetailReqDto, clientDetailDto);
+        OAuthDetailResponseV2 oAuthDetailResponseV2 = new OAuthDetailResponseV2();
+        return buildTransactionAndOAuthDetailResponse(oauthDetailReqDto, clientDetailDto, oAuthDetailResponseV2, oauthDetailReqDto.getIdTokenHint(), httpServletRequest);
     }
 
     @Override
@@ -169,10 +172,9 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             throw new EsignetException(ErrorConstants.INVALID_REQUEST);
         }
         OAuthDetailRequestV3 oAuthDetailRequestV3 = mapPushedAuthorizationRequestToOAuthDetailsRequest(pushedAuthorizationRequest);
-        handleIdTokenHint(oAuthDetailRequestV3, httpServletRequest);
         ClientDetail clientDetailDto = clientManagementService.getClientDetails(oAuthDetailRequestV3.getClientId());
         OAuthDetailResponseV2 oAuthDetailResponseV2 = new OAuthDetailResponseV2();
-        return buildTransactionAndOAuthDetailResponse(oAuthDetailRequestV3, clientDetailDto, oAuthDetailResponseV2);
+        return buildTransactionAndOAuthDetailResponse(oAuthDetailRequestV3, clientDetailDto, oAuthDetailResponseV2, oAuthDetailRequestV3.getIdTokenHint(),  httpServletRequest);
     }
 
     @Override
@@ -502,13 +504,23 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     }
 
     private OAuthDetailResponseV2 buildTransactionAndOAuthDetailResponse(OAuthDetailRequestV2 oauthDetailReqDto,
-                                                                         ClientDetail clientDetailDto, OAuthDetailResponseV2 oAuthDetailResponseV2) {
+                                                                         ClientDetail clientDetailDto,
+                                                                         OAuthDetailResponseV2 oAuthDetailResponseV2,
+                                                                         String idTokenHint,
+                                                                         HttpServletRequest httpServletRequest) {
 
         Pair<OAuthDetailResponse, OIDCTransaction> pair = checkAndBuildOIDCTransaction(oauthDetailReqDto, clientDetailDto, oAuthDetailResponseV2);
         oAuthDetailResponseV2 = (OAuthDetailResponseV2) pair.getFirst();
         oAuthDetailResponseV2.setClientName(clientDetailDto.getName());
 
         OIDCTransaction oidcTransaction = pair.getSecond();
+
+        if (idTokenHint != null) {
+            OAuthDetailRequestV3 v3 = (OAuthDetailRequestV3) oauthDetailReqDto;
+            handleIdTokenHint(v3, httpServletRequest);
+            oidcTransaction.setNonce(v3.getNonce());
+            oidcTransaction.setState(v3.getState());
+        }
 
         //TODO - Need to check to persist credential scopes in consent registry
         oAuthDetailResponseV2.setCredentialScopes(oidcTransaction.getRequestedCredentialScopes());

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
@@ -1196,7 +1196,7 @@ public class AuthorizationServiceTest {
             authorizationServiceImpl.getOauthDetailsV3(oauthDetailRequest, request);
             Assertions.fail();
         } catch (EsignetException e) {
-            Assertions.assertEquals(ErrorConstants.INVALID_ID_TOKEN_HINT, e.getErrorCode());
+            Assertions.assertEquals(ErrorConstants.LOGIN_REQUIRED, e.getErrorCode());
         }
     }
 

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
@@ -696,26 +696,61 @@ public class AuthorizationServiceTest {
 
     @Test
     public void testGetOauthDetailsV3_WithInvalidIdTokenHint_ShouldThrowEsignetException() {
+        ClientDetail clientDetail = new ClientDetail();
+        clientDetail.setId("test-client");
+        clientDetail.setRedirectUris(Arrays.asList("http://localhost:8088/v1/idp"));
+        clientDetail.setAcrValues(Arrays.asList("mosip:idp:acr:static-code"));
+        clientDetail.setClaims(Arrays.asList("email"));
+        clientDetail.setName(new HashMap<>());
+        clientDetail.getName().put(Constants.NONE_LANG_KEY, "clientName");
+
         OAuthDetailRequestV3 oauthDetailReqDto = new OAuthDetailRequestV3();
+        oauthDetailReqDto.setClientId("test-client");
+        oauthDetailReqDto.setRedirectUri("http://localhost:8088/v1/idp");
+        oauthDetailReqDto.setNonce("test-nonce");
         oauthDetailReqDto.setIdTokenHint("invalid_id_token_hint");
+
+        when(clientManagementService.getClientDetails("test-client")).thenReturn(clientDetail);
+        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
+        List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
+        authFactors.add(Collections.emptyList());
+        when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(authFactors);
+
         try {
             authorizationServiceImpl.getOauthDetailsV3(oauthDetailReqDto, httpServletRequest);
             Assertions.fail();
         } catch (EsignetException e) {
-            Assertions.assertTrue(e.getErrorCode().equals(ErrorConstants.INVALID_ID_TOKEN_HINT));
+            Assertions.assertTrue(e.getErrorCode().equals(ErrorConstants.LOGIN_REQUIRED));
         }
     }
 
     @Test
     public void getOauthDetailsV3_WithNoCookie_ThrowsEsignetException() {
+        ClientDetail clientDetail = new ClientDetail();
+        clientDetail.setId("test-client");
+        clientDetail.setRedirectUris(Arrays.asList("http://localhost:8088/v1/idp"));
+        clientDetail.setAcrValues(Arrays.asList("mosip:idp:acr:static-code"));
+        clientDetail.setClaims(Arrays.asList("email"));
+        clientDetail.setName(new HashMap<>());
+        clientDetail.getName().put(Constants.NONE_LANG_KEY, "clientName");
+
         OAuthDetailRequestV3 oauthDetailReqDto = new OAuthDetailRequestV3();
+        oauthDetailReqDto.setClientId("test-client");
+        oauthDetailReqDto.setRedirectUri("http://localhost:8088/v1/idp");
+        oauthDetailReqDto.setNonce("test-nonce");
         oauthDetailReqDto.setIdTokenHint("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.3RJf1g9bKzRC-dEj4b2Jx2yCk7Mz4oG1bZbDqGt8QxE");
+
+        when(clientManagementService.getClientDetails("test-client")).thenReturn(clientDetail);
+        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
+        List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
+        authFactors.add(Collections.emptyList());
+        when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(authFactors);
 
         try {
             authorizationServiceImpl.getOauthDetailsV3(oauthDetailReqDto, httpServletRequest);
             Assertions.fail();
         } catch (EsignetException e) {
-            Assertions.assertTrue(e.getErrorCode().equals(ErrorConstants.INVALID_ID_TOKEN_HINT));
+            Assertions.assertTrue(e.getErrorCode().equals(ErrorConstants.LOGIN_REQUIRED));
         }
     }
 
@@ -1119,6 +1154,12 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:biometrics mosip:idp:acr:generated-code");
         oauthDetailRequest.setIdTokenHint("eyJraWQiOiJtbG02RVNRaFB5dVVsWmY0dnBZbGJTVWlSMXBXcG5jdW9kamtnRjNaNU5nIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJxWS0tNVk0VG9Ga1dUb1hKclJGbVBXUEhEWkxrY2lNTDQtX2cxTDJBNXhJIiwiYXVkIjoibW9zaXAtc2lnbnVwLW9hdXRoLWNsaWVudCIsImFjciI6Im1vc2lwOmlkcDphY3I6Z2VuZXJhdGVkLWNvZGUiLCJhdXRoX3RpbWUiOjE3MjUyNjk4ODUsImlzcyI6Imh0dHBzOlwvXC9lc2lnbmV0bDIuY2FtZGdjLXFhLm1vc2lwLm5ldFwvdjFcL2VzaWduZXQiLCJleHAiOjE3MjUyNzAwNzMsImlhdCI6MTcyNTI2OTg5Mywibm9uY2UiOiI5NzNlaWVsanpuZyJ9.VMMn92CFzGkVyx8Jwrq03KhuXOXj3wRlUoxZQQBN7MxlfIxGSX_yE7iw3JWxohzQuHticndtQX2LELcGTPhclzRop3skHCeo6ZPGJklCiRA3F5SyfCYLvDprgE_-pQhLWeECqRtW_8jFFgZSORMoxy8eBj5Vvc8q2zcoDjE-JiLZvqE9UWDRpAKzumJcD3iJvBwE-9jkzQtWZbp-tZrpPrm-KCZU6-Q3qhWU23E9DSMg_6byq4iH51TFwO0nHW1kaxhsqHvCsTX7YTvmfWXUwPVRLNZh5Uszt8EIsgpKIUDkRImqmCUbP1LwoFG55MsW67QzHNTFuR6H-4LidSKnnA");
 
+        when(clientManagementService.getClientDetails("34567")).thenReturn(clientDetail);
+        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
+        List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
+        authFactors.add(Collections.emptyList());
+        when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:wallet"})).thenReturn(authFactors);
+
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setCookies(new Cookie("qY--5Y4ToFkWToXJrRFmPWPHDZLkciML4-_g1L2A5xI", "5Y4ToFkWToXJrRFmPWPHDZLkciML4" + SERVER_NONCE_SEPARATOR + "test-state"));
 
@@ -1126,15 +1167,32 @@ public class AuthorizationServiceTest {
             OAuthDetailResponseV2 oauthDetailResponseV2 = authorizationServiceImpl.getOauthDetailsV3(oauthDetailRequest, request);
             Assertions.assertNotNull(oauthDetailResponseV2);
         } catch (EsignetException e) {
-            Assertions.assertEquals(ErrorConstants.INVALID_ID_TOKEN_HINT, e.getErrorCode());
+            Assertions.assertEquals(ErrorConstants.LOGIN_REQUIRED, e.getErrorCode());
         }
     }
 
     @Test
     public void getOauthDetailsV3_withValidIDTokenHintNoCookie_thenFail() throws Exception {
+        ClientDetail clientDetail = new ClientDetail();
+        clientDetail.setId("mosip-signup-oauth-client");
+        clientDetail.setRedirectUris(Arrays.asList("http://localhost:8088/v1/idp"));
+        clientDetail.setAcrValues(Arrays.asList("mosip:idp:acr:generated-code"));
+        clientDetail.setClaims(Arrays.asList("email"));
+        clientDetail.setName(new HashMap<>());
+        clientDetail.getName().put(Constants.NONE_LANG_KEY, "clientName");
+
         OAuthDetailRequestV3 oauthDetailRequest = new OAuthDetailRequestV3();
         oauthDetailRequest.setIdTokenHint("eyJraWQiOiJtbG02RVNRaFB5dVVsWmY0dnBZbGJTVWlSMXBXcG5jdW9kamtnRjNaNU5nIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJxWS0tNVk0VG9Ga1dUb1hKclJGbVBXUEhEWkxrY2lNTDQtX2cxTDJBNXhJIiwiYXVkIjoibW9zaXAtc2lnbnVwLW9hdXRoLWNsaWVudCIsImFjciI6Im1vc2lwOmlkcDphY3I6Z2VuZXJhdGVkLWNvZGUiLCJhdXRoX3RpbWUiOjE3MjUyNjk4ODUsImlzcyI6Imh0dHBzOlwvXC9lc2lnbmV0bDIuY2FtZGdjLXFhLm1vc2lwLm5ldFwvdjFcL2VzaWduZXQiLCJleHAiOjE3MjUyNzAwNzMsImlhdCI6MTcyNTI2OTg5Mywibm9uY2UiOiI5NzNlaWVsanpuZyJ9.VMMn92CFzGkVyx8Jwrq03KhuXOXj3wRlUoxZQQBN7MxlfIxGSX_yE7iw3JWxohzQuHticndtQX2LELcGTPhclzRop3skHCeo6ZPGJklCiRA3F5SyfCYLvDprgE_-pQhLWeECqRtW_8jFFgZSORMoxy8eBj5Vvc8q2zcoDjE-JiLZvqE9UWDRpAKzumJcD3iJvBwE-9jkzQtWZbp-tZrpPrm-KCZU6-Q3qhWU23E9DSMg_6byq4iH51TFwO0nHW1kaxhsqHvCsTX7YTvmfWXUwPVRLNZh5Uszt8EIsgpKIUDkRImqmCUbP1LwoFG55MsW67QzHNTFuR6H-4LidSKnnA");
         oauthDetailRequest.setClientId("mosip-signup-oauth-client");
+        oauthDetailRequest.setRedirectUri("http://localhost:8088/v1/idp");
+        oauthDetailRequest.setNonce("test-nonce");
+
+        when(clientManagementService.getClientDetails("mosip-signup-oauth-client")).thenReturn(clientDetail);
+        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
+        List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
+        authFactors.add(Collections.emptyList());
+        when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:generated-code"})).thenReturn(authFactors);
+
         MockHttpServletRequest request = new MockHttpServletRequest();
         try {
             authorizationServiceImpl.getOauthDetailsV3(oauthDetailRequest, request);
@@ -1146,8 +1204,26 @@ public class AuthorizationServiceTest {
 
     @Test
     public void getOauthDetailsV3_withValidIDTokenHintWrongAudience_thenFail() throws Exception {
+        ClientDetail clientDetail = new ClientDetail();
+        clientDetail.setId("test-client");
+        clientDetail.setRedirectUris(Arrays.asList("http://localhost:8088/v1/idp"));
+        clientDetail.setAcrValues(Arrays.asList("mosip:idp:acr:static-code"));
+        clientDetail.setClaims(Arrays.asList("email"));
+        clientDetail.setName(new HashMap<>());
+        clientDetail.getName().put(Constants.NONE_LANG_KEY, "clientName");
+
         OAuthDetailRequestV3 oauthDetailRequest = new OAuthDetailRequestV3();
+        oauthDetailRequest.setClientId("test-client");
+        oauthDetailRequest.setRedirectUri("http://localhost:8088/v1/idp");
+        oauthDetailRequest.setNonce("test-nonce");
         oauthDetailRequest.setIdTokenHint("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+
+        when(clientManagementService.getClientDetails("test-client")).thenReturn(clientDetail);
+        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
+        List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
+        authFactors.add(Collections.emptyList());
+        when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(authFactors);
+
         MockHttpServletRequest request = new MockHttpServletRequest();
 
         //No audience claim
@@ -1155,7 +1231,7 @@ public class AuthorizationServiceTest {
             authorizationServiceImpl.getOauthDetailsV3(oauthDetailRequest, request);
             Assertions.fail();
         } catch (EsignetException e) {
-            Assertions.assertEquals(ErrorConstants.INVALID_ID_TOKEN_HINT, e.getErrorCode());
+            Assertions.assertEquals(ErrorConstants.LOGIN_REQUIRED, e.getErrorCode());
         }
 
         //wrong audience
@@ -1164,7 +1240,7 @@ public class AuthorizationServiceTest {
             authorizationServiceImpl.getOauthDetailsV3(oauthDetailRequest, request);
             Assertions.fail();
         } catch (EsignetException e) {
-            Assertions.assertEquals(ErrorConstants.INVALID_ID_TOKEN_HINT, e.getErrorCode());
+            Assertions.assertEquals(ErrorConstants.LOGIN_REQUIRED, e.getErrorCode());
         }
     }
 

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
@@ -1163,12 +1163,10 @@ public class AuthorizationServiceTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setCookies(new Cookie("qY--5Y4ToFkWToXJrRFmPWPHDZLkciML4-_g1L2A5xI", "5Y4ToFkWToXJrRFmPWPHDZLkciML4" + SERVER_NONCE_SEPARATOR + "test-state"));
 
-        try {
-            OAuthDetailResponseV2 oauthDetailResponseV2 = authorizationServiceImpl.getOauthDetailsV3(oauthDetailRequest, request);
-            Assertions.assertNotNull(oauthDetailResponseV2);
-        } catch (EsignetException e) {
-            Assertions.assertEquals(ErrorConstants.LOGIN_REQUIRED, e.getErrorCode());
-        }
+        EsignetException e = Assertions.assertThrows(EsignetException.class, () -> {
+            authorizationServiceImpl.getOauthDetailsV3(oauthDetailRequest, request);
+        });
+        Assertions.assertEquals(ErrorConstants.LOGIN_REQUIRED, e.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error responses so ID token hint validation and audience/client checks now return "Login required" when they fail.

* **Refactor**
  * Consolidated ID token hint handling into a single shared flow used across OAuth endpoints to unify behavior.

* **Tests**
  * Updated authorization tests to expect the new "Login required" error and to cover the centralized handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->