### PR TITLE
Issue #1883: accept non-public TLDs in redirect URLs.

### DIFF
--- a/esignet-core/src/main/java/io/mosip/esignet/core/util/IdentityProviderUtil.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/util/IdentityProviderUtil.java
@@ -16,7 +16,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.cert.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECParameterSpec;
@@ -24,16 +28,15 @@ import java.security.spec.RSAKeyGenParameterSpec;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
-import io.mosip.esignet.core.constants.Constants;
-import io.mosip.esignet.core.constants.ErrorConstants;
-import io.mosip.esignet.core.exception.EsignetException;
 import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -44,28 +47,31 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
-import org.apache.commons.validator.routines.UrlValidator;
+import org.jose4j.jwk.EllipticCurveJsonWebKey;
 import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jwk.RsaJsonWebKey;
-import org.jose4j.jwk.EllipticCurveJsonWebKey;
 import org.jose4j.keys.X509Util;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
-import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.util.ByteUtils;
 
-import lombok.extern.slf4j.Slf4j;
-
+import io.mosip.esignet.core.constants.Constants;
+import io.mosip.esignet.core.constants.ErrorConstants;
+import io.mosip.esignet.core.exception.EsignetException;
+import io.mosip.esignet.core.validator.RedirectURLValidator;
+import jakarta.annotation.PostConstruct;
 import jakarta.xml.bind.DatatypeConverter;
-
-import static org.apache.commons.validator.routines.UrlValidator.ALLOW_ALL_SCHEMES;
-import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -73,6 +79,9 @@ public class IdentityProviderUtil {
 
     @Value("#{${mosip.esignet.public-key-hash.fields}}")
     private Map<String, List<String>> publicKeyHashFields;
+
+    @Autowired
+    private RedirectURLValidator springManagedUrlValidator;
 
     private static final Logger logger = LoggerFactory.getLogger(IdentityProviderUtil.class);
     public static final String ALGO_SHA3_256 = "SHA3-256";
@@ -84,14 +93,19 @@ public class IdentityProviderUtil {
     private static Base64.Encoder urlSafeEncoder;
     private static Base64.Decoder urlSafeDecoder;
     private static PathMatcher pathMatcher;
-    private static UrlValidator urlValidator;
+    private static RedirectURLValidator urlValidator;
     private static final ObjectMapper objectMapper = JsonMapper.builder().addModule(new JavaTimeModule()).build();
 
     static {
         urlSafeEncoder = Base64.getUrlEncoder().withoutPadding();
         urlSafeDecoder = Base64.getUrlDecoder();
         pathMatcher = new AntPathMatcher();
-        urlValidator = new UrlValidator(ALLOW_ALL_SCHEMES+ALLOW_LOCAL_URLS);
+        urlValidator = new RedirectURLValidator(new String[0]); // safe default; @PostConstruct replaces with configured bean
+    }
+
+    @PostConstruct
+    private void initStaticUrlValidator() {
+        urlValidator = this.springManagedUrlValidator;
     }
 
     /**
@@ -224,7 +238,7 @@ public class IdentityProviderUtil {
     }
 
     private static boolean matchUri(String registeredUri, String requestedUri) {
-        return (urlValidator.isValid(registeredUri) && urlValidator.isValid(requestedUri))
+        return (urlValidator.isValid(registeredUri, null) && urlValidator.isValid(requestedUri, null))
                 && pathMatcher.match(registeredUri, requestedUri);
     }
     

--- a/esignet-core/src/main/java/io/mosip/esignet/core/validator/RedirectURLValidator.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/validator/RedirectURLValidator.java
@@ -1,24 +1,41 @@
 package io.mosip.esignet.core.validator;
 
+import java.util.List;
+
+import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.commons.validator.routines.UrlValidator;
-import org.hibernate.validator.constraints.URL;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-import static org.apache.commons.validator.routines.UrlValidator.ALLOW_ALL_SCHEMES;
-import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
-
+/**
+ * @class RedirectURLValidator uses a customised Apache {@link UrlValidator}
+ * to check syntactical validity of redirect URLs, allowing any scheme and local URLs,
+ * but restricting the authority part to valid IPv4/IPv6 addresses, localhost, or domain
+ * names with an extendable list of non-public TLDs if necessary.
+ */
 @Component
 public class RedirectURLValidator implements ConstraintValidator<RedirectURL, String> {
 
-    private final UrlValidator urlValidator = new UrlValidator(ALLOW_ALL_SCHEMES+ALLOW_LOCAL_URLS);
+    private final UrlValidator urlValidator;
 
-    @Override
-    public boolean isValid(String redirectUrl, ConstraintValidatorContext constraintValidatorContext) {
-        return urlValidator.isValid(redirectUrl);
+    public RedirectURLValidator(@Value("${mosip.esignet.allowed.non-public.tlds}") String[] allowedNonPublicTLDs) {
+        this.urlValidator = new UrlValidator(null, null, UrlValidator.ALLOW_ALL_SCHEMES | UrlValidator.ALLOW_LOCAL_URLS,
+                DomainValidator.getInstance(true, List.of(new DomainValidator.Item(DomainValidator.ArrayType.GENERIC_PLUS, allowedNonPublicTLDs))));
     }
 
+    /**
+     * Validates redirect URLs while allowing private/non-IANA TLDs.
+     *
+     * @param redirectUrl redirect URL to validate
+     * @param constraintValidatorContext validation context, unused
+     * @return true if the redirect URL is valid
+     */
+    @Override
+    public boolean isValid(final String redirectUrl, final ConstraintValidatorContext constraintValidatorContext) {
+        return this.urlValidator.isValid(redirectUrl);
+    }
 
 }

--- a/esignet-core/src/test/java/io/mosip/esignet/core/IdentityProviderUtilTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/IdentityProviderUtilTest.java
@@ -20,14 +20,15 @@ import java.util.UUID;
 
 import javax.security.auth.x500.X500Principal;
 
-import io.mosip.esignet.core.constants.ErrorConstants;
 import org.bouncycastle.x509.X509V3CertificateGenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 
+import io.mosip.esignet.core.constants.ErrorConstants;
 import io.mosip.esignet.core.exception.EsignetException;
 import io.mosip.esignet.core.util.IdentityProviderUtil;
 
@@ -36,6 +37,14 @@ public class IdentityProviderUtilTest {
 
     @Test
     public void validateRedirectURIPositiveTest() throws EsignetException {
+        // Simulate Spring initialisation by wiring a configured RedirectURLValidator into
+        // the static field via the same @PostConstruct path used at runtime.
+        IdentityProviderUtil util = new IdentityProviderUtil();
+        org.springframework.test.util.ReflectionTestUtils.setField(util, "springManagedUrlValidator",
+                new io.mosip.esignet.core.validator.RedirectURLValidator(
+                        new String[]{"corp", "internal"}));
+        org.springframework.test.util.ReflectionTestUtils.invokeMethod(util, "initStaticUrlValidator");
+
         IdentityProviderUtil.validateRedirectURI(Arrays.asList("https://api.dev.mosip.net/**"),
                 "https://api.dev.mosip.net/home/test");
         IdentityProviderUtil.validateRedirectURI(Arrays.asList("https://api.dev.mosip.net/home/test"),
@@ -48,6 +57,10 @@ public class IdentityProviderUtilTest {
                 "https://api.dev.mosip.net/home/testament?rr=rrr");
         IdentityProviderUtil.validateRedirectURI(Arrays.asList("io.mosip.residentapp://oauth"),
                 "io.mosip.residentapp://oauth");
+        IdentityProviderUtil.validateRedirectURI(Arrays.asList("https://sso.idp.corp/callback"),
+                "https://sso.idp.corp/callback");
+        IdentityProviderUtil.validateRedirectURI(Arrays.asList("https://portal.company.internal/**"),
+                "https://portal.company.internal/auth/callback");
     }
 
     @Test

--- a/esignet-core/src/test/java/io/mosip/esignet/core/ValidatorTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/ValidatorTest.java
@@ -5,23 +5,25 @@
  */
 package io.mosip.esignet.core;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.mosip.esignet.api.dto.claim.ClaimDetail;
-import io.mosip.esignet.api.dto.claim.ClaimsV2;
-import io.mosip.esignet.api.spi.Authenticator;
-import io.mosip.esignet.core.dto.OAuthDetailRequestV2;
-import io.mosip.esignet.core.exception.EsignetException;
-import io.mosip.esignet.core.constants.Constants;
-import io.mosip.esignet.core.util.AuthenticationContextClassRefUtil;
-import io.mosip.esignet.core.validator.*;
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -31,13 +33,36 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import static org.mockito.Mockito.when;
+import io.mosip.esignet.api.dto.claim.ClaimDetail;
+import io.mosip.esignet.api.dto.claim.ClaimsV2;
+import io.mosip.esignet.api.spi.Authenticator;
+import io.mosip.esignet.core.constants.Constants;
+import io.mosip.esignet.core.dto.OAuthDetailRequestV2;
+import io.mosip.esignet.core.exception.EsignetException;
+import io.mosip.esignet.core.util.AuthenticationContextClassRefUtil;
+import io.mosip.esignet.core.validator.AuthContextRefValidator;
+import io.mosip.esignet.core.validator.ClaimsSchemaValidator;
+import io.mosip.esignet.core.validator.ClientAdditionalConfigValidator;
+import io.mosip.esignet.core.validator.ClientNameLangValidator;
+import io.mosip.esignet.core.validator.CodeChallengeValidator;
+import io.mosip.esignet.core.validator.IdFormatValidator;
+import io.mosip.esignet.core.validator.OIDCClaimValidator;
+import io.mosip.esignet.core.validator.OIDCClientAssertionTypeValidator;
+import io.mosip.esignet.core.validator.OIDCClientAuthValidator;
+import io.mosip.esignet.core.validator.OIDCDisplayValidator;
+import io.mosip.esignet.core.validator.OIDCGrantTypeValidator;
+import io.mosip.esignet.core.validator.OIDCPromptValidator;
+import io.mosip.esignet.core.validator.OIDCResponseTypeValidator;
+import io.mosip.esignet.core.validator.OIDCScopeValidator;
+import io.mosip.esignet.core.validator.OtpChannelValidator;
+import io.mosip.esignet.core.validator.PKCECodeChallengeMethodValidator;
+import io.mosip.esignet.core.validator.RedirectURLValidator;
+import io.mosip.esignet.core.validator.RequestTimeValidator;
+import io.mosip.esignet.core.validator.SignatureFormatValidator;
 
 
 @MockitoSettings(strictness = Strictness.WARN)
@@ -621,7 +646,7 @@ public class ValidatorTest {
 
     @Test
     public void test_redirectURLValidator_withValidValues_thenPass() {
-        RedirectURLValidator validator = new RedirectURLValidator();
+        RedirectURLValidator validator = new RedirectURLValidator(new String[0]);
         Assertions.assertTrue(validator.isValid("https://domain.com/test", null));
         Assertions.assertTrue(validator.isValid("http://localhost:9090/png", null));
         Assertions.assertTrue(validator.isValid("http://domain.com/*", null));
@@ -632,7 +657,7 @@ public class ValidatorTest {
 
     @Test
     public void test_redirectURLValidator_withInvalidValues_thenFail() {
-        RedirectURLValidator validator = new RedirectURLValidator();
+        RedirectURLValidator validator = new RedirectURLValidator(new String[0]);
         Assertions.assertFalse(validator.isValid("*", null));
         Assertions.assertFalse(validator.isValid("https://domain*", null));
         Assertions.assertFalse(validator.isValid("io.mosip.residentapp://*", null));

--- a/esignet-core/src/test/java/io/mosip/esignet/core/validator/RedirectURLValidatorTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/validator/RedirectURLValidatorTest.java
@@ -1,0 +1,144 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.esignet.core.validator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that redirect URLs with standard public TLDs are accepted.
+ */
+public class RedirectURLValidatorTest {
+
+    private static final RedirectURLValidator REDIRECT_URL_VALIDATOR =
+            new RedirectURLValidator(new String[]{"xx", "internal", "local", "test", "mosip", "corp"});
+
+    /**
+     * Tests that valid URLs with standard IANA-registered TLDs are accepted.
+     */
+    @Test
+    public void standardIanaRegisteredTldsTest() {
+        // .com
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.com/callback", null));
+        // .org
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.org/callback", null));
+        // twoletter TLDs like .de
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.de/callback", null));
+        // longer TLDs like .technology
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.technology/callback", null));
+    }
+
+    /**
+     * Tests that valid URLs with non-IANA or custom TLDs are accepted.
+     */
+    @Test
+    public void nonIanaOrCustomTldTest() {
+        // .xx is not a real IANA TLD but must be accepted
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://api.dev.mosip.xx/home/test", null));
+        // .internal is commonly used for private networks
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://myservice.internal/callback", null));
+        // .local is used in mDNS / private environments
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://myapp.local/callback", null));
+        // .test is an RFC 2606 reserved name for testing
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://app.test/callback", null));
+        // private TLD used inside the MOSIP ecosystem
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://api.service.mosip/callback", null));
+        // non IANA TLD .corp
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://auth.sso.corp/callback", null));
+    }
+
+    /**
+     * Tests that valid URLs with IPv4 and IPv6 addresses, as well as localhost, are accepted.
+     */
+    @Test
+    public void ipAddressV4V6Test() {
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("http://192.168.1.1/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("http://10.0.0.1:8080/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("http://localhost/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("http://localhost:8080/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("http://[::1]/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("http://[2001:db8::1]/callback", null));
+      // invalid: only colons, no hex digits
+      Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("http://[::::]/callback", null));
+      // invalid: group exceeds four hex digits
+      Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("http://[12345::1]/callback", null));
+      // invalid: nine groups (too many)
+      Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("http://[1:2:3:4:5:6:7:8:9]/callback", null));
+      // invalid: non-hex character
+      Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("http://[::gggg]/callback", null));
+    }
+
+    /**
+     * Tests that valid URLs with ports are accepted and invalid ports are rejected.
+     */
+    @Test
+    public void portsTest() {
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.com:443/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.com:8443/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.com:65535/callback", null));
+        // first port value above the valid range must be rejected
+      Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://example.com:65536/callback", null));
+        // port 0 is accepted (enforcement is left to upper layers)
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.com:0/callback", null));
+        // clearly out-of-range port must be rejected
+      Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://example.com:99999/callback", null));
+    }
+
+    /**
+     * Tests that valid URLs with various schemes are accepted.
+     */
+    @Test
+    public void schemesTest() {
+        // http
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("http://example.com/callback", null));
+        // ftp
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("ftp://example.com/callback", null));
+        // Mobile deep-link used by MOSIP resident app
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("io.mosip.residentapp://oauth", null));
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("myapp://auth.internal/callback", null));
+        Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("myapp://auth-callback", null));
+    }
+
+    /**
+     * Tests that valid URLs with various path variations, query strings, and fragments are accepted.
+     */
+    @Test
+    public void pathVariationsAndQueryStringsTest() {
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://api.dev.mosip.net/home/testament?rr=rrr", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid(
+                "https://api.dev.mosip.net/home/werrrwqfdsfg5fgs34sdffggdfgsdfg?state=reefdf", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://example.com/page#section", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://a.b.c.example.com/callback", null));
+      Assertions.assertTrue(REDIRECT_URL_VALIDATOR.isValid("https://api.dev.mosip.net/home/test", null));
+    }
+
+    /**
+     * Tests that invalid URLs are rejected.
+     */
+    @Test
+    public void invalidUrlTest() {
+        // null
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid(null, null));
+        // empty
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("", null));
+        // A URL without a scheme is not valid
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("example.com/callback", null));
+        // TLD must be at least two letters; single-char TLD must be rejected
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://example.c/callback", null));
+        // TLD must consist of letters only, not digits
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://example.123/callback", null));
+        // 256 is not a valid octet
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("http://256.0.0.1/callback", null));
+        // space in host
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://exam ple.com/callback", null));
+        // label must not start with a hyphen (RFC 1123)
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://-bad.example.com/callback", null));
+        // label must not end with a hyphen (RFC 1123)
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://bad-.example.com/callback", null));
+        // only scheme
+        Assertions.assertFalse(REDIRECT_URL_VALIDATOR.isValid("https://", null));
+    }
+}

--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -17,6 +17,8 @@ mosip.esignet.generate-link-code.limit-per-transaction=10
 mosip.esignet.authentication-expire-in-secs=120
 # Time to complete authentication
 mosip.esignet.preauthentication-expire-in-secs=300
+# Non-public TLDs to be accepted in redirects / identity URLs (add entries if you want to deploy to an internal environment without public IPs)
+mosip.esignet.allowed.non-public.tlds=
 
 # Pushed Authorization Request (PAR) Properties
 mosip.esignet.par.expire-seconds=60

--- a/esignet-service/src/test/resources/application-test.properties
+++ b/esignet-service/src/test/resources/application-test.properties
@@ -8,6 +8,7 @@ mosip.esignet.supported-id-regex=\\S*
 mosip.esignet.id-token-expire-seconds=3600
 mosip.esignet.access-token.expire.seconds=3600
 mosip.esignet.link-code-expire-in-secs=60
+mosip.esignet.allowed.non-public.tlds=
 
 ## Auth challenge type & format mapping. Auth challenge length validations for each auth factor type.
 mosip.esignet.auth-challenge.OTP.format=alpha-numeric


### PR DESCRIPTION
This fixes issue #1883. 

Redirect URLs are validated using Apache UrlValidator which will also validate a URL's TLD against a whitelist. This leads to a new restriction: eSignet cannot redirect to URLs in sandbox environments where the TLD is not "official". 

In a sandbox environment, an organisation-wide root CA can be used to sign sandbox hosts' TLS certificates, hence they cannot just be renamed to something the UrlValidator acceps.

As a solution I propose to skip the validation of TLDs against the whitelist. Unfortunately this is a bit awkward when using Apache's UrlValidator, one has to implement the hostname + if present port validation oneself using a RegexValidator. 

This PR provides such an implementation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened redirect URI validation by switching to a dedicated validator that applies stricter domain/TLD checks.
  * Supports standard HTTP/FTP and mobile/deep-link schemes, including IPv4, IPv6 (with `localhost`), and correct port handling (rejects invalid/out-of-range ports).

* **Configuration**
  * Added `mosip.esignet.allowed.non-public.tlds` to allow specific non-public TLDs for redirect validation.

* **Tests**
  * Expanded unit test coverage for valid/invalid redirect URLs, including additional exact-match and wildcard scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->