### PR TITLE
[#1960] - Add SunbirdRC (KBI) authentication provider

### DIFF
--- a/esignet-service/.env.example
+++ b/esignet-service/.env.example
@@ -120,3 +120,31 @@ MOSIP_LICENSE_KEY=sample-license-key
 # Partner keystore for request signing (required for MOSIP auth flows)
 MOSIP_P12_PATH=./sample-partner-keystore.p12
 MOSIP_P12_PASSWORD=add-p12-password-here
+
+# ── SunbirdRC KBI authentication ──────────────────────────────────────────────
+# Knowledge-based-identity auth against a SunbirdRC registry. Enabled when
+# AUTHN_PROVIDER=sunbird. Variable names mirror the Java eSignet Sunbird plugin
+# property keys (uppercased; "." and "-" -> "_"). The search URL is required.
+#
+# Registry search endpoint (required; ...auth-factor.kbi.registry-search-url).
+# MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL=https://registry.dev1.mosip.net/api/v1/Insurance/search
+#
+# Registry entity (get) endpoint used to fetch attributes (...registry-get-url).
+# MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL=https://registry.dev1.mosip.net/api/v1/Insurance/
+#
+# Registry field that the entered individualId maps to in the search filter
+# (...auth-factor.kbi.individual-id-field). Default: policyNumber.
+# MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD=policyNumber
+#
+# Registry field holding the entity id returned by search (...kbi.entity-id-field). Default: osid.
+# MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_KBI_ENTITY_ID_FIELD=osid
+#
+# KBI fields collected from the user (JSON array; ...auth-factor.kbi.field-details).
+# The individual-id-field entry is the identifier; every other entry is a required credential.
+# MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_FIELD_DETAILS=[{"id":"policyNumber","type":"text","format":""},{"id":"fullName","type":"text","format":""},{"id":"dob","type":"date","format":"dd/mm/yyyy"}]
+#
+# OIDC claim -> registry field map (JSON; ...identity-openid-claims-mapping). Empty = raw passthrough.
+# MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING={"name":"fullName","email":"email","phone_number":"mobile","gender":"gender","birthdate":"dob"}
+#
+# HTTP timeout in seconds (Go-only; no Java equivalent). Default 10.
+# MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS=10

--- a/esignet-service/.env.example
+++ b/esignet-service/.env.example
@@ -142,7 +142,7 @@ MOSIP_P12_PASSWORD=add-p12-password-here
 # The individual-id-field entry is the identifier; every other entry is a required credential.
 # MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_FIELD_DETAILS=[{"id":"policyNumber","type":"text","format":""},{"id":"fullName","type":"text","format":""},{"id":"dob","type":"date","format":"dd/mm/yyyy"}]
 #
-# OIDC claim -> registry field map (JSON; ...identity-openid-claims-mapping). Empty = raw passthrough.
+# OIDC claim -> registry field map (JSON; ...identity-openid-claims-mapping). Empty/unset or malformed = no claims released (fail closed).
 # MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING={"name":"fullName","email":"email","phone_number":"mobile","gender":"gender","birthdate":"dob"}
 #
 # HTTP timeout in seconds. Default 10.

--- a/esignet-service/.env.example
+++ b/esignet-service/.env.example
@@ -123,8 +123,7 @@ MOSIP_P12_PASSWORD=add-p12-password-here
 
 # ── SunbirdRC KBI authentication ──────────────────────────────────────────────
 # Knowledge-based-identity auth against a SunbirdRC registry. Enabled when
-# AUTHN_PROVIDER=sunbird. Variable names mirror the Java eSignet Sunbird plugin
-# property keys (uppercased; "." and "-" -> "_"). The search URL is required.
+# AUTHN_PROVIDER=sunbird. The search URL is required.
 #
 # Registry search endpoint (required; ...auth-factor.kbi.registry-search-url).
 # MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL=https://registry.dev1.mosip.net/api/v1/Insurance/search
@@ -146,5 +145,5 @@ MOSIP_P12_PASSWORD=add-p12-password-here
 # OIDC claim -> registry field map (JSON; ...identity-openid-claims-mapping). Empty = raw passthrough.
 # MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING={"name":"fullName","email":"email","phone_number":"mobile","gender":"gender","birthdate":"dob"}
 #
-# HTTP timeout in seconds (Go-only; no Java equivalent). Default 10.
+# HTTP timeout in seconds. Default 10.
 # MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS=10

--- a/esignet-service/README.md
+++ b/esignet-service/README.md
@@ -170,7 +170,7 @@ Set `LOG_LEVEL=debug` for verbose tracing.
 | `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_KBI_ENTITY_ID_FIELD` | `osid` | Registry field holding the entity id returned by search |
 | `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_FIELD_DETAILS` | _(Insurance default)_ | JSON list of KBI fields collected from the user |
 | `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING` | _(Insurance default)_ | JSON map of OIDC claim → registry field (empty = raw passthrough) |
-| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS` | `10` | HTTP timeout in seconds for registry calls (Go-only; no Java equivalent) |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS` | `10` | HTTP timeout in seconds for registry calls |
 
 See `.env.example` for the full list including optional MOSIP URL overrides.
 
@@ -183,9 +183,6 @@ its entity-id field (default `osid`) becomes the user id. Attributes are then fe
 get URL (`.../{entityId}`) and mapped to OIDC claims via the claims-mapping config. This reuses the
 built-in `BasicAuthExecutor` (no custom executor); the demo flow `decl-sunbird-flow-1` and app
 `decl-app-sunbird` exercise it.
-
-The `SUNBIRD_RC` environment variables mirror the Java eSignet Sunbird plugin
-(`io.mosip.esignet.plugin.sunbirdrc`) property keys — uppercased, with `.` and `-` replaced by `_`.
 
 ## Client management API
 

--- a/esignet-service/README.md
+++ b/esignet-service/README.md
@@ -159,13 +159,33 @@ Set `LOG_LEVEL=debug` for verbose tracing.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `AUTHN_PROVIDER` | `catalog` | `catalog` (local YAML users) or `mosip` (MOSIP IDA) |
+| `AUTHN_PROVIDER` | `catalog` | `catalog` (local YAML users), `mosip` (MOSIP IDA), or `sunbird` (SunbirdRC registry KBI) |
 | `MOSIP_API_BASE_URL` | _(empty)_ | MOSIP API host |
 | `MOSIP_LICENSE_KEY` | _(empty)_ | License key used in IDA endpoint paths |
 | `MOSIP_P12_PATH` | _(empty)_ | Partner keystore (required for MOSIP auth) |
 | `MOSIP_P12_PASSWORD` | _(empty)_ | Partner keystore password |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL` | _(empty)_ | SunbirdRC registry search endpoint (**required** for `sunbird` auth) |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL` | _(empty)_ | SunbirdRC registry get/entity endpoint; used to fetch OIDC claims after auth |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD` | `policyNumber` | Registry field the entered `individualId` maps to in the search filter |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_KBI_ENTITY_ID_FIELD` | `osid` | Registry field holding the entity id returned by search |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_FIELD_DETAILS` | _(Insurance default)_ | JSON list of KBI fields collected from the user |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING` | _(Insurance default)_ | JSON map of OIDC claim → registry field (empty = raw passthrough) |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS` | `10` | HTTP timeout in seconds for registry calls (Go-only; no Java equivalent) |
 
 See `.env.example` for the full list including optional MOSIP URL overrides.
+
+### SunbirdRC (KBI) authentication
+
+With `AUTHN_PROVIDER=sunbird`, the user authenticates by knowledge-based identity: they enter an
+`individualId` plus KBI fields (default `fullName` and `dob`), which are POSTed as exact-match filters to the
+registry search URL. Authentication succeeds only when the registry returns **exactly one** matching entity;
+its entity-id field (default `osid`) becomes the user id. Attributes are then fetched from the registry
+get URL (`.../{entityId}`) and mapped to OIDC claims via the claims-mapping config. This reuses the
+built-in `BasicAuthExecutor` (no custom executor); the demo flow `decl-sunbird-flow-1` and app
+`decl-app-sunbird` exercise it.
+
+The `SUNBIRD_RC` environment variables mirror the Java eSignet Sunbird plugin
+(`io.mosip.esignet.plugin.sunbirdrc`) property keys — uppercased, with `.` and `-` replaced by `_`.
 
 ## Client management API
 

--- a/esignet-service/README.md
+++ b/esignet-service/README.md
@@ -169,7 +169,7 @@ Set `LOG_LEVEL=debug` for verbose tracing.
 | `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD` | `policyNumber` | Registry field the entered `individualId` maps to in the search filter |
 | `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_KBI_ENTITY_ID_FIELD` | `osid` | Registry field holding the entity id returned by search |
 | `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_FIELD_DETAILS` | _(Insurance default)_ | JSON list of KBI fields collected from the user |
-| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING` | _(Insurance default)_ | JSON map of OIDC claim → registry field (empty = raw passthrough) |
+| `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING` | _(Insurance default)_ | JSON map of OIDC claim → registry field (empty/unset or malformed = no claims released; fail closed) |
 | `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS` | `10` | HTTP timeout in seconds for registry calls |
 
 See `.env.example` for the full list including optional MOSIP URL overrides.

--- a/esignet-service/data/repository/resources/applications/app-declarative-sunbird.yaml
+++ b/esignet-service/data/repository/resources/applications/app-declarative-sunbird.yaml
@@ -1,0 +1,28 @@
+id: decl-app-sunbird
+name: Declarative SunbirdRC Application
+description: A declarative application that authenticates via the SunbirdRC KBI flow
+ou_id: decl-ou-1
+template: web
+auth_flow_id: decl-sunbird-flow-1
+registration_flow_id: decl-reg-flow-1
+recovery_flow_id: decl-recovery-flow-1
+is_registration_flow_enabled: true
+is_recovery_flow_enabled: true
+theme_id: decl-theme-1
+layout_id: decl-layout-1
+url: https://example.com
+contacts:
+  - test@example.com
+inbound_auth_config:
+  - type: "oauth2"
+    config:
+      client_id: "decl-sunbird-client-1"
+      redirect_uris:
+        - "https://localhost:3000"
+      grant_types:
+        - "authorization_code"
+      response_types:
+        - "code"
+      token_endpoint_auth_method: "none"
+      pkce_required: true
+      public_client: true

--- a/esignet-service/data/repository/resources/flows/flow-declarative-sunbird-1.yaml
+++ b/esignet-service/data/repository/resources/flows/flow-declarative-sunbird-1.yaml
@@ -1,0 +1,58 @@
+id: decl-sunbird-flow-1
+handle: decl-sunbird-flow-1
+name: SunbirdRC KBI Flow
+flowType: AUTHENTICATION
+activeVersion: 1
+nodes:
+  - id: start
+    type: START
+    onSuccess: prompt_credentials
+  - id: prompt_credentials
+    type: PROMPT
+    prompts:
+      - inputs:
+          - ref: input_001
+            identifier: individualId
+            type: TEXT_INPUT
+            required: true
+          - ref: input_002
+            identifier: fullName
+            type: TEXT_INPUT
+            required: true
+          - ref: input_003
+            identifier: dob
+            type: TEXT_INPUT
+            required: true
+        action:
+          ref: action_001
+          nextNode: basic_auth
+  - id: basic_auth
+    type: TASK_EXECUTION
+    executor:
+      name: BasicAuthExecutor
+      inputs:
+        - ref: input_001
+          identifier: individualId
+          type: TEXT_INPUT
+          required: true
+        - ref: input_002
+          identifier: fullName
+          type: PASSWORD_INPUT
+          required: true
+        - ref: input_003
+          identifier: dob
+          type: PASSWORD_INPUT
+          required: true
+    onSuccess: authorization_check
+  - id: authorization_check
+    type: TASK_EXECUTION
+    executor:
+      name: AuthorizationExecutor
+    onSuccess: auth_assert
+  - id: auth_assert
+    type: TASK_EXECUTION
+    executor:
+      name: AuthAssertExecutor
+    onSuccess: end
+  - id: end
+    type: END

--- a/esignet-service/internal/config/authn.go
+++ b/esignet-service/internal/config/authn.go
@@ -5,6 +5,7 @@ package config
 const (
 	AuthnProviderCatalog = "catalog"
 	AuthnProviderMosip   = "mosip"
+	AuthnProviderSunbird = "sunbird"
 	defaultAuthnProvider = AuthnProviderCatalog
 )
 
@@ -12,6 +13,7 @@ const (
 type Authn struct {
 	Provider string
 	Mosip    MosipAuthn
+	Sunbird  SunbirdAuthn
 }
 
 // LoadAuthn reads authn provider settings from environment variables.
@@ -19,5 +21,6 @@ func LoadAuthn() Authn {
 	return Authn{
 		Provider: envOrDefault("AUTHN_PROVIDER", defaultAuthnProvider),
 		Mosip:    LoadMosipAuthn(),
+		Sunbird:  LoadSunbirdAuthn(),
 	}
 }

--- a/esignet-service/internal/config/authn_test.go
+++ b/esignet-service/internal/config/authn_test.go
@@ -21,3 +21,12 @@ func TestLoadAuthn_mosip(t *testing.T) {
 	require.Equal(t, AuthnProviderMosip, cfg.Provider)
 	require.Equal(t, "/tmp/partner.p12", cfg.Mosip.P12Path)
 }
+
+func TestLoadAuthn_sunbird(t *testing.T) {
+	t.Setenv("AUTHN_PROVIDER", AuthnProviderSunbird)
+	t.Setenv(envSunbirdSearchURL, "https://reg.example/search")
+
+	cfg := LoadAuthn()
+	require.Equal(t, AuthnProviderSunbird, cfg.Provider)
+	require.Equal(t, "https://reg.example/search", cfg.Sunbird.SearchURL)
+}

--- a/esignet-service/internal/config/sunbird.go
+++ b/esignet-service/internal/config/sunbird.go
@@ -5,8 +5,7 @@ import (
 	"strconv"
 )
 
-// SunbirdRC env var names. These mirror the Java eSignet plugin property keys
-// (io.mosip.esignet.plugin.sunbirdrc), uppercased with "." and "-" replaced by "_".
+// SunbirdRC env var names.
 const (
 	envSunbirdIDField       = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD"
 	envSunbirdFieldDetails  = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_FIELD_DETAILS"
@@ -14,8 +13,7 @@ const (
 	envSunbirdEntityIDField = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_KBI_ENTITY_ID_FIELD"
 	envSunbirdClaimsMapping = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING"
 	envSunbirdEntityURL     = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL"
-	// envSunbirdTimeout has no Java counterpart; it is a Go-only HTTP timeout knob.
-	envSunbirdTimeout = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS"
+	envSunbirdTimeout       = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS"
 )
 
 const (
@@ -46,8 +44,15 @@ type SunbirdAuthn struct {
 //
 // SearchURL has no default and must be supplied for the sunbird provider to
 // start. The remaining fields default to the released MOSIP Insurance registry
-// conventions used by the Java eSignet Sunbird plugin.
+// conventions.
 func LoadSunbirdAuthn() SunbirdAuthn {
+	timeoutSecs := defaultSunbirdTimeoutSecs
+	if raw := os.Getenv(envSunbirdTimeout); raw != "" {
+		if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+			timeoutSecs = secs
+		}
+	}
+
 	return SunbirdAuthn{
 		SearchURL:     envOrDefault(envSunbirdSearchURL, ""),
 		EntityURL:     trimTrailingSlash(envOrDefault(envSunbirdEntityURL, "")),
@@ -55,18 +60,6 @@ func LoadSunbirdAuthn() SunbirdAuthn {
 		EntityIDField: envOrDefault(envSunbirdEntityIDField, defaultSunbirdEntityIDField),
 		FieldDetails:  envOrDefault(envSunbirdFieldDetails, defaultSunbirdFieldDetails),
 		ClaimsMapping: envOrDefault(envSunbirdClaimsMapping, defaultSunbirdClaimsMapping),
-		TimeoutSecs:   sunbirdTimeoutSecs(),
+		TimeoutSecs:   timeoutSecs,
 	}
-}
-
-func sunbirdTimeoutSecs() int {
-	raw := os.Getenv(envSunbirdTimeout)
-	if raw == "" {
-		return defaultSunbirdTimeoutSecs
-	}
-	secs, err := strconv.Atoi(raw)
-	if err != nil || secs <= 0 {
-		return defaultSunbirdTimeoutSecs
-	}
-	return secs
 }

--- a/esignet-service/internal/config/sunbird.go
+++ b/esignet-service/internal/config/sunbird.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"os"
+	"strconv"
+)
+
+// SunbirdRC env var names. These mirror the Java eSignet plugin property keys
+// (io.mosip.esignet.plugin.sunbirdrc), uppercased with "." and "-" replaced by "_".
+const (
+	envSunbirdIDField       = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD"
+	envSunbirdFieldDetails  = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_FIELD_DETAILS"
+	envSunbirdSearchURL     = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL"
+	envSunbirdEntityIDField = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_KBI_ENTITY_ID_FIELD"
+	envSunbirdClaimsMapping = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_IDENTITY_OPENID_CLAIMS_MAPPING"
+	envSunbirdEntityURL     = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL"
+	// envSunbirdTimeout has no Java counterpart; it is a Go-only HTTP timeout knob.
+	envSunbirdTimeout = "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REQUEST_TIMEOUT_SECS"
+)
+
+const (
+	defaultSunbirdIDField       = "policyNumber"
+	defaultSunbirdEntityIDField = "osid"
+	defaultSunbirdTimeoutSecs   = 10
+
+	defaultSunbirdFieldDetails = `[{"id":"policyNumber","type":"text","format":""},` +
+		`{"id":"fullName","type":"text","format":""},` +
+		`{"id":"dob","type":"date","format":"dd/mm/yyyy"}]`
+
+	defaultSunbirdClaimsMapping = `{"name":"fullName","email":"email",` +
+		`"phone_number":"mobile","gender":"gender","birthdate":"dob"}`
+)
+
+// SunbirdAuthn holds SunbirdRC registry (KBI) integration settings.
+type SunbirdAuthn struct {
+	SearchURL     string
+	EntityURL     string
+	IDField       string
+	EntityIDField string
+	FieldDetails  string
+	ClaimsMapping string
+	TimeoutSecs   int
+}
+
+// LoadSunbirdAuthn reads SunbirdRC auth settings from environment variables.
+//
+// SearchURL has no default and must be supplied for the sunbird provider to
+// start. The remaining fields default to the released MOSIP Insurance registry
+// conventions used by the Java eSignet Sunbird plugin.
+func LoadSunbirdAuthn() SunbirdAuthn {
+	return SunbirdAuthn{
+		SearchURL:     envOrDefault(envSunbirdSearchURL, ""),
+		EntityURL:     trimTrailingSlash(envOrDefault(envSunbirdEntityURL, "")),
+		IDField:       envOrDefault(envSunbirdIDField, defaultSunbirdIDField),
+		EntityIDField: envOrDefault(envSunbirdEntityIDField, defaultSunbirdEntityIDField),
+		FieldDetails:  envOrDefault(envSunbirdFieldDetails, defaultSunbirdFieldDetails),
+		ClaimsMapping: envOrDefault(envSunbirdClaimsMapping, defaultSunbirdClaimsMapping),
+		TimeoutSecs:   sunbirdTimeoutSecs(),
+	}
+}
+
+func sunbirdTimeoutSecs() int {
+	raw := os.Getenv(envSunbirdTimeout)
+	if raw == "" {
+		return defaultSunbirdTimeoutSecs
+	}
+	secs, err := strconv.Atoi(raw)
+	if err != nil || secs <= 0 {
+		return defaultSunbirdTimeoutSecs
+	}
+	return secs
+}

--- a/esignet-service/internal/config/sunbird.go
+++ b/esignet-service/internal/config/sunbird.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // SunbirdRC env var names.
@@ -54,7 +56,7 @@ func LoadSunbirdAuthn() SunbirdAuthn {
 	}
 
 	return SunbirdAuthn{
-		SearchURL:     envOrDefault(envSunbirdSearchURL, ""),
+		SearchURL:     strings.TrimSpace(envOrDefault(envSunbirdSearchURL, "")),
 		EntityURL:     trimTrailingSlash(envOrDefault(envSunbirdEntityURL, "")),
 		IDField:       envOrDefault(envSunbirdIDField, defaultSunbirdIDField),
 		EntityIDField: envOrDefault(envSunbirdEntityIDField, defaultSunbirdEntityIDField),
@@ -62,4 +64,23 @@ func LoadSunbirdAuthn() SunbirdAuthn {
 		ClaimsMapping: envOrDefault(envSunbirdClaimsMapping, defaultSunbirdClaimsMapping),
 		TimeoutSecs:   timeoutSecs,
 	}
+}
+
+// Validate reports whether the SunbirdRC settings are usable by the provider.
+//
+// It is called at provider construction rather than in LoadSunbirdAuthn, which
+// runs unconditionally for every provider; failing there would also break the
+// catalog/mosip providers. Gating here means a missing SearchURL only fails when
+// AUTHN_PROVIDER=sunbird.
+func (c SunbirdAuthn) Validate() error {
+	if strings.TrimSpace(c.SearchURL) == "" {
+		return errors.New("SUNBIRD_SEARCH_URL is required for the sunbird authn provider")
+	}
+	if c.IDField == "" {
+		return errors.New("SUNBIRD individual ID field must not be empty")
+	}
+	if c.EntityIDField == "" {
+		return errors.New("SUNBIRD entity ID field must not be empty")
+	}
+	return nil
 }

--- a/esignet-service/internal/config/sunbird_test.go
+++ b/esignet-service/internal/config/sunbird_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSunbirdAuthn_defaults(t *testing.T) {
+	for _, key := range []string{
+		envSunbirdSearchURL, envSunbirdEntityURL, envSunbirdIDField,
+		envSunbirdEntityIDField, envSunbirdFieldDetails, envSunbirdClaimsMapping,
+		envSunbirdTimeout,
+	} {
+		t.Setenv(key, "")
+	}
+
+	cfg := LoadSunbirdAuthn()
+	require.Empty(t, cfg.SearchURL)
+	require.Empty(t, cfg.EntityURL)
+	require.Equal(t, "policyNumber", cfg.IDField)
+	require.Equal(t, "osid", cfg.EntityIDField)
+	require.Equal(t, defaultSunbirdFieldDetails, cfg.FieldDetails)
+	require.Equal(t, defaultSunbirdClaimsMapping, cfg.ClaimsMapping)
+	require.Equal(t, 10, cfg.TimeoutSecs)
+}
+
+func TestLoadSunbirdAuthn_overrides(t *testing.T) {
+	t.Setenv(envSunbirdSearchURL, "https://reg.example/api/v1/Insurance/search")
+	t.Setenv(envSunbirdEntityURL, "https://reg.example/api/v1/Insurance/")
+	t.Setenv(envSunbirdIDField, "memberId")
+	t.Setenv(envSunbirdEntityIDField, "id")
+	t.Setenv(envSunbirdFieldDetails, `[{"id":"memberId","type":"text","format":""}]`)
+	t.Setenv(envSunbirdClaimsMapping, `{"name":"fullName"}`)
+	t.Setenv(envSunbirdTimeout, "25")
+
+	cfg := LoadSunbirdAuthn()
+	require.Equal(t, "https://reg.example/api/v1/Insurance/search", cfg.SearchURL)
+	// Trailing slash is trimmed so entity ids can be appended cleanly.
+	require.Equal(t, "https://reg.example/api/v1/Insurance", cfg.EntityURL)
+	require.Equal(t, "memberId", cfg.IDField)
+	require.Equal(t, "id", cfg.EntityIDField)
+	require.Equal(t, `[{"id":"memberId","type":"text","format":""}]`, cfg.FieldDetails)
+	require.Equal(t, `{"name":"fullName"}`, cfg.ClaimsMapping)
+	require.Equal(t, 25, cfg.TimeoutSecs)
+}
+
+func TestLoadSunbirdAuthn_invalidTimeoutFallsBackToDefault(t *testing.T) {
+	t.Setenv(envSunbirdTimeout, "not-a-number")
+	require.Equal(t, 10, LoadSunbirdAuthn().TimeoutSecs)
+
+	t.Setenv(envSunbirdTimeout, "0")
+	require.Equal(t, 10, LoadSunbirdAuthn().TimeoutSecs)
+}

--- a/esignet-service/internal/config/sunbird_test.go
+++ b/esignet-service/internal/config/sunbird_test.go
@@ -51,4 +51,7 @@ func TestLoadSunbirdAuthn_invalidTimeoutFallsBackToDefault(t *testing.T) {
 
 	t.Setenv(envSunbirdTimeout, "0")
 	require.Equal(t, 10, LoadSunbirdAuthn().TimeoutSecs)
+
+	t.Setenv(envSunbirdTimeout, "-5")
+	require.Equal(t, 10, LoadSunbirdAuthn().TimeoutSecs)
 }

--- a/esignet-service/internal/host/authn_factory.go
+++ b/esignet-service/internal/host/authn_factory.go
@@ -16,6 +16,8 @@ func NewAuthnProviderFromConfig(cfg config.Authn, cat *catalog.Catalog) (host.Au
 		return NewAuthnProvider(cat), nil
 	case config.AuthnProviderMosip:
 		return NewMosipAuthnProvider(cfg.Mosip), nil
+	case config.AuthnProviderSunbird:
+		return NewSunbirdAuthnProvider(cfg.Sunbird)
 	default:
 		return nil, fmt.Errorf("unsupported authn provider %q", cfg.Provider)
 	}

--- a/esignet-service/internal/host/authn_factory_test.go
+++ b/esignet-service/internal/host/authn_factory_test.go
@@ -23,6 +23,25 @@ func TestNewAuthnProviderFromConfig_mosip(t *testing.T) {
 	require.NotNil(t, provider)
 }
 
+func TestNewAuthnProviderFromConfig_sunbird(t *testing.T) {
+	cat := &catalog.Catalog{}
+	cfg := config.Authn{
+		Provider: config.AuthnProviderSunbird,
+		Sunbird:  config.SunbirdAuthn{SearchURL: "https://reg.example/search"},
+	}
+	provider, err := NewAuthnProviderFromConfig(cfg, cat)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+}
+
+func TestNewAuthnProviderFromConfig_sunbirdMissingSearchURL(t *testing.T) {
+	cat := &catalog.Catalog{}
+	provider, err := NewAuthnProviderFromConfig(config.Authn{Provider: config.AuthnProviderSunbird}, cat)
+	require.Error(t, err)
+	require.Nil(t, provider)
+	require.Contains(t, err.Error(), "SUNBIRD_SEARCH_URL")
+}
+
 func TestNewAuthnProviderFromConfig_unknown(t *testing.T) {
 	cat := &catalog.Catalog{}
 	provider, err := NewAuthnProviderFromConfig(config.Authn{Provider: "unknown"}, cat)

--- a/esignet-service/internal/host/authn_factory_test.go
+++ b/esignet-service/internal/host/authn_factory_test.go
@@ -27,7 +27,12 @@ func TestNewAuthnProviderFromConfig_sunbird(t *testing.T) {
 	cat := &catalog.Catalog{}
 	cfg := config.Authn{
 		Provider: config.AuthnProviderSunbird,
-		Sunbird:  config.SunbirdAuthn{SearchURL: "https://reg.example/search"},
+		Sunbird: config.SunbirdAuthn{
+			SearchURL:     "https://reg.example/search",
+			IDField:       "policyNumber",
+			EntityIDField: "osid",
+			FieldDetails:  testSunbirdFieldDetails,
+		},
 	}
 	provider, err := NewAuthnProviderFromConfig(cfg, cat)
 	require.NoError(t, err)

--- a/esignet-service/internal/host/sunbird_authn.go
+++ b/esignet-service/internal/host/sunbird_authn.go
@@ -1,0 +1,243 @@
+package host
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/host"
+
+	"github.com/mosip/esignet/internal/config"
+	applog "github.com/mosip/esignet/internal/log"
+)
+
+const sunbirdIndividualIDKey = "individualId"
+
+// errSunbirdKBIAuthFailed signals a registry lookup that did not match exactly one
+// entity, i.e. an authentication failure (as opposed to a transport/server error).
+var errSunbirdKBIAuthFailed = errors.New("authentication failed")
+
+type sunbirdFieldDetail struct {
+	ID     string `json:"id"`
+	Type   string `json:"type"`
+	Format string `json:"format"`
+}
+
+type sunbirdSearchFilter struct {
+	Eq string `json:"eq"`
+}
+
+type sunbirdSearchRequest struct {
+	Filters map[string]sunbirdSearchFilter `json:"filters"`
+}
+
+type sunbirdAuthnProvider struct {
+	cfg    config.SunbirdAuthn
+	client *http.Client
+}
+
+// NewSunbirdAuthnProvider creates a SunbirdRC registry-backed host.AuthnProvider.
+// It returns an error when SearchURL is not configured, since there is no default.
+func NewSunbirdAuthnProvider(cfg config.SunbirdAuthn) (host.AuthnProvider, error) {
+	if cfg.SearchURL == "" {
+		return nil, errors.New("SUNBIRD_SEARCH_URL is required for the sunbird authn provider")
+	}
+	timeout := time.Duration(cfg.TimeoutSecs) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &sunbirdAuthnProvider{
+		cfg:    cfg,
+		client: &http.Client{Timeout: timeout},
+	}, nil
+}
+
+func (p *sunbirdAuthnProvider) Authenticate(ctx context.Context, identifiers, credentials map[string]interface{},
+	_ *host.AuthnMetadata) (*host.AuthnResult, error) {
+
+	individualID, ok := identifiers[sunbirdIndividualIDKey].(string)
+	if !ok || individualID == "" {
+		return nil, fmt.Errorf("missing or invalid %q in identifiers", sunbirdIndividualIDKey)
+	}
+
+	fields, err := parseSunbirdFieldDetails(p.cfg.FieldDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	kbiFields := make(map[string]string, len(fields))
+	for _, f := range fields {
+		if f.ID == p.cfg.IDField {
+			continue
+		}
+		val, ok := credentials[f.ID].(string)
+		if !ok || val == "" {
+			return nil, fmt.Errorf("missing or invalid KBI field %q in credentials", f.ID)
+		}
+		kbiFields[f.ID] = val
+	}
+
+	entityID, err := p.validateKBI(ctx, individualID, kbiFields)
+	if err != nil {
+		if errors.Is(err, errSunbirdKBIAuthFailed) {
+			return nil, errSunbirdKBIAuthFailed
+		}
+		return nil, fmt.Errorf("sunbird registry search failed: %w", err)
+	}
+
+	return &host.AuthnResult{
+		Authenticated: true,
+		UserID:        entityID,
+		AuthToken:     entityID,
+	}, nil
+}
+
+func (p *sunbirdAuthnProvider) GetAttributes(ctx context.Context, token string, _ *host.RequestedAttributes,
+	_ *host.GetAttributesMetadata) (*host.GetAttributesResult, error) {
+
+	if p.cfg.EntityURL == "" {
+		return &host.GetAttributesResult{Attributes: json.RawMessage("{}")}, nil
+	}
+
+	entityData, err := p.fetchEntityData(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch sunbird entity data: %w", err)
+	}
+
+	mappedClaims := buildSunbirdMappedClaims(entityData, p.cfg.ClaimsMapping)
+	attributesJSON, err := json.Marshal(mappedClaims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal sunbird attributes: %w", err)
+	}
+
+	return &host.GetAttributesResult{Attributes: attributesJSON}, nil
+}
+
+func (p *sunbirdAuthnProvider) validateKBI(ctx context.Context, individualID string,
+	kbiFields map[string]string) (string, error) {
+
+	filters := make(map[string]sunbirdSearchFilter, len(kbiFields)+1)
+	filters[p.cfg.IDField] = sunbirdSearchFilter{Eq: individualID}
+	for fieldID, fieldValue := range kbiFields {
+		filters[fieldID] = sunbirdSearchFilter{Eq: fieldValue}
+	}
+
+	reqBody, err := json.Marshal(sunbirdSearchRequest{Filters: filters})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal registry search request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.cfg.SearchURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to build registry search request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("registry search request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("registry search returned status %d", resp.StatusCode)
+	}
+
+	var results []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return "", fmt.Errorf("failed to decode registry search response: %w", err)
+	}
+
+	if len(results) != 1 {
+		applog.GetLogger().Debug("sunbird registry search did not match exactly one entity",
+			applog.Int("matches", len(results)))
+		return "", errSunbirdKBIAuthFailed
+	}
+
+	entityIDVal, ok := results[0][p.cfg.EntityIDField]
+	if !ok {
+		return "", fmt.Errorf("entity_id_field %q not found in registry response", p.cfg.EntityIDField)
+	}
+	entityID, ok := entityIDVal.(string)
+	if !ok || entityID == "" {
+		return "", fmt.Errorf("entity_id_field %q has invalid value in registry response", p.cfg.EntityIDField)
+	}
+
+	return entityID, nil
+}
+
+func (p *sunbirdAuthnProvider) fetchEntityData(ctx context.Context, entityID string) (map[string]interface{}, error) {
+	url := fmt.Sprintf("%s/%s", p.cfg.EntityURL, entityID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build entity fetch request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("entity fetch request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("entity fetch returned status %d", resp.StatusCode)
+	}
+
+	var entityData map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&entityData); err != nil {
+		return nil, fmt.Errorf("failed to decode entity fetch response: %w", err)
+	}
+
+	return entityData, nil
+}
+
+func parseSunbirdFieldDetails(jsonStr string) ([]sunbirdFieldDetail, error) {
+	if jsonStr == "" {
+		return nil, errors.New("SUNBIRD_FIELD_DETAILS is empty")
+	}
+	var fields []sunbirdFieldDetail
+	if err := json.Unmarshal([]byte(jsonStr), &fields); err != nil {
+		return nil, fmt.Errorf("invalid SUNBIRD_FIELD_DETAILS JSON: %w", err)
+	}
+	return fields, nil
+}
+
+func parseSunbirdClaimsMapping(jsonStr string) (map[string]string, error) {
+	var mapping map[string]string
+	if err := json.Unmarshal([]byte(jsonStr), &mapping); err != nil {
+		return nil, fmt.Errorf("invalid SUNBIRD_CLAIMS_MAPPING JSON: %w", err)
+	}
+	return mapping, nil
+}
+
+// buildSunbirdMappedClaims maps registry entity fields to OIDC claims using
+// claimsMappingJSON ({oidcClaim: registryField}). When the mapping is empty or
+// invalid, the raw entity data is returned unchanged.
+func buildSunbirdMappedClaims(entityData map[string]interface{},
+	claimsMappingJSON string) map[string]interface{} {
+
+	if claimsMappingJSON == "" {
+		return entityData
+	}
+
+	claimsMapping, err := parseSunbirdClaimsMapping(claimsMappingJSON)
+	if err != nil {
+		applog.GetLogger().Warn("failed to parse SUNBIRD_CLAIMS_MAPPING; using raw entity data",
+			applog.Error(err))
+		return entityData
+	}
+
+	mapped := make(map[string]interface{}, len(claimsMapping))
+	for oidcClaim, registryField := range claimsMapping {
+		if val, ok := entityData[registryField]; ok {
+			mapped[oidcClaim] = val
+		}
+	}
+	return mapped
+}

--- a/esignet-service/internal/host/sunbird_authn.go
+++ b/esignet-service/internal/host/sunbird_authn.go
@@ -217,8 +217,10 @@ func parseSunbirdClaimsMapping(jsonStr string) (map[string]string, error) {
 }
 
 // buildSunbirdMappedClaims maps registry entity fields to OIDC claims using
-// claimsMappingJSON ({oidcClaim: registryField}). When the mapping is empty or
-// invalid, the raw entity data is returned unchanged.
+// claimsMappingJSON ({oidcClaim: registryField}). When the mapping is empty,
+// the raw entity data is returned unchanged. When the mapping is malformed it
+// fails closed and returns an empty map, so unmapped registry fields are never
+// disclosed as OIDC attributes.
 func buildSunbirdMappedClaims(entityData map[string]interface{},
 	claimsMappingJSON string) map[string]interface{} {
 
@@ -228,9 +230,9 @@ func buildSunbirdMappedClaims(entityData map[string]interface{},
 
 	claimsMapping, err := parseSunbirdClaimsMapping(claimsMappingJSON)
 	if err != nil {
-		applog.GetLogger().Warn("failed to parse SUNBIRD_CLAIMS_MAPPING; using raw entity data",
+		applog.GetLogger().Warn("failed to parse SUNBIRD_CLAIMS_MAPPING; dropping all claims to avoid disclosing raw registry fields",
 			applog.Error(err))
-		return entityData
+		return map[string]interface{}{}
 	}
 
 	mapped := make(map[string]interface{}, len(claimsMapping))

--- a/esignet-service/internal/host/sunbird_authn.go
+++ b/esignet-service/internal/host/sunbird_authn.go
@@ -38,21 +38,42 @@ type sunbirdSearchRequest struct {
 type sunbirdAuthnProvider struct {
 	cfg    config.SunbirdAuthn
 	client *http.Client
+	// kbiFieldIDs are the KBI credential fields (from SUNBIRD_FIELD_DETAILS,
+	// excluding IDField) parsed once at construction and reused per request.
+	kbiFieldIDs []string
 }
 
 // NewSunbirdAuthnProvider creates a SunbirdRC registry-backed host.AuthnProvider.
-// It returns an error when SearchURL is not configured, since there is no default.
+// It validates the config and parses the KBI field details once, returning an
+// error when SearchURL is unset or no KBI field other than IDField is configured.
 func NewSunbirdAuthnProvider(cfg config.SunbirdAuthn) (host.AuthnProvider, error) {
-	if cfg.SearchURL == "" {
-		return nil, errors.New("SUNBIRD_SEARCH_URL is required for the sunbird authn provider")
+	if err := cfg.Validate(); err != nil {
+		return nil, err
 	}
+
+	fields, err := parseSunbirdFieldDetails(cfg.FieldDetails)
+	if err != nil {
+		return nil, err
+	}
+	kbiFieldIDs := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f.ID == cfg.IDField {
+			continue
+		}
+		kbiFieldIDs = append(kbiFieldIDs, f.ID)
+	}
+	if len(kbiFieldIDs) == 0 {
+		return nil, errors.New("SUNBIRD_FIELD_DETAILS must define at least one KBI field other than the individual ID field")
+	}
+
 	timeout := time.Duration(cfg.TimeoutSecs) * time.Second
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
 	return &sunbirdAuthnProvider{
-		cfg:    cfg,
-		client: &http.Client{Timeout: timeout},
+		cfg:         cfg,
+		client:      &http.Client{Timeout: timeout},
+		kbiFieldIDs: kbiFieldIDs,
 	}, nil
 }
 
@@ -64,21 +85,13 @@ func (p *sunbirdAuthnProvider) Authenticate(ctx context.Context, identifiers, cr
 		return nil, fmt.Errorf("missing or invalid %q in identifiers", sunbirdIndividualIDKey)
 	}
 
-	fields, err := parseSunbirdFieldDetails(p.cfg.FieldDetails)
-	if err != nil {
-		return nil, err
-	}
-
-	kbiFields := make(map[string]string, len(fields))
-	for _, f := range fields {
-		if f.ID == p.cfg.IDField {
-			continue
-		}
-		val, ok := credentials[f.ID].(string)
+	kbiFields := make(map[string]string, len(p.kbiFieldIDs))
+	for _, id := range p.kbiFieldIDs {
+		val, ok := credentials[id].(string)
 		if !ok || val == "" {
-			return nil, fmt.Errorf("missing or invalid KBI field %q in credentials", f.ID)
+			return nil, fmt.Errorf("missing or invalid KBI field %q in credentials", id)
 		}
-		kbiFields[f.ID] = val
+		kbiFields[id] = val
 	}
 
 	entityID, err := p.validateKBI(ctx, individualID, kbiFields)
@@ -217,15 +230,15 @@ func parseSunbirdClaimsMapping(jsonStr string) (map[string]string, error) {
 }
 
 // buildSunbirdMappedClaims maps registry entity fields to OIDC claims using
-// claimsMappingJSON ({oidcClaim: registryField}). When the mapping is empty,
-// the raw entity data is returned unchanged. When the mapping is malformed it
-// fails closed and returns an empty map, so unmapped registry fields are never
-// disclosed as OIDC attributes.
+// claimsMappingJSON ({oidcClaim: registryField}). It fails closed: when the
+// mapping is empty or malformed, no claims are released, so unmapped registry
+// fields are never disclosed as OIDC attributes. This mirrors the upstream Java
+// SunbirdRC plugin, which only emits claims that have an explicit mapping.
 func buildSunbirdMappedClaims(entityData map[string]interface{},
 	claimsMappingJSON string) map[string]interface{} {
 
 	if claimsMappingJSON == "" {
-		return entityData
+		return map[string]interface{}{}
 	}
 
 	claimsMapping, err := parseSunbirdClaimsMapping(claimsMappingJSON)

--- a/esignet-service/internal/host/sunbird_authn_test.go
+++ b/esignet-service/internal/host/sunbird_authn_test.go
@@ -1,0 +1,151 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mosip/esignet/internal/config"
+)
+
+const (
+	testSunbirdFieldDetails = `[{"id":"policyNumber","type":"text","format":""},` +
+		`{"id":"fullName","type":"text","format":""},` +
+		`{"id":"dob","type":"date","format":"dd/mm/yyyy"}]`
+	testSunbirdClaimsMapping = `{"name":"fullName","email":"email","birthdate":"dob"}`
+)
+
+func newTestSunbirdProvider(t *testing.T, searchURL, entityURL string) *sunbirdAuthnProvider {
+	t.Helper()
+	provider, err := NewSunbirdAuthnProvider(config.SunbirdAuthn{
+		SearchURL:     searchURL,
+		EntityURL:     entityURL,
+		IDField:       "policyNumber",
+		EntityIDField: "osid",
+		FieldDetails:  testSunbirdFieldDetails,
+		ClaimsMapping: testSunbirdClaimsMapping,
+		TimeoutSecs:   5,
+	})
+	require.NoError(t, err)
+	return provider.(*sunbirdAuthnProvider)
+}
+
+func TestNewSunbirdAuthnProvider_requiresSearchURL(t *testing.T) {
+	_, err := NewSunbirdAuthnProvider(config.SunbirdAuthn{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SUNBIRD_SEARCH_URL")
+}
+
+func TestSunbirdAuthenticate_success(t *testing.T) {
+	var gotReq sunbirdSearchRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotReq))
+		_, _ = w.Write([]byte(`[{"osid":"entity-123"}]`))
+	}))
+	defer srv.Close()
+
+	p := newTestSunbirdProvider(t, srv.URL, "")
+	result, err := p.Authenticate(context.Background(),
+		map[string]interface{}{"individualId": "POL-1"},
+		map[string]interface{}{"fullName": "John Doe", "dob": "1990-01-01"},
+		nil)
+
+	require.NoError(t, err)
+	require.True(t, result.Authenticated)
+	require.Equal(t, "entity-123", result.UserID)
+	require.Equal(t, "entity-123", result.AuthToken)
+
+	// individualId maps to the configured IDField in the search filter.
+	require.Equal(t, "POL-1", gotReq.Filters["policyNumber"].Eq)
+	require.Equal(t, "John Doe", gotReq.Filters["fullName"].Eq)
+	require.Equal(t, "1990-01-01", gotReq.Filters["dob"].Eq)
+}
+
+func TestSunbirdAuthenticate_zeroMatchFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	p := newTestSunbirdProvider(t, srv.URL, "")
+	_, err := p.Authenticate(context.Background(),
+		map[string]interface{}{"individualId": "POL-1"},
+		map[string]interface{}{"fullName": "John Doe", "dob": "1990-01-01"},
+		nil)
+	require.ErrorIs(t, err, errSunbirdKBIAuthFailed)
+}
+
+func TestSunbirdAuthenticate_multiMatchFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"osid":"a"},{"osid":"b"}]`))
+	}))
+	defer srv.Close()
+
+	p := newTestSunbirdProvider(t, srv.URL, "")
+	_, err := p.Authenticate(context.Background(),
+		map[string]interface{}{"individualId": "POL-1"},
+		map[string]interface{}{"fullName": "John Doe", "dob": "1990-01-01"},
+		nil)
+	require.ErrorIs(t, err, errSunbirdKBIAuthFailed)
+}
+
+func TestSunbirdAuthenticate_missingCredentialFails(t *testing.T) {
+	p := newTestSunbirdProvider(t, "https://reg.example/search", "")
+	_, err := p.Authenticate(context.Background(),
+		map[string]interface{}{"individualId": "POL-1"},
+		map[string]interface{}{"fullName": "John Doe"}, // dob missing
+		nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dob")
+	require.False(t, errors.Is(err, errSunbirdKBIAuthFailed))
+}
+
+func TestSunbirdAuthenticate_missingIndividualIDFails(t *testing.T) {
+	p := newTestSunbirdProvider(t, "https://reg.example/search", "")
+	_, err := p.Authenticate(context.Background(),
+		map[string]interface{}{},
+		map[string]interface{}{"fullName": "John Doe", "dob": "1990-01-01"},
+		nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "individualId")
+}
+
+func TestSunbirdGetAttributes_mapsClaims(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.True(t, strings.HasSuffix(r.URL.Path, "/entity-123"))
+		_, _ = w.Write([]byte(`{"fullName":"John Doe","email":"john@example.com","dob":"1990-01-01","extra":"ignored"}`))
+	}))
+	defer srv.Close()
+
+	p := newTestSunbirdProvider(t, "https://reg.example/search", srv.URL)
+	result, err := p.GetAttributes(context.Background(), "entity-123", nil, nil)
+	require.NoError(t, err)
+
+	var claims map[string]interface{}
+	require.NoError(t, json.Unmarshal(result.Attributes, &claims))
+	require.Equal(t, "John Doe", claims["name"])
+	require.Equal(t, "john@example.com", claims["email"])
+	require.Equal(t, "1990-01-01", claims["birthdate"])
+	require.NotContains(t, claims, "extra") // unmapped fields are dropped
+}
+
+func TestSunbirdGetAttributes_emptyEntityURLReturnsEmpty(t *testing.T) {
+	p := newTestSunbirdProvider(t, "https://reg.example/search", "")
+	result, err := p.GetAttributes(context.Background(), "entity-123", nil, nil)
+	require.NoError(t, err)
+	require.JSONEq(t, "{}", string(result.Attributes))
+}
+
+func TestBuildSunbirdMappedClaims_rawPassthroughWhenNoMapping(t *testing.T) {
+	entity := map[string]interface{}{"fullName": "John", "email": "j@e.com"}
+	out := buildSunbirdMappedClaims(entity, "")
+	require.Equal(t, entity, out)
+}

--- a/esignet-service/internal/host/sunbird_authn_test.go
+++ b/esignet-service/internal/host/sunbird_authn_test.go
@@ -149,3 +149,9 @@ func TestBuildSunbirdMappedClaims_rawPassthroughWhenNoMapping(t *testing.T) {
 	out := buildSunbirdMappedClaims(entity, "")
 	require.Equal(t, entity, out)
 }
+
+func TestBuildSunbirdMappedClaims_invalidMappingFailsClosed(t *testing.T) {
+	entity := map[string]interface{}{"fullName": "John", "email": "j@e.com", "extra": "sensitive"}
+	out := buildSunbirdMappedClaims(entity, `{"name":`)
+	require.Empty(t, out)
+}

--- a/esignet-service/internal/host/sunbird_authn_test.go
+++ b/esignet-service/internal/host/sunbird_authn_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mosip/esignet/internal/config"
@@ -42,11 +43,22 @@ func TestNewSunbirdAuthnProvider_requiresSearchURL(t *testing.T) {
 	require.Contains(t, err.Error(), "SUNBIRD_SEARCH_URL")
 }
 
+func TestNewSunbirdAuthnProvider_requiresNonIDKBIField(t *testing.T) {
+	_, err := NewSunbirdAuthnProvider(config.SunbirdAuthn{
+		SearchURL:     "https://reg.example/search",
+		IDField:       "policyNumber",
+		EntityIDField: "osid",
+		FieldDetails:  `[{"id":"policyNumber","type":"text","format":""}]`,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one KBI field")
+}
+
 func TestSunbirdAuthenticate_success(t *testing.T) {
 	var gotReq sunbirdSearchRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotReq))
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&gotReq))
 		_, _ = w.Write([]byte(`[{"osid":"entity-123"}]`))
 	}))
 	defer srv.Close()
@@ -119,8 +131,8 @@ func TestSunbirdAuthenticate_missingIndividualIDFails(t *testing.T) {
 
 func TestSunbirdGetAttributes_mapsClaims(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
-		require.True(t, strings.HasSuffix(r.URL.Path, "/entity-123"))
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/entity-123"))
 		_, _ = w.Write([]byte(`{"fullName":"John Doe","email":"john@example.com","dob":"1990-01-01","extra":"ignored"}`))
 	}))
 	defer srv.Close()
@@ -144,10 +156,10 @@ func TestSunbirdGetAttributes_emptyEntityURLReturnsEmpty(t *testing.T) {
 	require.JSONEq(t, "{}", string(result.Attributes))
 }
 
-func TestBuildSunbirdMappedClaims_rawPassthroughWhenNoMapping(t *testing.T) {
+func TestBuildSunbirdMappedClaims_emptyMappingReleasesNothing(t *testing.T) {
 	entity := map[string]interface{}{"fullName": "John", "email": "j@e.com"}
 	out := buildSunbirdMappedClaims(entity, "")
-	require.Equal(t, entity, out)
+	require.Empty(t, out) // fail closed: no mapping means no claims disclosed
 }
 
 func TestBuildSunbirdMappedClaims_invalidMappingFailsClosed(t *testing.T) {


### PR DESCRIPTION
Resolves #1960

## What
Adds a new authentication provider `AUTHN_PROVIDER=sunbird` that authenticates
users via Knowledge-Based Identity (KBI) against a SunbirdRC registry, alongside
the existing `catalog` and `mosip` providers.

## Why
To support SunbirdRC registry-based login in the Go eSignet service, mirroring
the existing Java eSignet Sunbird plugin (`io.mosip.esignet.plugin.sunbirdrc`).

## How it works
- User enters `individualId` + KBI fields (default `fullName`, `dob`).
- These are POSTed as exact-match filters to the registry **search** endpoint.
- Auth succeeds only when the registry returns **exactly one** matching entity;
  its entity id (default `osid`) becomes the user id.
- User attributes are fetched from the registry **get** endpoint and mapped to
  OIDC claims via configurable claim mapping.
- Reuses the built-in `BasicAuthExecutor` (no custom executor needed).

## Changes
- `internal/config/sunbird.go` – config + env vars (mirrors the Java property keys)
- `internal/host/sunbird_authn.go` – the provider (search + attribute fetch + claims mapping)
- Wired into `config/authn.go` and `host/authn_factory.go`
- Demo flow `flow-declarative-sunbird-1.yaml` + app `app-declarative-sunbird.yaml`
- Unit tests (config, factory, httptest-based provider tests)
- Docs: `README.md` + `.env.example`
- Build fix: `make keys` now works on Windows Git Bash (MSYS path handling)

## Testing
- `go build ./...` and `go test ./...` pass.
- Verified end-to-end against a live registry: authorize → flow → token returns
  `flowStatus: COMPLETE` and a valid assertion/access token.

## Configuration
Set `AUTHN_PROVIDER=sunbird` and the `MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_*`
env vars (registry search/get URLs are required). See `.env.example`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SunbirdRC (KBI) authentication as a configurable provider, including registry entity lookup, exact-match validation, and mapping registry attributes into OIDC claims (with configurable request timeout).
  * Introduced new declarative SunbirdRC application and authentication flow that collect `individualId`, `fullName`, and `dob` and perform the required auth steps.
* **Documentation**
  * Updated README and `.env.example` with SunbirdRC setup details and field/claim mapping formats.
* **Tests**
  * Added unit tests for Sunbird configuration loading and provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->