### PR TITLE
Fixes: mosip/esignet#1878 Add company-internal CA extension point to eSignet Helm chart

### DIFF
--- a/deploy/configure_tls_trust.sh
+++ b/deploy/configure_tls_trust.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Configures Helm arguments for eSignet TLS trust settings.
+# Usage: configure_tls_trust <namespace>
+# Exports TRUST_HELM_ARGS for the caller to pass to Helm.
+
+configure_tls_trust() {
+  local ns="${1:?namespace is required}"
+  local ca_secret ca_file ca_secret_key available_keys
+  export TRUST_HELM_ARGS=''
+
+  secret_has_key() {
+    kubectl -n "$1" get secret "$2" -o "go-template={{if index .data \"${3}\"}}present{{end}}" | grep -q present
+  }
+
+  echo "TLS trust configuration:"
+  echo "1) Public domain with valid SSL certificate (default)"
+  echo "2) Development/self-signed workaround (enable_insecure)"
+  echo "3) Company internal CA"
+  read -r -p "Choose option [1/2/3] (default: 1): " ssl_choice
+  ssl_choice=${ssl_choice:-1}
+
+  case "$ssl_choice" in
+    2)
+      echo "Using enable_insecure for development/self-signed environments."
+      export TRUST_HELM_ARGS='--set enable_insecure=true'
+      ;;
+    3)
+      read -r -p "Name of the Secret containing PEM-encoded CA cert(s) [company-internal-ca]: " ca_secret
+      ca_secret=${ca_secret:-company-internal-ca}
+      ca_secret_key="ca.crt"
+
+      if kubectl -n "$ns" get secret "$ca_secret" >/dev/null 2>&1; then
+        if ! secret_has_key "$ns" "$ca_secret" "$ca_secret_key"; then
+          available_keys=$(kubectl -n "$ns" get secret "$ca_secret" -o go-template='{{range $k,$v := .data}}{{printf "%s " $k}}{{end}}')
+          echo "Key '$ca_secret_key' not found in Secret '$ca_secret'. Available keys: ${available_keys}"
+          read -r -p "Enter the Secret data key containing the PEM bundle: " ca_secret_key_input
+          ca_secret_key=${ca_secret_key_input:-ca.crt}
+          if ! secret_has_key "$ns" "$ca_secret" "$ca_secret_key"; then
+            echo "Key '$ca_secret_key' not found in Secret '$ca_secret'; EXITING"
+            exit 1
+          fi
+        fi
+      else
+        read -r -p "Secret '$ca_secret' not found. Provide path to PEM CA bundle file: " ca_file
+        if [[ -z "${ca_file}" || ! -f "${ca_file}" ]]; then
+          echo "CA bundle file not found; EXITING"
+          exit 1
+        fi
+        kubectl -n "$ns" create secret generic "$ca_secret" \
+          --from-file="${ca_secret_key}=${ca_file}" \
+          --dry-run=client -o yaml | kubectl apply -f -
+        echo "Created Secret '$ca_secret' with company CA bundle."
+      fi
+
+      export TRUST_HELM_ARGS="--set customCA.enabled=true --set customCA.secretName=${ca_secret} --set customCA.secretKey=${ca_secret_key}"
+      ;;
+    1|*)
+      echo "Using default Java truststore (public CAs)."
+      ;;
+  esac
+}

--- a/deploy/esignet-with-plugins/install.sh
+++ b/deploy/esignet-with-plugins/install.sh
@@ -48,20 +48,8 @@ function installing_esignet_with_plugins() {
     fi
   done
 
-  echo "Do you have public domain & valid SSL? (Y/n) "
-  echo "Y: if you have public domain & valid ssl certificate"
-  echo "n: If you don't have a public domain and a valid SSL certificate. Note: It is recommended to use this option only in development environments."
-  read -p "" flag
-
-  if [ -z "$flag" ]; then
-    echo "'flag' was not provided; EXITING;"
-    exit 1;
-  fi
-
-  ENABLE_INSECURE=''
-  if [ "$flag" = "n" ]; then
-    ENABLE_INSECURE='--set enable_insecure=true';
-  fi
+  source ../configure_tls_trust.sh
+  configure_tls_trust "$NS"
 
   while true; do
     read -p "For PKCS12 mounted keys, opt 'y' to enable volume (y/n) [ default: n ]: " enable_volume
@@ -227,7 +215,7 @@ EOF
 
   echo Installing esignet-with-plugins
   helm -n $NS install $ESIGNET_SERVICE_NAME mosip/esignet --version $CHART_VERSION  \
-    $ENABLE_INSECURE $plugin_option \
+    $TRUST_HELM_ARGS $plugin_option \
     $ESIGNET_HELM_ARGS \
     $extra_env_vars_cm_set \
     --set metrics.serviceMonitor.enabled=$servicemonitorflag -f values.yaml --wait

--- a/deploy/esignet-with-plugins/values.yaml
+++ b/deploy/esignet-with-plugins/values.yaml
@@ -97,6 +97,13 @@
 #  prefix: /v1/esignet/
 
 #enable_insecure: false
+
+#customCA:
+#  enabled: true
+#  secretName: company-internal-ca
+#  secretKey: ca.crt
+#  # configMapName: company-internal-ca
+#  # configMapKey: ca.crt
 #springConfigNameEnv:
 #activeProfileEnv:
 #pluginNameEnv: esignet-mock-plugin.jar

--- a/deploy/esignet/install.sh
+++ b/deploy/esignet/install.sh
@@ -55,19 +55,8 @@ function installing_esignet() {
     fi
   done
 
-  echo "Do you have public domain & valid SSL? (Y/n) "
-  echo "Y: if you have public domain & valid ssl certificate"
-  echo "n: If you don't have a public domain and a valid SSL certificate. Note: It is recommended to use this option only in development environments."
-  read -p "" flag
-
-  if [ -z "$flag" ]; then
-    echo "'flag' was provided; EXITING;"
-    exit 1;
-  fi
-  ENABLE_INSECURE=''
-  if [ "$flag" = "n" ]; then
-    ENABLE_INSECURE='--set enable_insecure=true';
-  fi
+  source ../configure_tls_trust.sh
+  configure_tls_trust "$NS"
 
   while true; do
     read -p "For PKCS12, opt 'y' to enable volume (y/n) [ default: n ]: " enable_volume
@@ -116,7 +105,7 @@ function installing_esignet() {
   helm -n $NS install esignet mosip/esignet --version $CHART_VERSION \
   $ESIGNET_HELM_ARGS \
   --set image.repository=mosipdev/esignet --set image.tag=develop \
-  $ENABLE_INSECURE $plugin_option \
+  $TRUST_HELM_ARGS $plugin_option \
   --set metrics.serviceMonitor.enabled=$servicemonitorflag -f values.yaml --wait
 
   kubectl -n $NS  get deploy -o name |  xargs -n1 -t  kubectl -n $NS rollout status

--- a/deploy/esignet/values.yaml
+++ b/deploy/esignet/values.yaml
@@ -97,6 +97,13 @@
 #  prefix: /v1/esignet/
 
 #enable_insecure: false
+
+#customCA:
+#  enabled: true
+#  secretName: company-internal-ca
+#  secretKey: ca.crt
+#  # configMapName: company-internal-ca
+#  # configMapKey: ca.crt
 #springConfigNameEnv:
 #activeProfileEnv:
 #pluginNameEnv: esignet-mock-plugin.jar

--- a/helm/esignet/README.md
+++ b/helm/esignet/README.md
@@ -38,3 +38,40 @@ Refer [Commons](https://docs.mosip.io/1.2.0/modules/commons).
 ```
 ./delete.sh
 ```
+
+## TLS trust configuration
+
+The chart supports three modes for outbound HTTPS trust from the Java service:
+
+1. **Public CAs (default)** — uses the JVM default truststore.
+2. **`enable_insecure: true`** — development-only workaround that fetches a self-signed leaf certificate from `mosip-api-internal-host`.
+3. **`customCA.enabled: true`** — recommended for on-prem deployments using a company-internal CA.
+
+### Company internal CA
+
+Create a Secret (or ConfigMap) with PEM-encoded root/intermediate certificate(s), then enable `customCA`:
+
+```yaml
+customCA:
+  enabled: true
+  secretName: company-internal-ca
+  secretKey: ca.crt
+```
+
+Example:
+
+```sh
+kubectl -n esignet create secret generic company-internal-ca \
+  --from-file=ca.crt=/path/to/company-ca-bundle.pem
+
+helm upgrade --install esignet ./helm/esignet \
+  --set customCA.enabled=true \
+  --set customCA.secretName=company-internal-ca
+```
+
+`enable_insecure` and `customCA` are mutually exclusive.
+
+Additional extension points:
+
+- `extraVolumes` / `extraVolumeMounts` — mount extra volumes into the eSignet container
+- `extraInitContainers` — append custom init containers after built-in truststore init containers

--- a/helm/esignet/templates/_helpers.tpl
+++ b/helm/esignet/templates/_helpers.tpl
@@ -37,11 +37,48 @@ Compile all warnings into a single message.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "esignet.validateValues.foo" .) -}}
 {{- $messages := append $messages (include "esignet.validateValues.bar" .) -}}
+{{- $messages := append $messages (include "esignet.validateValues.customCA" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
 {{- if $message -}}
-{{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
+{{- fail $message -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true when a custom Java truststore should be mounted into the container.
+*/}}
+{{- define "esignet.truststoreRequired" -}}
+{{- or .Values.enable_insecure .Values.customCA.enabled -}}
+{{- end -}}
+
+{{/*
+Return the image used by the company-internal CA init container.
+*/}}
+{{- define "esignet.customCAInitImage" -}}
+{{- $image := .Values.customCA.initContainerImage -}}
+{{- if .Values.global.imageRegistry -}}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry $image.repository $image.tag -}}
+{{- else if $image.registry -}}
+{{- printf "%s/%s:%s" $image.registry $image.repository $image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" $image.repository $image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate customCA configuration.
+*/}}
+{{- define "esignet.validateValues.customCA" -}}
+{{- if and .Values.customCA.enabled (and (not .Values.customCA.secretName) (not .Values.customCA.configMapName)) -}}
+{{- fail "When customCA.enabled is true, set either customCA.secretName or customCA.configMapName." -}}
+{{- end -}}
+{{- if and .Values.customCA.enabled .Values.customCA.secretName .Values.customCA.configMapName -}}
+{{- fail "When customCA.enabled is true, set either customCA.secretName or customCA.configMapName, not both." -}}
+{{- end -}}
+{{- if and .Values.enable_insecure .Values.customCA.enabled -}}
+{{- fail "enable_insecure and customCA.enabled cannot be used together. Use customCA for company-internal PKI." -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/esignet/templates/custom-ca-initcontainer.yaml
+++ b/helm/esignet/templates/custom-ca-initcontainer.yaml
@@ -1,0 +1,55 @@
+{{- define "esignet.customCAInitContainer" -}}
+- name: company-ca-truststore
+  image: {{ include "esignet.customCAInitImage" . }}
+  imagePullPolicy: {{ .Values.customCA.initContainerImage.pullPolicy }}
+  securityContext:
+    runAsUser: 0
+  command:
+    - /bin/bash
+    - -c
+    - |
+      set -euo pipefail
+      JAVA_HOME="{{ .Values.customCA.javaHome }}"
+      KEYSTORE="/cacerts/cacerts"
+      STOREPASS="{{ .Values.customCA.keystorePassword }}"
+      ALIAS_PREFIX="{{ .Values.customCA.aliasPrefix }}"
+      CA_FILE="{{ .Values.customCA.mountPath }}/{{ if .Values.customCA.secretName }}{{ .Values.customCA.secretKey }}{{ else }}{{ .Values.customCA.configMapKey }}{{ end }}"
+
+      if [[ ! -f "${JAVA_HOME}/lib/security/cacerts" ]]; then
+        echo "Java cacerts not found at ${JAVA_HOME}/lib/security/cacerts"
+        echo "Verify that customCA.javaHome (${JAVA_HOME}) matches the Java installation in this image"
+        exit 1
+      fi
+
+      cp "${JAVA_HOME}/lib/security/cacerts" "${KEYSTORE}"
+
+      if [[ ! -f "${CA_FILE}" ]]; then
+        echo "Company CA bundle not found at ${CA_FILE}; EXITING"
+        exit 1
+      fi
+
+      awk '/BEGIN CERTIFICATE/{n++} {print > ("/tmp/company-ca-" n ".pem")}' "${CA_FILE}"
+
+      idx=0
+      for pem in /tmp/company-ca-*; do
+        [[ -s "${pem}" ]] || continue
+        grep -q "BEGIN CERTIFICATE" "${pem}" || continue
+        alias="${ALIAS_PREFIX}-${idx}"
+        keytool -delete -alias "${alias}" -keystore "${KEYSTORE}" -storepass "${STOREPASS}" >/dev/null 2>&1 || true
+        keytool -importcert -trustcacerts -keystore "${KEYSTORE}" -storepass "${STOREPASS}" -noprompt -alias "${alias}" -file "${pem}"
+        idx=$((idx + 1))
+      done
+
+      if [[ "${idx}" -eq 0 ]]; then
+        echo "No certificates found in ${CA_FILE}; EXITING"
+        exit 1
+      fi
+
+      echo "Imported ${idx} company CA certificate(s) into Java truststore"
+  volumeMounts:
+    - name: cacerts
+      mountPath: /cacerts
+    - name: company-ca-bundle
+      mountPath: {{ .Values.customCA.mountPath }}
+      readOnly: true
+{{- end -}}

--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "esignet.validateValues" . -}}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -72,8 +73,14 @@ spec:
             - name: {{ .Values.persistence.volume_name }}
               mountPath: {{ .Values.persistence.mountDir }}
         {{- end }}
-        {{- if .Values.enable_insecure }}
+        {{- if .Values.customCA.enabled }}
+        {{- include "esignet.customCAInitContainer" . | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.enable_insecure (not .Values.customCA.enabled) }}
           {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.extraInitContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraInitContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: esignet
@@ -158,8 +165,8 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if .Values.enable_insecure }}
-          - mountPath: /usr/local/openjdk-11/lib/security/cacerts
+          {{- if include "esignet.truststoreRequired" . }}
+          - mountPath: {{ .Values.customCA.javaHome }}/lib/security/cacerts
             name: cacerts
             subPath: cacerts
           {{- end }}
@@ -167,16 +174,32 @@ spec:
           - name: {{ .Values.persistence.volume_name }}
             mountPath: {{ .Values.persistence.mountDir }}
           {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+          {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-      {{- if .Values.enable_insecure }}
+      {{- if include "esignet.truststoreRequired" . }}
       - name: cacerts
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.customCA.enabled }}
+      - name: company-ca-bundle
+        {{- if .Values.customCA.secretName }}
+        secret:
+          secretName: {{ .Values.customCA.secretName }}
+        {{- else }}
+        configMap:
+          name: {{ .Values.customCA.configMapName }}
+        {{- end }}
       {{- end }}
       {{- if .Values.persistence.enabled }}
       - name: {{ .Values.persistence.volume_name }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default .Values.persistence.pvc_claim_name  }}
       {{ end }}
+      {{- if .Values.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 6 }}
+      {{- end }}

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -333,15 +333,7 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
-## Add init containers to the  pods.
-## Example:
-## initContainers:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##         containerPort: 1234
+## Init container used when enable_insecure=true (development/self-signed only).
 ##
 initContainers:
   - command:
@@ -375,6 +367,10 @@ initContainers:
     volumeMounts:
       - mountPath: /cacerts
         name: cacerts
+
+## Additional init containers appended after built-in truststore init containers.
+##
+extraInitContainers: []
 
 ## Add sidecars to the  pods.
 ## Example:
@@ -527,6 +523,31 @@ istio:
     - istio-system/public
     - istio-system/internal
   prefix: /v1/esignet/
+
+## Trust a company-internal CA for outbound HTTPS calls from the Java service.
+## Create a Secret or ConfigMap with PEM-encoded root/intermediate certificate(s)
+## before enabling this option. Recommended for on-prem deployments using internal PKI.
+##
+customCA:
+  enabled: false
+  ## Use an existing Secret that contains PEM-encoded CA certificate(s).
+  secretName: ""
+  secretKey: ca.crt
+  ## Alternatively, use a ConfigMap instead of a Secret.
+  configMapName: ""
+  configMapKey: ca.crt
+  ## Path where the CA bundle is mounted inside the init container.
+  mountPath: /etc/ssl/certs/company-ca
+  ## Prefix used for keytool aliases when importing certificates.
+  aliasPrefix: company-ca
+  ## Must match the Java installation path in the main application container image.
+  javaHome: /usr/local/openjdk-11
+  keystorePassword: changeit
+  initContainerImage:
+    registry: docker.io
+    repository: openjdk
+    tag: 11-jre
+    pullPolicy: Always
 
 enable_insecure: false
 springConfigNameEnv:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds first-class Helm support for trusting a **company-internal CA** in eSignet deployments, addressing the gap where only the development-oriented `enable_insecure` workaround existed.

## Changes

### Helm chart (`helm/esignet`)
- New `customCA` values block to mount a Secret/ConfigMap with PEM-encoded root/intermediate CA certificate(s)
- Init container imports the CA bundle into the Java `cacerts` truststore before the app starts
- Wired previously unused `extraVolumes` / `extraVolumeMounts` extension points in the deployment template
- Added `extraInitContainers` for additional custom init hooks
- Validation prevents using `customCA` and `enable_insecure` together

### Deploy scripts
- New shared `deploy/configure_tls_trust.sh` helper used by eSignet install scripts
- Install flow now offers three TLS trust options:
  1. Public SSL (default)
  2. Development self-signed (`enable_insecure`)
  3. Company internal CA (`customCA`)

### Documentation
- Updated `helm/esignet/README.md` with usage examples
- Added commented `customCA` samples in deploy values files

## Usage

```sh
kubectl -n esignet create secret generic company-internal-ca \
  --from-file=ca.crt=/path/to/company-ca-bundle.pem

helm upgrade --install esignet mosip/esignet \
  --set customCA.enabled=true \
  --set customCA.secretName=company-internal-ca
```

## Notes

- `enable_insecure` remains available for dev/self-signed environments but is mutually exclusive with `customCA`
- Supports PEM bundles containing multiple certificates (root + intermediate)
- OIDC UI is unchanged (nginx-based; no Java truststore requirement)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9c04ad7-4bcc-48a0-894d-d45d38d8403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9c04ad7-4bcc-48a0-894d-d45d38d8403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TLS trust configuration with three modes: default public CAs, a development “insecure” workaround, or trusting company-internal CAs via a custom CA init step that imports PEMs into the Java truststore.
  * Added support for optional custom CA source from a Secret or ConfigMap, plus an extension point to add extra init containers.
* **Bug Fixes**
  * Improved chart value validation, including enforcing mutual exclusivity between the “insecure” and custom CA options.
* **Documentation**
  * Updated Helm docs with a new “TLS trust configuration” section, including examples and creation steps for the CA Secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->