### PR TITLE
[MOSIP-44770] actuator env enabled based on auth token

### DIFF
--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -106,9 +106,10 @@ mosip.esignet.binding.key-expire-days=10
 mosip.esignet.security.auth.post-urls={'/client-mgmt/**' : {'SCOPE_add_oidc_client'} , '/system-info/**' : { 'SCOPE_upload_certificate'},\
   \ '/binding/wallet-binding' : { 'SCOPE_wallet_binding'}, '/binding/binding-otp' : { 'SCOPE_send_binding_otp'}}
 mosip.esignet.security.auth.put-urls={'/client-mgmt/**' : { 'SCOPE_update_oidc_client'} }
-mosip.esignet.security.auth.get-urls={'/system-info/**' : { 'SCOPE_get_certificate'} }
+mosip.esignet.security.auth.get-urls={'/system-info/**' : { 'SCOPE_get_certificate'}, \
+  '/actuator/env' : { 'SCOPE_get_certificate'} }
 
-mosip.esignet.security.ignore-csrf-urls=/oidc/**,/oauth/**,/actuator/health,/actuator/health/**,/actuator/info,/actuator/prometheus,/favicon.ico,/error,\
+mosip.esignet.security.ignore-csrf-urls=/oidc/**,/oauth/**,/actuator/health,/actuator/health/**,/actuator/info,/actuator/prometheus,/actuator/env,/favicon.ico,/error,\
   /swagger-ui/**,/v3/api-docs/**,/linked-authorization/link-transaction,/linked-authorization/authenticate,\
   /linked-authorization/consent,/binding/**,/client-mgmt/**,/system-info/**,/linked-authorization/v2/link-transaction,\
   /linked-authorization/v2/authenticate,/linked-authorization/v2/consent

--- a/esignet-service/src/main/resources/bootstrap.properties
+++ b/esignet-service/src/main/resources/bootstrap.properties
@@ -39,8 +39,9 @@ server.tomcat.accesslog.pattern={"@timestamp":"%{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}t"
 ## Prometheus / Actuator
 # SECURITY: Restrict actuator exposure to only required endpoints. Do NOT use '*',
 # as that exposes sensitive endpoints such as /actuator/env, /actuator/beans, /actuator/configprops, /actuator/heapdump.
-management.endpoints.web.exposure.include=health,info,prometheus
-management.endpoints.web.exposure.exclude=env,beans,configprops,heapdump,threaddump,loggers,mappings,scheduledtasks,caches,conditions,httptrace,shutdown
+# Only /actuator/env is exposed and protected with OAuth2 authentication (see mosip.esignet.security.auth.get-urls).
+management.endpoints.web.exposure.include=health,info,prometheus,env
+management.endpoints.web.exposure.exclude=beans,configprops,heapdump,threaddump,loggers,mappings,scheduledtasks,caches,conditions,httptrace,shutdown
 management.endpoint.metrics.access=read-only
 management.endpoint.prometheus.access=read-only
 management.prometheus.metrics.export.enabled=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system's environment configuration endpoint is now exposed and accessible with OAuth2 authentication protection, providing authorized users with access to detailed system environment information.

* **Chores**
  * Updated actuator web exposure configuration to include the environment endpoint in the accessible endpoints list and adjusted security scope assignments to ensure proper OAuth2-based access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->