### PR TITLE
[mosip/mosip-infra#1890] Added domainConfig support in helm charts

### DIFF
--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -122,6 +122,10 @@ spec:
             {{- if .Values.extraEnvVarsAdditional }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsAdditional "context" $) | nindent 12 }}
             {{- end }}
+            {{- range $key, $val := .Values.domainConfig }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             {{- range .Values.extraEnvVarsCM }}

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -534,4 +534,5 @@ activeProfileEnv:
 pluginNameEnv: esignet-mock-plugin.jar
 pluginUrlEnv:
 
+# domainConfig entries are injected as container env vars; values must be scalar/string (maps/lists will not render correctly)
 domainConfig: {}

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -533,3 +533,5 @@ springConfigNameEnv:
 activeProfileEnv:
 pluginNameEnv: esignet-mock-plugin.jar
 pluginUrlEnv:
+
+domainConfig: {}


### PR DESCRIPTION
## Summary
Cherry-pick of #1988 from `develop` onto `release-1.8.x`: adds `domainConfig` support in the esignet helm charts (deployment.yaml and values.yaml), replacing `esignet-global` with a generic domainConfig values mechanism.

Original commit: mosip/esignet@429c6cb24944a0ebc637a55a6c716b213dfb97b2

## Test plan
- [ ] Verify helm template renders domainConfig env vars correctly
- [ ] Verify no regression for deployments without domainConfig set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for injecting additional application environment variables via deployment configuration.
  * Introduced a new `domainConfig` values entry to supply key/value pairs that are rendered as container environment settings during install or upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->