### PR TITLE
Fix consent screen text alignment

### DIFF
--- a/oidc-ui/src/App.css
+++ b/oidc-ui/src/App.css
@@ -249,3 +249,8 @@ input[type="password"]::-ms-clear {
   border-color: var(--primary-color) !important;
   color: var(--primary-color) !important;
 }
+
+/* Workaround: center consent timer text */
+[data-testid="thunderid-signin"] .thunderid-typography:first-child {
+  text-align: center !important;
+}


### PR DESCRIPTION
Fixed Issue: #2254.
This is a workaround fix. The real fix will be in the javascript-sdk. That will be taken later. Attaching screenshot of the fix.
<img width="1917" height="972" alt="image (13)" src="https://github.com/user-attachments/assets/0e6cfc59-1e24-4d43-873f-ff36c1050146" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Centered the consent timer text on the sign-in screen for improved visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->