### PR TITLE
#2228 removed thunderidengine hardcoded log level

### DIFF
--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -91,8 +91,13 @@ func main() {
 	}
 	logger.Info("authn provider selected", applog.String("provider", appCfg.Provider))
 
+	logLevel, err := applog.ConfiguredLevel()
+	if err != nil {
+		logger.Fatal("resolve log level", applog.Error(err))
+	}
+
 	_ = thunderidengine.New(mux,
-		thunderidengine.WithLogConfig(engineconfig.LogConfig{Level: "DEBUG", Format: "json"}),
+		thunderidengine.WithLogConfig(engineconfig.LogConfig{Level: logLevel, Format: "json"}),
 		thunderidengine.WithServerHome(appCfg.DataDir),
 		thunderidengine.WithRuntimeTransientDBType("redis"),
 		thunderidengine.WithKeyConfigs([]engineconfig.KeyConfig{appCfg.KeyConfig}),

--- a/esignet-service/internal/log/log.go
+++ b/esignet-service/internal/log/log.go
@@ -14,8 +14,10 @@ package log
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -68,13 +70,34 @@ func GetLogger() *Logger {
 	return logger
 }
 
-func initLogger() error {
-	logLevel := os.Getenv(logLevelEnvVar)
-	if logLevel == "" {
-		logLevel = defaultLogLevel
+// resolveLevel reads the log level from the LOG_LEVEL environment variable
+// (falling back to defaultLogLevel when unset), normalizes casing, and
+// validates it against supportedLevels. It returns the canonical, lower-cased
+// name together with its slog.Level. This service's logger and the embedded
+// ThunderID engine both resolve through it, so they cannot diverge on casing
+// or an unsupported level.
+func resolveLevel() (string, slog.Level, error) {
+	name := defaultLogLevel
+	if logLevel := os.Getenv(logLevelEnvVar); logLevel != "" {
+		name = strings.ToLower(logLevel)
 	}
+	level, ok := supportedLevels[name]
+	if !ok {
+		return "", 0, fmt.Errorf("unsupported log level %q", name)
+	}
+	return name, level, nil
+}
 
-	level, err := parseLogLevel(logLevel)
+// ConfiguredLevel returns the canonical, lower-cased log level name so the
+// embedded ThunderID engine is configured from the same value this service's
+// logger uses.
+func ConfiguredLevel() (string, error) {
+	name, _, err := resolveLevel()
+	return name, err
+}
+
+func initLogger() error {
+	_, level, err := resolveLevel()
 	if err != nil {
 		return errors.New("error parsing log level: " + err.Error())
 	}
@@ -165,12 +188,15 @@ func withLevelValue(fields []Field, levelValue int) []any {
 	return append(convertFields(fields), slog.Any(levelValueKey, levelValue))
 }
 
-func parseLogLevel(logLevel string) (slog.Level, error) {
-	var level slog.Level
-	if err := level.UnmarshalText([]byte(logLevel)); err != nil {
-		return slog.LevelError, err
-	}
-	return level, nil
+// supportedLevels is the single source of truth for the level names this
+// service and the embedded ThunderID engine both accept, mapped to their
+// slog.Level. Only these values are honored; anything else is rejected by
+// resolveLevel rather than silently downgraded.
+var supportedLevels = map[string]slog.Level{
+	"debug": slog.LevelDebug,
+	"info":  slog.LevelInfo,
+	"warn":  slog.LevelWarn,
+	"error": slog.LevelError,
 }
 
 func convertFields(fields []Field) []any {

--- a/esignet-service/internal/log/log_test.go
+++ b/esignet-service/internal/log/log_test.go
@@ -19,34 +19,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (ts *LogTestSuite) TestParseLogLevel() {
+func (ts *LogTestSuite) TestResolveLevel() {
 	t := ts.T()
-	t.Parallel()
 
 	tests := []struct {
 		name      string
-		input     string
-		expected  slog.Level
+		env       string
+		wantName  string
+		wantLevel slog.Level
 		wantError bool
 	}{
-		{"debug", "debug", slog.LevelDebug, false},
-		{"info", "info", slog.LevelInfo, false},
-		{"warn", "warn", slog.LevelWarn, false},
-		{"error", "error", slog.LevelError, false},
-		{"invalid", "invalid", slog.LevelError, true},
-		{"empty", "", slog.LevelInfo, true},
+		{"debug", "debug", "debug", slog.LevelDebug, false},
+		{"info", "info", "info", slog.LevelInfo, false},
+		{"warn", "warn", "warn", slog.LevelWarn, false},
+		{"error", "error", "error", slog.LevelError, false},
+		{"uppercase is normalized", "DEBUG", "debug", slog.LevelDebug, false},
+		{"unset defaults to info", "", "info", slog.LevelInfo, false},
+		{"invalid", "invalid", "", 0, true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			level, err := parseLogLevel(tc.input)
+			t.Setenv("LOG_LEVEL", tc.env)
+			name, level, err := resolveLevel()
 			if tc.wantError {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tc.expected, level)
+			assert.Equal(t, tc.wantName, name)
+			assert.Equal(t, tc.wantLevel, level)
 		})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Application startup logs now follow the configured log level instead of always using DEBUG.
  * Log-level configuration is resolved and applied consistently, including canonical casing and validation.
  * Existing handling for invalid log-level values remains unchanged.
* **Tests**
  * Updated log-level unit tests to validate the shared resolver behavior (normalized output and errors) rather than the previous parsing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->