### PR TITLE
[#2142] Fix: Preserve flow session on OTP send failure to allow retry. 

### DIFF
--- a/esignet-service/internal/engine/executors.go
+++ b/esignet-service/internal/engine/executors.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/mosip/esignet/internal/engine/shared"
@@ -99,6 +100,14 @@ func (e *mosipOtpExecutor) Execute(ctx *providers.NodeContext) (*providers.Execu
 	if serviceError != nil {
 		// username is the individual's identity number and must not be logged.
 		applog.GetLogger().Warn("failed to send OTP via MOSIP API", applog.String("errorCode", serviceError.Code))
+		// Return ExecFailure so the engine surfaces the error to the user without terminating the flow session
+		if serviceError.Type == common.ClientErrorType {
+			execResp.Status = providers.ExecFailure
+			execResp.Error = serviceError
+			return execResp, nil
+		}
+		// Genuine server-side failures (infrastructure, unexpected API errors) propagate
+		// as a Go error so the engine converts them to an HTTP 500.
 		return execResp, fmt.Errorf("failed to send OTP via MOSIP API: %s", serviceError.Code)
 	}
 

--- a/esignet-service/internal/engine/executors_test.go
+++ b/esignet-service/internal/engine/executors_test.go
@@ -166,14 +166,32 @@ func (ts *ExecutorsTestSuite) TestMosipOtpExecutor_Execute() {
 		}
 	})
 
-	t.Run("service error propagates", func(t *testing.T) {
-		fake := &fakeAuthnProvider{sendOTPErr: &common.ServiceError{Code: "boom"}}
+	t.Run("client error returns ExecFailure without Go error", func(t *testing.T) {
+		svcErr := &common.ServiceError{Code: "UIN_NOT_FOUND", Type: common.ClientErrorType}
+		fake := &fakeAuthnProvider{sendOTPErr: svcErr}
+		e := NewMosipOtpExecutor(fake)
+		ctx := newNodeContext(map[string]string{"username": "bad-uin"}, nil)
+
+		resp, err := e.Execute(ctx)
+		if err != nil {
+			t.Fatalf("Execute returned Go error for client error: %v", err)
+		}
+		if resp.Status != providers.ExecFailure {
+			t.Errorf("Status = %v, want ExecFailure", resp.Status)
+		}
+		if resp.Error != svcErr {
+			t.Errorf("Error = %v, want the original ServiceError", resp.Error)
+		}
+	})
+
+	t.Run("server error propagates as Go error", func(t *testing.T) {
+		fake := &fakeAuthnProvider{sendOTPErr: &common.ServiceError{Code: "INTERNAL", Type: common.ServerErrorType}}
 		e := NewMosipOtpExecutor(fake)
 		ctx := newNodeContext(map[string]string{"username": "user-1"}, nil)
 
 		_, err := e.Execute(ctx)
 		if err == nil {
-			t.Fatal("expected error when SendOTP fails")
+			t.Fatal("expected Go error when SendOTP returns a server error")
 		}
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP authentication error handling.
  * Client-side OTP failures now return a clear execution failure response.
  * Server-side OTP failures continue to be reported as internal errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->