### PR TITLE
[ES-1943G] Removed method calls for nonce caching

### DIFF
--- a/esignet-service/src/test/java/io/mosip/esignet/flows/AuthCodeFlowTest.java
+++ b/esignet-service/src/test/java/io/mosip/esignet/flows/AuthCodeFlowTest.java
@@ -30,22 +30,16 @@ import io.mosip.esignet.repository.ClientDetailRepository;
 import io.mosip.esignet.core.spi.TokenService;
 import io.mosip.esignet.core.util.AuthenticationContextClassRefUtil;
 import io.mosip.esignet.core.constants.Constants;
-import io.mosip.esignet.services.CacheUtilService;
 import lombok.extern.slf4j.Slf4j;
 import org.jose4j.jwe.JsonWebEncryption;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisScriptingCommands;
-import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -61,8 +55,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import static io.mosip.esignet.core.constants.Constants.UTC_DATETIME_PATTERN;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -85,8 +77,6 @@ public class AuthCodeFlowTest {
     @Autowired
     private Authenticator authenticationWrapper;
 
-    @Autowired
-    private CacheUtilService cacheUtilService;
 
     @Autowired
     private TokenService tokenService;
@@ -118,17 +108,6 @@ public class AuthCodeFlowTest {
         mockDiscoveryMap.put("token_endpoint_auth_signing_alg_values_supported", Arrays.asList("RS256", "PS256","ES256"));
         mockDiscoveryMap.put("issuer",clientId);
 
-        RedisScriptingCommands redisScriptingCommands = Mockito.mock(RedisScriptingCommands.class);
-        RedisConnection redisConnection = Mockito.mock(RedisConnection.class);
-        RedisConnectionFactory redisConnectionFactory = Mockito.mock(RedisConnectionFactory.class);
-        when(redisConnectionFactory.getConnection()).thenReturn(redisConnection);
-        when(redisConnection.scriptingCommands()).thenReturn(redisScriptingCommands);
-        when(redisScriptingCommands.scriptExists("nonceScriptHash")).thenReturn(List.of(true));
-        when(redisScriptingCommands.evalSha(anyString(), any(ReturnType.class), anyInt(), any(), any())).thenReturn(1L);
-
-        ReflectionTestUtils.setField(cacheUtilService, "redisConnectionFactory", redisConnectionFactory);
-        ReflectionTestUtils.setField(cacheUtilService, "nonceScriptHash", "nonceScriptHash");
-        ReflectionTestUtils.setField(cacheUtilService, "nonceValidity", 86400);
         ReflectionTestUtils.setField(tokenService,"discoveryMap",mockDiscoveryMap);
     }
 

--- a/esignet-service/src/test/java/io/mosip/esignet/flows/AuthorizationAPIFlowTest.java
+++ b/esignet-service/src/test/java/io/mosip/esignet/flows/AuthorizationAPIFlowTest.java
@@ -32,10 +32,8 @@ import io.mosip.esignet.core.util.AuthenticationContextClassRefUtil;
 import io.mosip.esignet.core.constants.Constants;
 import io.mosip.esignet.core.constants.ErrorConstants;
 import io.mosip.esignet.repository.ClientDetailRepository;
-import io.mosip.esignet.services.CacheUtilService;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +41,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -78,8 +75,6 @@ public class AuthorizationAPIFlowTest {
     @Autowired
     private Authenticator authenticationWrapper;
 
-    @Autowired
-    private CacheUtilService cacheUtilService;
 
     @Autowired
     private TokenService tokenService;
@@ -101,10 +96,6 @@ public class AuthorizationAPIFlowTest {
     private JWK clientJWK = TestUtil.generateJWK_RSA();
     private boolean created = false;
 
-    @BeforeEach
-    public void init() {
-        ReflectionTestUtils.setField(cacheUtilService, "cacheType", "simple");
-    }
 
 
     @Test

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationHelperService.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationHelperService.java
@@ -30,7 +30,6 @@ import io.mosip.kernel.keymanagerservice.entity.KeyAlias;
 import io.mosip.kernel.keymanagerservice.helper.KeymanagerDBHelper;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.env.Environment;
 import org.springframework.data.util.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -104,8 +103,6 @@ public class AuthorizationHelperService {
     @Autowired
     private ClaimsHelperService claimsHelperService;
 
-    @Autowired
-    private Environment environment;
 
     @Value("#{${mosip.esignet.supported.authorize.scopes}}")
     private List<String> authorizeScopes;
@@ -448,17 +445,5 @@ public class AuthorizationHelperService {
             log.error("Failed to parse the given IDTokenHint as JWT", e);
         }
         throw new EsignetException(ErrorConstants.LOGIN_REQUIRED);
-    }
-
-    protected void validateNonce(String nonce) {
-        if(isLocalEnvironment() || nonce == null || nonce.isBlank())
-            return;
-
-        if(cacheUtilService.checkNonce(nonce.trim()) == 0L)
-            throw new EsignetException(ErrorConstants.INVALID_REQUEST);
-    }
-
-    private boolean isLocalEnvironment() {
-        return Arrays.stream(environment.getActiveProfiles()).anyMatch(env -> env.equalsIgnoreCase("local"));
     }
 }

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
@@ -409,7 +409,6 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     private void validateRedirectURIAndNonce(OAuthDetailRequest oAuthDetailRequest, ClientDetail clientDetail) {
         log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", oAuthDetailRequest.getNonce());
         IdentityProviderUtil.validateRedirectURI(clientDetail.getRedirectUris(), oAuthDetailRequest.getRedirectUri());
-        authorizationHelperService.validateNonce(oAuthDetailRequest.getNonce());
     }
 
     private void assertPARRequiredIsFalse(ClientDetail clientDetail) throws EsignetException {

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
@@ -128,7 +128,8 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     public OAuthDetailResponseV1 getOauthDetails(OAuthDetailRequest oauthDetailReqDto) throws EsignetException {
         ClientDetail clientDetailDto = clientManagementService.getClientDetails(oauthDetailReqDto.getClientId());
         assertPARRequiredIsFalse(clientDetailDto);
-        validateRedirectURIAndNonce(oauthDetailReqDto, clientDetailDto);
+        log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", oauthDetailReqDto.getNonce());
+        IdentityProviderUtil.validateRedirectURI(clientDetailDto.getRedirectUris(), oauthDetailReqDto.getRedirectUri());
         OAuthDetailResponseV1 oAuthDetailResponseV1 = new OAuthDetailResponseV1();
         Pair<OAuthDetailResponse, OIDCTransaction> pair = checkAndBuildOIDCTransaction(oauthDetailReqDto, clientDetailDto, oAuthDetailResponseV1);
         oAuthDetailResponseV1 = (OAuthDetailResponseV1) pair.getFirst();
@@ -144,7 +145,8 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     public OAuthDetailResponseV2 getOauthDetailsV2(OAuthDetailRequestV2 oauthDetailReqDto) throws EsignetException {
         ClientDetail clientDetailDto = clientManagementService.getClientDetails(oauthDetailReqDto.getClientId());
         assertPARRequiredIsFalse(clientDetailDto);
-        validateRedirectURIAndNonce(oauthDetailReqDto, clientDetailDto);
+        log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", oauthDetailReqDto.getNonce());
+        IdentityProviderUtil.validateRedirectURI(clientDetailDto.getRedirectUris(), oauthDetailReqDto.getRedirectUri());
         OAuthDetailResponseV2 oAuthDetailResponseV2 = new OAuthDetailResponseV2();
         // V2 path does not validate id_token_hint -> pass null for HttpServletRequest
         return buildTransactionAndOAuthDetailResponse(oauthDetailReqDto, clientDetailDto, oAuthDetailResponseV2, null, null);
@@ -154,7 +156,8 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     public OAuthDetailResponseV2 getOauthDetailsV3(OAuthDetailRequestV3 oauthDetailReqDto, HttpServletRequest httpServletRequest) throws EsignetException {
         ClientDetail clientDetailDto = clientManagementService.getClientDetails(oauthDetailReqDto.getClientId());
         assertPARRequiredIsFalse(clientDetailDto);
-        validateRedirectURIAndNonce(oauthDetailReqDto, clientDetailDto);
+        log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", oauthDetailReqDto.getNonce());
+        IdentityProviderUtil.validateRedirectURI(clientDetailDto.getRedirectUris(), oauthDetailReqDto.getRedirectUri());
         OAuthDetailResponseV2 oAuthDetailResponseV2 = new OAuthDetailResponseV2();
         return buildTransactionAndOAuthDetailResponse(oauthDetailReqDto, clientDetailDto, oAuthDetailResponseV2, oauthDetailReqDto.getIdTokenHint(), httpServletRequest);
     }
@@ -406,10 +409,6 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         return transaction;
     }
 
-    private void validateRedirectURIAndNonce(OAuthDetailRequest oAuthDetailRequest, ClientDetail clientDetail) {
-        log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", oAuthDetailRequest.getNonce());
-        IdentityProviderUtil.validateRedirectURI(clientDetail.getRedirectUris(), oAuthDetailRequest.getRedirectUri());
-    }
 
     private void assertPARRequiredIsFalse(ClientDetail clientDetail) throws EsignetException {
         if (serverProfile.getFeatureMap().containsKey(REQUIRE_PAR) || clientDetail.getAdditionalConfig(REQUIRE_PAR, false)) {

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/CacheUtilService.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/CacheUtilService.java
@@ -23,13 +23,8 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Objects;
 
 import static io.mosip.esignet.core.util.IdentityProviderUtil.ALGO_SHA3_256;
@@ -39,27 +34,8 @@ import static io.mosip.esignet.core.util.IdentityProviderUtil.ALGO_SHA3_256;
 @Service
 public class CacheUtilService {
 
-    private static final String NONCE_CHECK_SCRIPT = """
-            if redis.call("EXISTS", KEYS[1]) == 0 then
-                redis.call("SETEX", KEYS[1], tonumber(ARGV[1]), "1")
-                return 1
-            else
-                return 0
-            end""";
-    private String nonceScriptHash = null;
-    private static String NONCE_KEY = "nonce::%s";
-
-    @Value("${mosip.esignet.nonce-expire-seconds:86400}")
-    private int nonceValidity;
-
-    @Value("${spring.cache.type}")
-    private String cacheType;
-
     @Autowired
     CacheManager cacheManager;
-
-    @Autowired
-    private RedisConnectionFactory redisConnectionFactory;
 
     @Cacheable(value = Constants.PRE_AUTH_SESSION_CACHE, key = "#transactionId")
     public OIDCTransaction setTransaction(String transactionId, OIDCTransaction oidcTransaction) {
@@ -106,29 +82,6 @@ public class CacheUtilService {
     @CacheEvict(value = Constants.HALTED_CACHE, key = "#transactionId")
     public void removeHaltedTransaction(String transactionId) {
         log.debug("Evicting entry from HALTED_CACHE");
-    }
-
-    public long checkNonce(String nonce) {
-        if("simple".equalsIgnoreCase(cacheType))
-            return 1L;
-
-        try (RedisConnection connection = redisConnectionFactory.getConnection()) {
-            if (isScriptNotLoaded(connection, nonceScriptHash)) {
-                nonceScriptHash = connection.scriptingCommands().scriptLoad(NONCE_CHECK_SCRIPT.getBytes());
-            }
-            log.debug("Running NONCE_CHECK_SCRIPT script: {}", nonceScriptHash);
-            final String key = NONCE_KEY.formatted(nonce);
-            return connection.scriptingCommands().evalSha(
-                    nonceScriptHash,
-                    ReturnType.INTEGER,
-                    1,  // Number of keys
-                    key.getBytes(), // The Redis hash name (key)
-                    String.valueOf(nonceValidity).getBytes(StandardCharsets.UTF_8) // ttl
-            );
-        } catch (Exception e) {
-            log.error("Redis nonce check failed, rejecting nonce. {}", e);
-            return 0L;
-        }
     }
 
     //---------------------------------------------- Linked authorization ----------------------------------------------
@@ -286,11 +239,5 @@ public class CacheUtilService {
 
     public String getSharedIDVResult(String transactionId) {
         return cacheManager.getCache(Constants.SHARED_IDV_RESULT).get(transactionId, String.class); //NOSONAR getCache() will not be returning null here.
-    }
-
-    private boolean isScriptNotLoaded(RedisConnection connection, String scriptHash) {
-        if(scriptHash == null) return true;
-        List<Boolean> scriptExists = connection.scriptingCommands().scriptExists(scriptHash);
-        return scriptExists == null || !scriptExists.getFirst();
     }
 }

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
@@ -194,6 +194,7 @@ public class OAuthServiceImpl implements OAuthService {
         log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", pushedAuthorizationRequest.getNonce());
         IdentityProviderUtil.validateRedirectURI(clientDetailDto.getRedirectUris(), pushedAuthorizationRequest.getRedirect_uri());
         authorizationHelperService.validateNonce(pushedAuthorizationRequest.getNonce());
+
         List<String> validAudience = List.of((String) oauthServerDiscoveryMap.get(PAR_ENDPOINT), (String) oauthServerDiscoveryMap.get(TOKEN_ENDPOINT), (String) discoveryMap.get(ISSUER));
 
         tokenService.verifyClientAssertionToken(clientDetailDto.getId(), clientDetailDto.getPublicKey(), pushedAuthorizationRequest.getClient_assertion(), validAudience);

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
@@ -193,7 +193,7 @@ public class OAuthServiceImpl implements OAuthService {
 
         log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", pushedAuthorizationRequest.getNonce());
         IdentityProviderUtil.validateRedirectURI(clientDetailDto.getRedirectUris(), pushedAuthorizationRequest.getRedirect_uri());
-
+        authorizationHelperService.validateNonce(pushedAuthorizationRequest.getNonce());
         List<String> validAudience = List.of((String) oauthServerDiscoveryMap.get(PAR_ENDPOINT), (String) oauthServerDiscoveryMap.get(TOKEN_ENDPOINT), (String) discoveryMap.get(ISSUER));
 
         tokenService.verifyClientAssertionToken(clientDetailDto.getId(), clientDetailDto.getPublicKey(), pushedAuthorizationRequest.getClient_assertion(), validAudience);

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
@@ -193,7 +193,6 @@ public class OAuthServiceImpl implements OAuthService {
 
         log.info("nonce : {} Valid client id found, proceeding to validate redirect URI", pushedAuthorizationRequest.getNonce());
         IdentityProviderUtil.validateRedirectURI(clientDetailDto.getRedirectUris(), pushedAuthorizationRequest.getRedirect_uri());
-        authorizationHelperService.validateNonce(pushedAuthorizationRequest.getNonce());
 
         List<String> validAudience = List.of((String) oauthServerDiscoveryMap.get(PAR_ENDPOINT), (String) oauthServerDiscoveryMap.get(TOKEN_ENDPOINT), (String) discoveryMap.get(ISSUER));
 

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationServiceTest.java
@@ -246,7 +246,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setRequest("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."); // Setting request parameter
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -272,7 +271,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setPrompt("none"); // Setting unsupported prompt value
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -298,7 +296,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setPrompt("login"); // Setting unsupported prompt value
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -324,7 +321,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setPrompt("consent login"); // Space-delimited prompt containing unsupported value
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -355,7 +351,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV1 oauthDetailResponse = authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -380,7 +375,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV1 oauthDetailResponse = authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -413,7 +407,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("level4");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV1 oauthDetailResponse = authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -446,7 +439,6 @@ public class AuthorizationServiceTest {
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(new ArrayList<>());
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         OAuthDetailResponseV1 oauthDetailResponse = authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
         Assertions.assertNotNull(oauthDetailResponse);
@@ -477,7 +469,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:generated-code");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:generated-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV1 oauthDetailResponse = authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -502,7 +493,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -530,7 +520,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         authFactors.add(Collections.emptyList());
@@ -560,7 +549,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:linked-wallet"})).thenReturn(authFactors);
@@ -591,8 +579,6 @@ public class AuthorizationServiceTest {
         //NOTE: if order differs then below mock will not be used, hence will not return null
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:linked-wallet",
                 "mosip:idp:acr:generated-code"})).thenReturn(null);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
-
         OAuthDetailResponseV1 oauthDetailResponse = authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
         Assertions.assertNotNull(oauthDetailResponse);
         Assertions.assertNull(oauthDetailResponse.getAuthFactors());
@@ -621,7 +607,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:biometrics mosip:idp:acr:generated-code");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         //Highest priority is given to ACR in claims request parameter
@@ -653,7 +638,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:wallet");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetails(oauthDetailRequest);
@@ -711,7 +695,6 @@ public class AuthorizationServiceTest {
         oauthDetailReqDto.setIdTokenHint("invalid_id_token_hint");
 
         when(clientManagementService.getClientDetails("test-client")).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(authFactors);
@@ -741,7 +724,6 @@ public class AuthorizationServiceTest {
         oauthDetailReqDto.setIdTokenHint("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.3RJf1g9bKzRC-dEj4b2Jx2yCk7Mz4oG1bZbDqGt8QxE");
 
         when(clientManagementService.getClientDetails("test-client")).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(authFactors);
@@ -772,7 +754,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV2 oauthDetailResponseV2 = authorizationServiceImpl.getOauthDetailsV2(oauthDetailRequest);
@@ -804,7 +785,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("level4");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV2 oauthDetailResponseV2 = authorizationServiceImpl.getOauthDetailsV2(oauthDetailRequest);
@@ -836,7 +816,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV2 oauthDetailResponseV2 = authorizationServiceImpl.getOauthDetailsV2(oauthDetailRequest);
@@ -868,7 +847,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:generated-code");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:generated-code"})).thenReturn(new ArrayList<>());
 
         OAuthDetailResponseV2 oauthDetailResponseV2 = authorizationServiceImpl.getOauthDetailsV2(oauthDetailRequest);
@@ -893,7 +871,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetailsV2(oauthDetailRequest);
@@ -921,7 +898,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         authFactors.add(Collections.emptyList());
@@ -951,7 +927,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:linked-wallet"})).thenReturn(authFactors);
@@ -979,7 +954,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         //NOTE: if order differs then below mock will not be used, hence will not return null
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:linked-wallet",
                 "mosip:idp:acr:generated-code"})).thenReturn(null);
@@ -1012,7 +986,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:biometrics mosip:idp:acr:generated-code");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         //Highest priority is given to ACR in claims request parameter
@@ -1044,7 +1017,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:wallet");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
 
         try {
             authorizationServiceImpl.getOauthDetailsV2(oauthDetailRequest);
@@ -1081,7 +1053,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setScope("sample_ldp_vc");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         //Highest priority is given to ACR in claims request parameter
@@ -1118,7 +1089,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setAcrValues("mosip:idp:acr:biometrics mosip:idp:acr:generated-code");
 
         when(clientManagementService.getClientDetails(oauthDetailRequest.getClientId())).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         //Highest priority is given to ACR in claims request parameter
@@ -1155,7 +1125,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setIdTokenHint("eyJraWQiOiJtbG02RVNRaFB5dVVsWmY0dnBZbGJTVWlSMXBXcG5jdW9kamtnRjNaNU5nIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJxWS0tNVk0VG9Ga1dUb1hKclJGbVBXUEhEWkxrY2lNTDQtX2cxTDJBNXhJIiwiYXVkIjoibW9zaXAtc2lnbnVwLW9hdXRoLWNsaWVudCIsImFjciI6Im1vc2lwOmlkcDphY3I6Z2VuZXJhdGVkLWNvZGUiLCJhdXRoX3RpbWUiOjE3MjUyNjk4ODUsImlzcyI6Imh0dHBzOlwvXC9lc2lnbmV0bDIuY2FtZGdjLXFhLm1vc2lwLm5ldFwvdjFcL2VzaWduZXQiLCJleHAiOjE3MjUyNzAwNzMsImlhdCI6MTcyNTI2OTg5Mywibm9uY2UiOiI5NzNlaWVsanpuZyJ9.VMMn92CFzGkVyx8Jwrq03KhuXOXj3wRlUoxZQQBN7MxlfIxGSX_yE7iw3JWxohzQuHticndtQX2LELcGTPhclzRop3skHCeo6ZPGJklCiRA3F5SyfCYLvDprgE_-pQhLWeECqRtW_8jFFgZSORMoxy8eBj5Vvc8q2zcoDjE-JiLZvqE9UWDRpAKzumJcD3iJvBwE-9jkzQtWZbp-tZrpPrm-KCZU6-Q3qhWU23E9DSMg_6byq4iH51TFwO0nHW1kaxhsqHvCsTX7YTvmfWXUwPVRLNZh5Uszt8EIsgpKIUDkRImqmCUbP1LwoFG55MsW67QzHNTFuR6H-4LidSKnnA");
 
         when(clientManagementService.getClientDetails("34567")).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:wallet"})).thenReturn(authFactors);
@@ -1186,7 +1155,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setNonce("test-nonce");
 
         when(clientManagementService.getClientDetails("mosip-signup-oauth-client")).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:generated-code"})).thenReturn(authFactors);
@@ -1217,7 +1185,6 @@ public class AuthorizationServiceTest {
         oauthDetailRequest.setIdTokenHint("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
 
         when(clientManagementService.getClientDetails("test-client")).thenReturn(clientDetail);
-        when(cacheUtilService.checkNonce(anyString())).thenReturn(1L);
         List<List<AuthenticationFactor>> authFactors = new ArrayList<>();
         authFactors.add(Collections.emptyList());
         when(authenticationContextClassRefUtil.getAuthFactors(new String[]{"mosip:idp:acr:static-code"})).thenReturn(authFactors);

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/CacheUtilServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/CacheUtilServiceTest.java
@@ -22,16 +22,6 @@ import io.mosip.esignet.core.constants.Constants;
 import io.mosip.esignet.core.dto.LinkTransactionMetadata;
 import io.mosip.esignet.core.dto.OIDCTransaction;
 import io.mosip.esignet.core.exception.DuplicateLinkCodeException;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisScriptingCommands;
-import org.springframework.data.redis.connection.ReturnType;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CacheUtilServiceTest {
@@ -44,15 +34,6 @@ public class CacheUtilServiceTest {
 
     @Mock
     private CacheManager cacheManager;
-
-    @Mock
-    private RedisConnectionFactory redisConnectionFactory;
-
-    @Mock
-    private RedisConnection redisConnection;
-
-    @Mock
-    private RedisScriptingCommands redisScriptingCommands;
 
     @Test
     public void test_OIDCTransaction_cache() {
@@ -125,114 +106,4 @@ public class CacheUtilServiceTest {
             cacheUtilService.setLinkCodeGenerated("1234", linkTransactionMetadata);
         });
     }
-
-    // -------------------------------- checkNonce() tests --------------------------------
-
-    @Test
-    public void checkNonce_simpleCacheType_returnsOneWithoutRedis() {
-        ReflectionTestUtils.setField(cacheUtilService, "cacheType", "simple");
-
-        long result = cacheUtilService.checkNonce("test-nonce");
-
-        Assertions.assertEquals(1L, result);
-        verifyNoInteractions(redisConnectionFactory);
-    }
-
-    @Test
-    public void checkNonce_scriptAlreadyLoaded_reusesHashAndClosesConnection() {
-        ReflectionTestUtils.setField(cacheUtilService, "cacheType", "redis");
-        ReflectionTestUtils.setField(cacheUtilService, "nonceValidity", 86400);
-        ReflectionTestUtils.setField(cacheUtilService, "nonceScriptHash", "existing-sha");
-
-        when(redisConnectionFactory.getConnection()).thenReturn(redisConnection);
-        when(redisConnection.scriptingCommands()).thenReturn(redisScriptingCommands);
-        when(redisScriptingCommands.scriptExists("existing-sha")).thenReturn(List.of(true));
-        when(redisScriptingCommands.evalSha(eq("existing-sha"), eq(ReturnType.INTEGER), eq(1),
-                any(byte[].class), any(byte[].class))).thenReturn(1L);
-
-        long result = cacheUtilService.checkNonce("test-nonce");
-
-        Assertions.assertEquals(1L, result);
-        verify(redisScriptingCommands, never()).scriptLoad(any(byte[].class));
-        verify(redisConnection).close();
-    }
-
-    @Test
-    public void checkNonce_scriptNotLoaded_loadsScriptAndClosesConnection() {
-        ReflectionTestUtils.setField(cacheUtilService, "cacheType", "redis");
-        ReflectionTestUtils.setField(cacheUtilService, "nonceValidity", 86400);
-        ReflectionTestUtils.setField(cacheUtilService, "nonceScriptHash", null);
-
-        String newHash = "new-sha-hash";
-        when(redisConnectionFactory.getConnection()).thenReturn(redisConnection);
-        when(redisConnection.scriptingCommands()).thenReturn(redisScriptingCommands);
-        when(redisScriptingCommands.scriptLoad(any(byte[].class))).thenReturn(newHash);
-        when(redisScriptingCommands.evalSha(eq(newHash), eq(ReturnType.INTEGER), eq(1),
-                any(byte[].class), any(byte[].class))).thenReturn(0L);
-
-        long result = cacheUtilService.checkNonce("unique-nonce");
-
-        Assertions.assertEquals(0L, result);
-        verify(redisScriptingCommands).scriptLoad(any(byte[].class));
-        Assertions.assertEquals(newHash, ReflectionTestUtils.getField(cacheUtilService, "nonceScriptHash"));
-        verify(redisConnection).close();
-    }
-
-    @Test
-    public void checkNonce_scriptExistsReturnsFalse_reloadsScriptAndClosesConnection() {
-        ReflectionTestUtils.setField(cacheUtilService, "cacheType", "redis");
-        ReflectionTestUtils.setField(cacheUtilService, "nonceValidity", 86400);
-        ReflectionTestUtils.setField(cacheUtilService, "nonceScriptHash", "stale-sha");
-
-        String reloadedHash = "reloaded-sha";
-        when(redisConnectionFactory.getConnection()).thenReturn(redisConnection);
-        when(redisConnection.scriptingCommands()).thenReturn(redisScriptingCommands);
-        when(redisScriptingCommands.scriptExists("stale-sha")).thenReturn(List.of(false));
-        when(redisScriptingCommands.scriptLoad(any(byte[].class))).thenReturn(reloadedHash);
-        when(redisScriptingCommands.evalSha(eq(reloadedHash), eq(ReturnType.INTEGER), eq(1),
-                any(byte[].class), any(byte[].class))).thenReturn(1L);
-
-        long result = cacheUtilService.checkNonce("another-nonce");
-
-        Assertions.assertEquals(1L, result);
-        verify(redisScriptingCommands).scriptLoad(any(byte[].class));
-        verify(redisConnection).close();
-    }
-
-    @Test
-    public void checkNonce_redisThrowsException_connectionStillClosed() {
-        ReflectionTestUtils.setField(cacheUtilService, "cacheType", "redis");
-        ReflectionTestUtils.setField(cacheUtilService, "nonceValidity", 86400);
-        ReflectionTestUtils.setField(cacheUtilService, "nonceScriptHash", null);
-
-        when(redisConnectionFactory.getConnection()).thenReturn(redisConnection);
-        when(redisConnection.scriptingCommands()).thenReturn(redisScriptingCommands);
-        when(redisScriptingCommands.scriptLoad(any(byte[].class)))
-                .thenThrow(new RuntimeException("Redis unavailable"));
-
-        long result = cacheUtilService.checkNonce("fail-nonce");
-
-        Assertions.assertEquals(0L, result);
-        verify(redisConnection).close();
-    }
-
-    @Test
-    public void checkNonce_singleConnectionUsedForAllOperations() {
-        ReflectionTestUtils.setField(cacheUtilService, "cacheType", "redis");
-        ReflectionTestUtils.setField(cacheUtilService, "nonceValidity", 86400);
-        ReflectionTestUtils.setField(cacheUtilService, "nonceScriptHash", null);
-
-        String hash = "test-sha";
-        when(redisConnectionFactory.getConnection()).thenReturn(redisConnection);
-        when(redisConnection.scriptingCommands()).thenReturn(redisScriptingCommands);
-        when(redisScriptingCommands.scriptLoad(any(byte[].class))).thenReturn(hash);
-        when(redisScriptingCommands.evalSha(eq(hash), eq(ReturnType.INTEGER), eq(1),
-                any(byte[].class), any(byte[].class))).thenReturn(1L);
-
-        cacheUtilService.checkNonce("nonce-123");
-
-        verify(redisConnectionFactory, times(1)).getConnection();
-        verify(redisConnection).close();
-    }
-
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated OAuth/OIDC authorization flows to remove server-side nonce validation (including cache/Redis-based nonce checks). Redirect URI allowlist validation remains enforced, and DPoP thumbprint validation continues when a DPoP header is provided.
* **Tests**
  * Simplified OIDC authorization and flow tests by removing Redis/cache mocking and nonce-check stubbing, and trimmed cache utility test coverage to focus on remaining cache behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->