### PR TITLE
fixed: transactionID missing in runtime metadata for non-otp flows

### DIFF
--- a/esignet-service/internal/engine/mock/authenticator.go
+++ b/esignet-service/internal/engine/mock/authenticator.go
@@ -9,7 +9,6 @@ package mock
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -77,7 +76,7 @@ func (p *mockAuthnProvider) SendOTP(_ context.Context, identifiers map[string]an
 		return nil, shared.InvalidIndividualIDError
 	}
 
-	transactionID, err := generateTransactionID(metadata.RuntimeMetadata)
+	transactionID, err := shared.GenerateTransactionID(metadata.RuntimeMetadata)
 	if err != nil {
 		return nil, shared.InvalidRequestError
 	}
@@ -115,7 +114,7 @@ func (p *mockAuthnProvider) AuthenticateUser(_ context.Context, identifiers, cre
 		return authUser, nil, shared.InvalidIndividualIDError
 	}
 
-	transactionID, err := generateTransactionID(metadata.RuntimeMetadata)
+	transactionID, err := shared.GenerateTransactionID(metadata.RuntimeMetadata)
 	if err != nil {
 		return authUser, nil, shared.InvalidRequestError
 	}
@@ -138,7 +137,7 @@ func (p *mockAuthnProvider) AuthenticateUser(_ context.Context, identifiers, cre
 		return authUser, nil, shared.AuthenticationFailedError
 	}
 
-	authUser.SetAttributeToken(strings.Join([]string{kycToken, individualID}, "||"))
+	authUser.SetAttributeToken(strings.Join([]string{kycToken, individualID, transactionID}, "||"))
 	authUser.SetEntityReferenceToken(psut)
 	return authUser, nil, nil
 }
@@ -177,16 +176,11 @@ func (p *mockAuthnProvider) GetUserAttributes(_ context.Context,
 		return authUser, nil, nil
 	}
 
-	tokenParts := strings.SplitN(attributeToken.(string), "||", 2)
-	if len(tokenParts) != 2 {
+	tokenParts := strings.SplitN(attributeToken.(string), "||", 3)
+	if len(tokenParts) != 3 {
 		return authUser, nil, shared.AuthenticationFailedError
 	}
-	kycToken, individualID := tokenParts[0], tokenParts[1]
-
-	transactionID, err := generateTransactionID(metadata.RuntimeMetadata)
-	if err != nil {
-		return authUser, nil, shared.InvalidRequestError
-	}
+	kycToken, individualID, transactionID := tokenParts[0], tokenParts[1], tokenParts[2]
 
 	acceptedClaims := acceptedClaimsFromRequest(requestedAttributes)
 	claimLocales := []string{defaultClaimLocale}
@@ -455,26 +449,6 @@ func buildEndpointURL(baseURL, relyingPartyID, clientID string) string {
 // getUTCDateTime returns current time in UTC as string in ISO 8601 format.
 func getUTCDateTime() string {
 	return time.Now().UTC().Format(utcDateTimeFormat)
-}
-
-// generateTransactionID generates a cryptographically random 10-digit numeric string,
-// reusing any transaction id already established for this runtime context (so
-// SendOTP/AuthenticateUser/GetUserAttributes calls for the same flow execution share
-// one transaction id, as mock-identity-system requires).
-func generateTransactionID(runtimeMetadata map[string]string) (string, error) {
-	if runtimeMetadata != nil && runtimeMetadata["ext_TransactionID"] != "" {
-		return runtimeMetadata["ext_TransactionID"], nil
-	}
-
-	const digitCount = 10
-	b := make([]byte, digitCount)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	for i := range b {
-		b[i] = '0' + b[i]%10
-	}
-	return string(b), nil
 }
 
 // decodeJWTUnsafe decodes a JWT's payload without verifying its signature. The mock

--- a/esignet-service/internal/engine/mock/authenticator_test.go
+++ b/esignet-service/internal/engine/mock/authenticator_test.go
@@ -139,7 +139,7 @@ func (ts *AuthenticatorTestSuite) TestAuthenticateUser_OTP_Success() {
 
 	require.Nil(t, svcErr)
 	assert.Nil(t, claims)
-	assert.Equal(t, "kyc-token-xyz||2760459465", resultUser.AttributeToken())
+	assert.Equal(t, "kyc-token-xyz||2760459465||1234567890", resultUser.AttributeToken())
 	assert.Equal(t, "psut-xyz", resultUser.EntityReferenceToken())
 	assert.Equal(t, "111111", gotBody["otp"])
 	assert.Equal(t, "2760459465", gotBody["individualId"])
@@ -336,7 +336,7 @@ func (ts *AuthenticatorTestSuite) TestGetUserAttributes_Success() {
 	require.NoError(t, err)
 
 	var authUser providers.AuthUser
-	authUser.SetAttributeToken("kyc-token-xyz||2760459465")
+	authUser.SetAttributeToken("kyc-token-xyz||2760459465||1234567890")
 
 	_, attrs, svcErr := provider.GetUserAttributes(context.Background(), newRequestedAttributes("name"), newGetAttributesMetadata(), authUser)
 

--- a/esignet-service/internal/engine/mosip/authenticator.go
+++ b/esignet-service/internal/engine/mosip/authenticator.go
@@ -83,7 +83,7 @@ func (p *mosipAuthnProvider) AuthenticateUser(_ context.Context, identifiers, cr
 		return authUser, nil, shared.InvalidIndividualIDError
 	}
 
-	transactionID, err := GenerateTransactionID(metadata.RuntimeMetadata)
+	transactionID, err := shared.GenerateTransactionID(metadata.RuntimeMetadata)
 	if err != nil {
 		return authUser, nil, shared.InvalidRequestError
 	}
@@ -192,7 +192,7 @@ func (p *mosipAuthnProvider) AuthenticateUser(_ context.Context, identifiers, cr
 		return authUser, nil, shared.AuthenticationFailedError
 	}
 
-	authUser.SetAttributeToken(strings.Join([]string{kycToken, individualID}, "||"))
+	authUser.SetAttributeToken(strings.Join([]string{kycToken, individualID, transactionID}, "||"))
 	authUser.SetEntityReferenceToken(psut)
 	return authUser, nil, nil
 }
@@ -232,13 +232,11 @@ func (p *mosipAuthnProvider) GetUserAttributes(_ context.Context,
 		return authUser, nil, nil
 	}
 
-	kycToken := strings.Split(attributeToken.(string), "||")[0] // Extract KYC token from token (assuming format "kycToken||username")
-	username := strings.Split(attributeToken.(string), "||")[1] // Extract username from token (assuming format "kycToken||username")
-
-	transactionID, err := GenerateTransactionID(metadata.RuntimeMetadata)
-	if err != nil {
-		return authUser, nil, shared.InvalidRequestError
+	tokenParts := strings.Split(attributeToken.(string), "||") // Extract KYC token, username and transaction ID from token (format "kycToken||username||transactionID")
+	if len(tokenParts) != 3 {
+		return authUser, nil, shared.AuthenticationFailedError
 	}
+	kycToken, username, transactionID := tokenParts[0], tokenParts[1], tokenParts[2]
 
 	// TODO add requested attributes to the request with value and values
 	keys := make([]string, 0, len(requestedAttributes.Attributes))
@@ -286,7 +284,7 @@ func (p *mosipAuthnProvider) SendOTP(_ context.Context, identifiers map[string]i
 		return nil, shared.ClientNotFoundError
 	}
 
-	transactionID, err := GenerateTransactionID(metadata.RuntimeMetadata)
+	transactionID, err := shared.GenerateTransactionID(metadata.RuntimeMetadata)
 	if err != nil {
 		return nil, shared.InvalidRequestError
 	}
@@ -355,24 +353,6 @@ const utcTimeFormat = "2006-01-02T15:04:05.000Z"
 func GetUTCDateTime() string {
 	// Go uses a reference time Mon Jan 2 15:04:05 MST 2006 to define the format pattern
 	return time.Now().UTC().Format(utcTimeFormat)
-}
-
-// GenerateTransactionID generates a cryptographically random 10-digit numeric string.
-func GenerateTransactionID(runtimeMetadata map[string]string) (string, error) {
-
-	if runtimeMetadata != nil && runtimeMetadata["ext_TransactionID"] != "" {
-		return runtimeMetadata["ext_TransactionID"], nil
-	}
-
-	const digitCount = 10
-	b := make([]byte, digitCount)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	for i := range b {
-		b[i] = '0' + b[i]%10
-	}
-	return string(b), nil
 }
 
 // B64EncodeBytes returns base64url-encoded string (no padding)

--- a/esignet-service/internal/engine/shared/utils.go
+++ b/esignet-service/internal/engine/shared/utils.go
@@ -1,0 +1,29 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package shared
+
+import "crypto/rand"
+
+// GenerateTransactionID generates a cryptographically random 10-digit numeric string,
+// reusing any transaction id already established for this runtime context (so
+// SendOTP/AuthenticateUser/GetUserAttributes calls for the same flow execution share
+// one transaction id, as mock-identity-system and MOSIP IDA require).
+func GenerateTransactionID(runtimeMetadata map[string]string) (string, error) {
+	if runtimeMetadata != nil && runtimeMetadata["ext_TransactionID"] != "" {
+		return runtimeMetadata["ext_TransactionID"], nil
+	}
+
+	const digitCount = 10
+	b := make([]byte, digitCount)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = '0' + b[i]%10
+	}
+	return string(b), nil
+}


### PR DESCRIPTION
Closes #2195 