### PR TITLE
Comment out action-slack notification in workflows

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -287,13 +287,13 @@ jobs:
         with:
           name: ${{ env.BUILD_ARTIFACT }}
           path: ${{ env.BUILD_ARTIFACT }}.zip
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,author,commit,workflow,job # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-        if: failure() # Pick up events even if the job fails or is canceled.
+#      - uses: 8398a7/action-slack@v3
+#        with:
+#          status: ${{ job.status }}
+#          fields: repo,message,author,commit,workflow,job # selectable (default: repo,message)
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+#        if: failure() # Pick up events even if the job fails or is canceled.
 
   build_dockers_apitest_esignet:
     needs: build_apitest_esignet_local


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Comments out all `8398a7/action-slack@v3` failure notification steps in `push-trigger.yml`
- Disabled 1 slack notification block(s) on branch `MOSIP-41674`

## Motivation
Disable Slack webhook notifications triggered on workflow job failures via the action-slack GitHub Action.

## Changes
Each `action-slack` step block (uses, with, env, if: failure()) has been commented out in the workflow file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ca47210-0dff-4aa6-99a5-cc05897dc1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca47210-0dff-4aa6-99a5-cc05897dc1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

