### PR TITLE
fix: #302[mosip/mosip-infra#1890]  Added domainConfig support in helm charts .…

### DIFF
--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -122,6 +122,10 @@ spec:
             {{- if .Values.extraEnvVarsAdditional }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsAdditional "context" $) | nindent 12 }}
             {{- end }}
+            {{- range $key, $val := .Values.domainConfig }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             {{- range .Values.extraEnvVarsCM }}

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -563,3 +563,5 @@ springConfigNameEnv:
 activeProfileEnv:
 pluginNameEnv: esignet-mock-plugin.jar
 pluginUrlEnv:
+
+domainConfig: {}


### PR DESCRIPTION
… (#1988)

* [mosip/mosip-infra#1890] Removed esignet-global, added domainConfig support in helm charts and deploy scripts



* [mosip/mosip-infra#1890] Set chart versions to 0.0.1-develop



* migrate to domainConfig helm values #1890



---------



(cherry picked from commit 429c6cb24944a0ebc637a55a6c716b213dfb97b2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional domain-related environment variables through Helm values.
  * Domain configuration settings are now automatically passed to the application during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->