### PR TITLE
[ADDED] resend otp captcha

### DIFF
--- a/esignet-service/data/flows/flow-esignet.yaml
+++ b/esignet-service/data/flows/flow-esignet.yaml
@@ -148,7 +148,7 @@ captcha_box: &captcha_box
   resourceType: ELEMENT
   required: true
   captcha:
-    provider: google-recaptcha
+    provider: ${MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER}
     siteKey: ${MOSIP_ESIGNET_CAPTCHA_SITE_KEY}
     theme: light
     size: normal
@@ -532,6 +532,10 @@ nodes:
                   timeLeft: 20
                   variant: OUTLINE
                   label: "otp.resend_otp"
+                  required: true
+                  captcha:
+                    provider: ${MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER}
+                    siteKey: ${MOSIP_ESIGNET_CAPTCHA_SITE_KEY}
     prompts:
       - inputs:
           - ref: otp_input
@@ -1041,7 +1045,7 @@ nodes:
           nextNode: consent_check
       - action:
           ref: action_deny
-          nextNode: end
+          nextNode: consent_check
 
   - id: auth_assert
     type: TASK_EXECUTION

--- a/esignet-service/data/i18n/ar.yaml
+++ b/esignet-service/data/i18n/ar.yaml
@@ -1280,3 +1280,6 @@ app:
   otp.submit: إرسال
   back: رجوع
   esignet_details: تفاصيل eSignet
+
+captcha:
+  config.error: إعداد موفر خدمة CAPTCHA غير صالح.

--- a/esignet-service/data/i18n/en.yaml
+++ b/esignet-service/data/i18n/en.yaml
@@ -1280,3 +1280,6 @@ app:
   otp.submit: Submit
   back: Back
   esignet_details: eSignet Details
+
+captcha:
+  config.error: CAPTCHA provider configuration is invalid.

--- a/esignet-service/data/i18n/es.yaml
+++ b/esignet-service/data/i18n/es.yaml
@@ -86,8 +86,8 @@ system:
   "error.agentservice.missing_agent_id_description": El ID del agente es obligatorio
   "error.agentservice.multiple_oauth_configs": No se permiten múltiples configuraciones de autenticación entrante OAuth
   "error.agentservice.multiple_oauth_configs_description": Una entidad puede tener como máximo una configuración de autenticación entrante por protocolo
-  "error.agentservice.none_auth_method_cannot_have_cert_or_secret_description": "El método de autenticación \"none\" no puede tener un certificado o secreto de cliente"
-  "error.agentservice.none_auth_method_requires_public_client_description": "El método de autenticación \"none\" requiere que el cliente sea un cliente público"
+  "error.agentservice.none_auth_method_cannot_have_cert_or_secret_description": 'El método de autenticación "none" no puede tener un certificado o secreto de cliente'
+  "error.agentservice.none_auth_method_requires_public_client_description": 'El método de autenticación "none" requiere que el cliente sea un cliente público'
   "error.agentservice.organization_unit_not_found": Unidad organizacional no encontrada
   "error.agentservice.organization_unit_not_found_description": La unidad organizacional especificada no existe
   "error.agentservice.owner_not_found": Propietario no encontrado
@@ -170,7 +170,7 @@ system:
   "error.applicationservice.invalid_jwks_uri": URI JWKS no válida
   "error.applicationservice.invalid_jwks_uri_description": El URI JWKS proporcionado no es un URI válido
   "error.applicationservice.invalid_jwks_uri_scheme": Esquema de URI JWKS no válido
-  "error.applicationservice.invalid_jwks_uri_scheme_description": "\"jwks_uri\" debe usar el esquema HTTPS"
+  "error.applicationservice.invalid_jwks_uri_scheme_description": '"jwks_uri" debe usar el esquema HTTPS'
   "error.applicationservice.invalid_logo_url": URL de logotipo no válida
   "error.applicationservice.invalid_logo_url_description": La URL del logotipo proporcionada no es un URI válido
   "error.applicationservice.invalid_oauth_configuration": Configuración OAuth no válida
@@ -197,8 +197,8 @@ system:
   "error.applicationservice.layout_not_found_description": La configuración de diseño especificada no existe
   "error.applicationservice.multiple_oauth_configs": No se permiten múltiples configuraciones de autenticación entrante OAuth
   "error.applicationservice.multiple_oauth_configs_description": Una aplicación puede tener como máximo una configuración de autenticación entrante por protocolo
-  "error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description": "El método de autenticación \"none\" no puede tener un certificado o secreto de cliente"
-  "error.applicationservice.none_auth_method_requires_public_client_description": "El método de autenticación \"none\" requiere que el cliente sea un cliente público"
+  "error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description": 'El método de autenticación "none" no puede tener un certificado o secreto de cliente'
+  "error.applicationservice.none_auth_method_requires_public_client_description": 'El método de autenticación "none" requiere que el cliente sea un cliente público'
   "error.applicationservice.pkce_requires_authorization_code_description": PKCE solo puede habilitarse cuando se selecciona el tipo de concesión authorization_code
   "error.applicationservice.private_key_jwt_cannot_have_client_secret_description": El método de autenticación private_key_jwt no puede tener un secreto de cliente
   "error.applicationservice.private_key_jwt_requires_certificate_description": El método de autenticación private_key_jwt requiere un certificado
@@ -528,11 +528,11 @@ system:
   "error.flowmetaservice.application_not_found_description": La aplicación especificada no existe
   "error.flowmetaservice.internal_server_error": Error interno del servidor
   "error.flowmetaservice.invalid_request": Solicitud no válida
-  "error.flowmetaservice.invalid_type_description": "El parámetro \"type\" debe ser \"APP\" o \"OU\""
-  "error.flowmetaservice.missing_id_description": "El parámetro de consulta \"id\" es obligatorio"
+  "error.flowmetaservice.invalid_type_description": 'El parámetro "type" debe ser "APP" o "OU"'
+  "error.flowmetaservice.missing_id_description": 'El parámetro de consulta "id" es obligatorio'
   "error.flowmetaservice.missing_id_parameter": Parámetro obligatorio faltante
   "error.flowmetaservice.missing_required_parameter": Parámetro obligatorio faltante
-  "error.flowmetaservice.missing_type_description": "El parámetro de consulta \"type\" es obligatorio"
+  "error.flowmetaservice.missing_type_description": 'El parámetro de consulta "type" es obligatorio'
   "error.flowmetaservice.ou_fetch_failed": Error interno del servidor
   "error.flowmetaservice.ou_fetch_failed_description": Error al recuperar la información de la unidad organizacional
   "error.flowmetaservice.ou_not_found": Recurso no encontrado
@@ -600,7 +600,7 @@ system:
   "error.groupservice.invalid_member_id": ID de miembro no válido
   "error.groupservice.invalid_member_id_description": Uno o más IDs de miembros de usuario o aplicación en la solicitud no existen o no coinciden con el tipo declarado
   "error.groupservice.invalid_member_type": Tipo de miembro no válido
-  "error.groupservice.invalid_member_type_description": "El tipo de miembro debe ser \"user\", \"group\" o \"APP\""
+  "error.groupservice.invalid_member_type_description": 'El tipo de miembro debe ser "user", "group" o "APP"'
   "error.groupservice.invalid_offset_parameter": Parámetro de desplazamiento no válido
   "error.groupservice.invalid_offset_parameter_description": El parámetro de desplazamiento debe ser un número entero no negativo
   "error.groupservice.invalid_ou_id": ID de unidad organizacional no válido
@@ -754,7 +754,7 @@ system:
   "error.ouservice.circular_dependency_detected": Dependencia circular detectada
   "error.ouservice.circular_dependency_detected_description": Establecer este padre crearía una dependencia circular
   "error.ouservice.invalid_filter": Parámetro de filtro no válido
-  "error.ouservice.invalid_filter_description": "El parámetro de filtro no es válido. Use el formato: atributo (eq|gt|lt) \"valor\""
+  "error.ouservice.invalid_filter_description": 'El parámetro de filtro no es válido. Use el formato: atributo (eq|gt|lt) "valor"'
   "error.ouservice.invalid_handle_path": Ruta de identificador no válida
   "error.ouservice.invalid_handle_path_description": La ruta de identificador especificada no existe
   "error.ouservice.invalid_limit_parameter": Parámetro de límite no válido
@@ -868,7 +868,7 @@ system:
   "error.roleservice.empty_assignments_list": Lista de asignaciones vacía
   "error.roleservice.empty_assignments_list_description": Debe proporcionarse al menos una asignación
   "error.roleservice.invalid_assignee_type": Tipo de asignatario no válido
-  "error.roleservice.invalid_assignee_type_description": "El parámetro de tipo debe ser \"user\", \"group\" o \"APP\""
+  "error.roleservice.invalid_assignee_type_description": 'El parámetro de tipo debe ser "user", "group" o "APP"'
   "error.roleservice.invalid_assignment_id": ID de asignación no válido
   "error.roleservice.invalid_assignment_id_description": Uno o más IDs de asignación en la solicitud no existen o no coinciden con el tipo declarado
   "error.roleservice.invalid_limit_parameter": Parámetro de límite no válido
@@ -1280,3 +1280,6 @@ app:
   otp.submit: Enviar
   back: Atrás
   esignet_details: Detalles de eSignet
+
+captcha:
+  config.error: La configuración del proveedor de CAPTCHA no es válida.

--- a/esignet-service/data/i18n/fr.yaml
+++ b/esignet-service/data/i18n/fr.yaml
@@ -86,8 +86,8 @@ system:
   "error.agentservice.missing_agent_id_description": L'ID de l'agent est obligatoire
   "error.agentservice.multiple_oauth_configs": Les configurations d'authentification OAuth multiples ne sont pas autorisées
   "error.agentservice.multiple_oauth_configs_description": Une entité ne peut avoir qu'une seule configuration d'authentification entrante par protocole
-  "error.agentservice.none_auth_method_cannot_have_cert_or_secret_description": "La méthode d'authentification \"none\" ne peut pas avoir de certificat ou de secret client"
-  "error.agentservice.none_auth_method_requires_public_client_description": "La méthode d'authentification \"none\" requiert que le client soit un client public"
+  "error.agentservice.none_auth_method_cannot_have_cert_or_secret_description": 'La méthode d''authentification "none" ne peut pas avoir de certificat ou de secret client'
+  "error.agentservice.none_auth_method_requires_public_client_description": 'La méthode d''authentification "none" requiert que le client soit un client public'
   "error.agentservice.organization_unit_not_found": Unité organisationnelle introuvable
   "error.agentservice.organization_unit_not_found_description": L'unité organisationnelle spécifiée n'existe pas
   "error.agentservice.owner_not_found": Propriétaire introuvable
@@ -170,7 +170,7 @@ system:
   "error.applicationservice.invalid_jwks_uri": URI JWKS non valide
   "error.applicationservice.invalid_jwks_uri_description": L'URI JWKS fournie n'est pas une URI valide
   "error.applicationservice.invalid_jwks_uri_scheme": Schéma d'URI JWKS non valide
-  "error.applicationservice.invalid_jwks_uri_scheme_description": "\"jwks_uri\" doit utiliser le schéma HTTPS"
+  "error.applicationservice.invalid_jwks_uri_scheme_description": '"jwks_uri" doit utiliser le schéma HTTPS'
   "error.applicationservice.invalid_logo_url": URL de logo non valide
   "error.applicationservice.invalid_logo_url_description": L'URL du logo fournie n'est pas une URI valide
   "error.applicationservice.invalid_oauth_configuration": Configuration OAuth non valide
@@ -197,8 +197,8 @@ system:
   "error.applicationservice.layout_not_found_description": La configuration de mise en page spécifiée n'existe pas
   "error.applicationservice.multiple_oauth_configs": Les configurations d'authentification OAuth multiples ne sont pas autorisées
   "error.applicationservice.multiple_oauth_configs_description": Une application ne peut avoir qu'une seule configuration d'authentification entrante par protocole
-  "error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description": "La méthode d'authentification \"none\" ne peut pas avoir de certificat ou de secret client"
-  "error.applicationservice.none_auth_method_requires_public_client_description": "La méthode d'authentification \"none\" requiert que le client soit un client public"
+  "error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description": 'La méthode d''authentification "none" ne peut pas avoir de certificat ou de secret client'
+  "error.applicationservice.none_auth_method_requires_public_client_description": 'La méthode d''authentification "none" requiert que le client soit un client public'
   "error.applicationservice.pkce_requires_authorization_code_description": PKCE ne peut être activé que lorsque le type d'octroi authorization_code est sélectionné
   "error.applicationservice.private_key_jwt_cannot_have_client_secret_description": La méthode d'authentification private_key_jwt ne peut pas avoir de secret client
   "error.applicationservice.private_key_jwt_requires_certificate_description": La méthode d'authentification private_key_jwt nécessite un certificat
@@ -754,7 +754,7 @@ system:
   "error.ouservice.circular_dependency_detected": Dépendance circulaire détectée
   "error.ouservice.circular_dependency_detected_description": La définition de ce parent créerait une dépendance circulaire
   "error.ouservice.invalid_filter": Paramètre de filtre non valide
-  "error.ouservice.invalid_filter_description": "Le paramètre de filtre est non valide. Utilisez le format : attribut (eq|gt|lt) \"valeur\""
+  "error.ouservice.invalid_filter_description": 'Le paramètre de filtre est non valide. Utilisez le format : attribut (eq|gt|lt) "valeur"'
   "error.ouservice.invalid_handle_path": Chemin d'identifiant non valide
   "error.ouservice.invalid_handle_path_description": Le chemin d'identifiant spécifié n'existe pas
   "error.ouservice.invalid_limit_parameter": Paramètre de limite non valide
@@ -1280,3 +1280,6 @@ app:
   otp.submit: Soumettre
   back: Retour
   esignet_details: Détails eSignet
+
+captcha:
+  config.error: La configuration du fournisseur CAPTCHA n'est pas valide.

--- a/esignet-service/data/i18n/hi.yaml
+++ b/esignet-service/data/i18n/hi.yaml
@@ -1279,3 +1279,6 @@ app:
   otp.submit: सबमिट करें
   back: पीछे
   esignet_details: ईसिग्नेट विवरण
+
+captcha:
+  config.error: CAPTCHA प्रदाता कॉन्फ़िगरेशन अमान्य है।

--- a/esignet-service/data/i18n/km.yaml
+++ b/esignet-service/data/i18n/km.yaml
@@ -1280,3 +1280,6 @@ app:
   otp.submit: ដាក់ស្នើ
   back: ថយក្រោយ
   esignet_details: ព័ត៌មានលម្អិត eSignet
+
+captcha:
+  config.error: ការកំណត់រចនាសម្ព័ន្ធរបស់អ្នកផ្តល់សេវា CAPTCHA មិនត្រឹមត្រូវទេ។

--- a/esignet-service/data/i18n/kn.yaml
+++ b/esignet-service/data/i18n/kn.yaml
@@ -1280,3 +1280,6 @@ app:
   otp.submit: ಸಲ್ಲಿಸಿ
   back: ಹಿಂದೆ
   esignet_details: ಈಸಿಗ್ನೆಟ್ ವಿವರಗಳು
+
+captcha:
+  config.error: CAPTCHA ಪೂರೈಕೆದಾರರ ಕಾನ್ಫಿಗರೇಶನ್ ಅಮಾನ್ಯವಾಗಿದೆ.

--- a/esignet-service/data/i18n/si.yaml
+++ b/esignet-service/data/i18n/si.yaml
@@ -86,8 +86,8 @@ system:
   "error.agentservice.missing_agent_id_description": නියෝජිත හැඳුනුම්පත අවශ්‍ය වේ
   "error.agentservice.multiple_oauth_configs": බහු OAuth අභ්‍යන්තර සත්‍යාපන වින්‍යාස අවසර නැත
   "error.agentservice.multiple_oauth_configs_description": ආයතනයකට ප්‍රොටෝකෝලයකට උපරිම එක් අභ්‍යන්තර සත්‍යාපන වින්‍යාසයක් තිබිය හැක
-  "error.agentservice.none_auth_method_cannot_have_cert_or_secret_description": "\"none\" සත්‍යාපන ක්‍රමයට සහතිකයක් හෝ සේවාලාභී රහසක් තිබිය නොහැක"
-  "error.agentservice.none_auth_method_requires_public_client_description": "\"none\" සත්‍යාපන ක්‍රමයට සේවාලාභියා පොදු සේවාලාභියෙකු විය යුතුය"
+  "error.agentservice.none_auth_method_cannot_have_cert_or_secret_description": '"none" සත්‍යාපන ක්‍රමයට සහතිකයක් හෝ සේවාලාභී රහසක් තිබිය නොහැක'
+  "error.agentservice.none_auth_method_requires_public_client_description": '"none" සත්‍යාපන ක්‍රමයට සේවාලාභියා පොදු සේවාලාභියෙකු විය යුතුය'
   "error.agentservice.organization_unit_not_found": සංවිධාන ඒකකය සොයාගත නොහැක
   "error.agentservice.organization_unit_not_found_description": නිශ්චිත සංවිධාන ඒකකය පවතින්නේ නැත
   "error.agentservice.owner_not_found": හිමිකරු සොයාගත නොහැක
@@ -170,7 +170,7 @@ system:
   "error.applicationservice.invalid_jwks_uri": වලංගු නොවන JWKS URI
   "error.applicationservice.invalid_jwks_uri_description": සපයා ඇති JWKS URI වලංගු URI එකක් නොවේ
   "error.applicationservice.invalid_jwks_uri_scheme": වලංගු නොවන JWKS URI scheme
-  "error.applicationservice.invalid_jwks_uri_scheme_description": "\"jwks_uri\" HTTPS ක්‍රමය භාවිතා කළ යුතුය"
+  "error.applicationservice.invalid_jwks_uri_scheme_description": '"jwks_uri" HTTPS ක්‍රමය භාවිතා කළ යුතුය'
   "error.applicationservice.invalid_logo_url": වලංගු නොවන ලාංඡන URL
   "error.applicationservice.invalid_logo_url_description": සපයා ඇති ලාංඡන URL වලංගු URI එකක් නොවේ
   "error.applicationservice.invalid_oauth_configuration": වලංගු නොවන OAuth වින්‍යාසය
@@ -197,8 +197,8 @@ system:
   "error.applicationservice.layout_not_found_description": නිශ්චිත පිරිසැලසුම් වින්‍යාසය පවතින්නේ නැත
   "error.applicationservice.multiple_oauth_configs": බහු OAuth අභ්‍යන්තර සත්‍යාපන වින්‍යාස අවසර නැත
   "error.applicationservice.multiple_oauth_configs_description": යෙදුමකට ප්‍රොටෝකෝලයකට උපරිම එක් අභ්‍යන්තර සත්‍යාපන වින්‍යාසයක් තිබිය හැක
-  "error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description": "\"none\" සත්‍යාපන ක්‍රමයට සහතිකයක් හෝ සේවාලාභී රහසක් තිබිය නොහැක"
-  "error.applicationservice.none_auth_method_requires_public_client_description": "\"none\" සත්‍යාපන ක්‍රමය සඳහා සේවාලාභියා පොදු සේවාලාභියෙකු විය යුතුය"
+  "error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description": '"none" සත්‍යාපන ක්‍රමයට සහතිකයක් හෝ සේවාලාභී රහසක් තිබිය නොහැක'
+  "error.applicationservice.none_auth_method_requires_public_client_description": '"none" සත්‍යාපන ක්‍රමය සඳහා සේවාලාභියා පොදු සේවාලාභියෙකු විය යුතුය'
   "error.applicationservice.pkce_requires_authorization_code_description": authorization_code grant type තෝරාගත් විට පමණක් PKCE සක්‍රිය කළ හැක
   "error.applicationservice.private_key_jwt_cannot_have_client_secret_description": private_key_jwt සත්‍යාපන ක්‍රමයට සේවාලාභී රහසක් තිබිය නොහැක
   "error.applicationservice.private_key_jwt_requires_certificate_description": private_key_jwt සත්‍යාපන ක්‍රමයට සහතිකයක් අවශ්‍යයි
@@ -754,7 +754,7 @@ system:
   "error.ouservice.circular_dependency_detected": චක්‍රීය පරායත්තතාවය හඳුනාගන්නා ලදී
   "error.ouservice.circular_dependency_detected_description": මෙම මව් සැකසීම චක්‍රීය පරායත්තතාවයක් නිර්මාණය කරනු ඇත
   "error.ouservice.invalid_filter": වලංගු නොවන පෙරහන් පරාමිතිය
-  "error.ouservice.invalid_filter_description": "පෙරහන් පරාමිතිය වලංගු නොවේ. ආකෘතිය භාවිතා කරන්න: attribute (eq|gt|lt) \"value\""
+  "error.ouservice.invalid_filter_description": 'පෙරහන් පරාමිතිය වලංගු නොවේ. ආකෘතිය භාවිතා කරන්න: attribute (eq|gt|lt) "value"'
   "error.ouservice.invalid_handle_path": වලංගු නොවන හසුරු මාර්ගය
   "error.ouservice.invalid_handle_path_description": නිශ්චිත හසුරු මාර්ගය නොපවතී
   "error.ouservice.invalid_limit_parameter": වලංගු නොවන සීමා පරාමිතිය
@@ -1280,3 +1280,6 @@ app:
   otp.submit: ඉදිරිපත් කරන්න
   back: ආපසු
   esignet_details: eSignet විස්තර
+
+captcha:
+  config.error: CAPTCHA සැපයුම්කරුගේ වින්‍යාසය වලංගු නොවේ.

--- a/esignet-service/data/i18n/ta.yaml
+++ b/esignet-service/data/i18n/ta.yaml
@@ -1280,3 +1280,6 @@ app:
   otp.submit: சமர்ப்பிக்கவும்
   back: பின்னால்
   esignet_details: ஈசிக்னெட் விவரங்கள்
+
+captcha:
+  config.error: கேப்ட்சா வழங்கி உள்ளமைப்பு செல்லாதது.

--- a/oidc-ui/src/components/CaptchaComponent/CaptchaComponent.tsx
+++ b/oidc-ui/src/components/CaptchaComponent/CaptchaComponent.tsx
@@ -1,18 +1,30 @@
-import { FormControl, validateFieldValue } from "@thunderid/react";
+import {
+  FormControl,
+  useTranslation,
+  validateFieldValue,
+} from "@thunderid/react";
 import GoogleReCaptcha from "./GoogleReCaptcha";
 import CloudflareTurnstile from "./CloudflareTurnstile";
 import HCaptcha from "./HCaptcha";
 import type { CaptchaComponentProps } from "./CaptchaModel";
 
+// available captcha provider
+const availableProvider = [
+  "google-recaptcha",
+  "cloudflare-turnstile",
+  "hcaptcha",
+];
+
 export default function CaptchaComponent({
   component,
   context,
 }: CaptchaComponentProps) {
+  const { t } = useTranslation();
   const fieldRef = component.ref ?? component.id;
   const { formValues, formErrors, touchedFields } = context;
   const isTouched = touchedFields[fieldRef] || false;
   const values = formValues[fieldRef];
-  const { provider } = component.captcha ?? {};
+  const { provider, siteKey } = component.captcha ?? {};
 
   const validationError = validateFieldValue(
     values,
@@ -54,18 +66,21 @@ export default function CaptchaComponent({
 
   let providerElement = null;
 
-  if (provider === "google-recaptcha") {
-    providerElement = <GoogleReCaptcha {...captchaProps} />;
-  } else if (provider === "cloudflare-turnstile") {
-    providerElement = <CloudflareTurnstile {...captchaProps} />;
-  } else if (provider === "hcaptcha") {
-    providerElement = <HCaptcha {...captchaProps} />;
+  if (!siteKey || !availableProvider.includes(provider ?? "")) {
+    providerElement = <span role="alert">{t("captcha.config.error")}</span>;
+
+    if (context.formValues[fieldRef]) {
+      context.onInputChange(fieldRef, "");
+    }
+    context.formErrors[fieldRef] = t("captcha.config.error");
   } else {
-    providerElement = (
-      <span role="alert">CAPTCHA provider configuration is invalid.</span>
-    );
-    context.onInputChange(fieldRef, "");
-    context.formErrors[fieldRef] = "CAPTCHA provider configuration is invalid.";
+    if (provider === "google-recaptcha") {
+      providerElement = <GoogleReCaptcha {...captchaProps} />;
+    } else if (provider === "cloudflare-turnstile") {
+      providerElement = <CloudflareTurnstile {...captchaProps} />;
+    } else if (provider === "hcaptcha") {
+      providerElement = <HCaptcha {...captchaProps} />;
+    }
   }
 
   return (

--- a/oidc-ui/src/components/CaptchaComponent/CaptchaComponent.tsx
+++ b/oidc-ui/src/components/CaptchaComponent/CaptchaComponent.tsx
@@ -7,6 +7,7 @@ import GoogleReCaptcha from "./GoogleReCaptcha";
 import CloudflareTurnstile from "./CloudflareTurnstile";
 import HCaptcha from "./HCaptcha";
 import type { CaptchaComponentProps } from "./CaptchaModel";
+import { useEffect } from "react";
 
 // available captcha provider
 const availableProvider = [
@@ -26,12 +27,21 @@ export default function CaptchaComponent({
   const values = formValues[fieldRef];
   const { provider, siteKey } = component.captcha ?? {};
 
+  const isConfigValid = siteKey && availableProvider.includes(provider ?? "");
+
   const validationError = validateFieldValue(
     values,
     "TEXT" as any,
     component.required,
     isTouched,
   );
+
+  useEffect(() => {
+    if (!isConfigValid) {
+      context.onInputChange(fieldRef, "");
+      context.formErrors[fieldRef] = t("captcha.config.error");
+    }
+  }, [isConfigValid]);
 
   const error = formErrors[fieldRef] || validationError || undefined;
 
@@ -66,13 +76,10 @@ export default function CaptchaComponent({
 
   let providerElement = null;
 
-  if (!siteKey || !availableProvider.includes(provider ?? "")) {
+  // if sitekey or provider is not configured
+  // properly then it will throw error
+  if (!isConfigValid) {
     providerElement = <span role="alert">{t("captcha.config.error")}</span>;
-
-    if (context.formValues[fieldRef]) {
-      context.onInputChange(fieldRef, "");
-    }
-    context.formErrors[fieldRef] = t("captcha.config.error");
   } else {
     if (provider === "google-recaptcha") {
       providerElement = <GoogleReCaptcha {...captchaProps} />;

--- a/oidc-ui/src/components/CaptchaComponent/CaptchaModel.tsx
+++ b/oidc-ui/src/components/CaptchaComponent/CaptchaModel.tsx
@@ -8,7 +8,7 @@ export type CaptchaProvider =
   | "cloudflare-turnstile"
   | "hcaptcha";
 
-export interface CaptchaComponent {
+export interface CaptchaComponentType {
   provider?: CaptchaProvider;
   siteKey?: string;
   theme?: "light" | "dark";
@@ -16,7 +16,7 @@ export interface CaptchaComponent {
 }
 
 export interface CaptchaFlowComponent extends EmbeddedFlowComponent {
-  captcha?: CaptchaComponent;
+  captcha?: CaptchaComponentType;
 }
 
 export interface CaptchaComponentProps {
@@ -25,7 +25,7 @@ export interface CaptchaComponentProps {
 }
 
 export interface CaptchaProps {
-  captcha: CaptchaComponent | undefined;
+  captcha: CaptchaComponentType | undefined;
   handleSuccess: (token: string | null) => void;
   handleError: () => void;
   handleExpire: () => void;

--- a/oidc-ui/src/components/ResendOtpComponent/ResendOtpComponent.tsx
+++ b/oidc-ui/src/components/ResendOtpComponent/ResendOtpComponent.tsx
@@ -62,16 +62,17 @@ export default function ResendOtp({
   const handleClick = () => {
     if (context.onSubmit) {
       // checking whether captcha has been checked or not
-      context.touchedFields[captchaId] = true;
-      if (!context.formValues[captchaId]) {
+      const captchaToken = context.formValues[captchaId];
+      if (component.captcha && !captchaToken) {
         // if it is not checked, make the value not,
         // so that it will throw error in ui
+        context.touchedFields[captchaId] = true;
         context.onInputChange(captchaId, "");
         return;
       }
       const payload = {
         ...context.formValues,
-        captcha_token: context.formValues[captchaId],
+        ...(component.captcha ? { captcha_token: captchaToken } : {}),
       };
 
       context.onSubmit(component, payload, true);

--- a/oidc-ui/src/components/ResendOtpComponent/ResendOtpComponent.tsx
+++ b/oidc-ui/src/components/ResendOtpComponent/ResendOtpComponent.tsx
@@ -1,20 +1,17 @@
 import { useRef, useState, useEffect } from "react";
 import {
   type ComponentRenderContext,
-  type EmbeddedFlowComponent,
   Button,
   useTranslation,
 } from "@thunderid/react";
-
-interface EmbeddedFlowComponentWithTimeLeft extends EmbeddedFlowComponent {
-  timeLeft?: number;
-}
+import { CaptchaComponent } from "../index";
+import type { ResendOtpFlowComponent } from "./ResendOtpModel";
 
 export default function ResendOtp({
   component,
   context,
 }: {
-  component: EmbeddedFlowComponentWithTimeLeft;
+  component: ResendOtpFlowComponent;
   context: ComponentRenderContext;
 }) {
   const { t } = useTranslation();
@@ -25,6 +22,8 @@ export default function ResendOtp({
   const [formattedTime, setFormattedTime] = useState<string>("00:00");
   const [timeLeft, setTimeLeft] = useState<boolean>(true);
   const expiresIn = component?.timeLeft ?? 0;
+
+  const captchaId = `${component.id}_captcha`;
 
   useEffect(() => {
     if (expiresIn <= 0) {
@@ -62,8 +61,20 @@ export default function ResendOtp({
 
   const handleClick = () => {
     if (context.onSubmit) {
-      context.resetForm?.();
-      context.onSubmit(component, {}, true);
+      // checking whether captcha has been checked or not
+      context.touchedFields[captchaId] = true;
+      if (!context.formValues[captchaId]) {
+        // if it is not checked, make the value not,
+        // so that it will throw error in ui
+        context.onInputChange(captchaId, "");
+        return;
+      }
+      const payload = {
+        ...context.formValues,
+        captcha_token: context.formValues[captchaId],
+      };
+
+      context.onSubmit(component, payload, true);
     }
   };
 
@@ -73,6 +84,21 @@ export default function ResendOtp({
         <h6 className="thunderid-typography thunderid-typography__h6">
           {t("app.otp.resend_timer")} {formattedTime}
         </h6>
+      )}
+
+      {!timeLeft && component.captcha && (
+        <>
+          <CaptchaComponent
+            component={{ ...component, ref: captchaId }}
+            context={context}
+            key={captchaId}
+          ></CaptchaComponent>
+          {context.formErrors[captchaId] && (
+            <div style={{ color: "red", fontSize: "10px" }}>
+              {context.formErrors[captchaId]}
+            </div>
+          )}
+        </>
       )}
 
       <Button
@@ -90,7 +116,7 @@ export default function ResendOtp({
             ? "primary"
             : "secondary"
         }
-        type="reset"
+        type="button"
       >
         {t(component?.label ?? "otp.resend_otp", {
           defaultValue: t("otp.resend_otp"),

--- a/oidc-ui/src/components/ResendOtpComponent/ResendOtpModel.tsx
+++ b/oidc-ui/src/components/ResendOtpComponent/ResendOtpModel.tsx
@@ -1,0 +1,7 @@
+import type { EmbeddedFlowComponent } from "@thunderid/react";
+import type { CaptchaComponentType } from "../index";
+
+export interface ResendOtpFlowComponent extends EmbeddedFlowComponent {
+  timeLeft?: number;
+  captcha?: CaptchaComponentType;
+}

--- a/oidc-ui/src/components/ResendOtpComponent/ResendOtpRenderer.tsx
+++ b/oidc-ui/src/components/ResendOtpComponent/ResendOtpRenderer.tsx
@@ -1,15 +1,9 @@
-import type {
-  ComponentRenderContext,
-  EmbeddedFlowComponent,
-} from "@thunderid/react";
+import type { ComponentRenderContext } from "@thunderid/react";
 import ResendOtp from "./ResendOtpComponent";
-
-interface EmbeddedFlowComponentWithTimeLeft extends EmbeddedFlowComponent {
-  timeLeft?: number;
-}
+import type { ResendOtpFlowComponent } from "./ResendOtpModel";
 
 export default function ResendOtpRenderer(
-  component: EmbeddedFlowComponentWithTimeLeft,
+  component: ResendOtpFlowComponent,
   context: ComponentRenderContext,
 ) {
   return (

--- a/oidc-ui/src/components/index.tsx
+++ b/oidc-ui/src/components/index.tsx
@@ -3,16 +3,33 @@ import ResendOtpRenderer from "./ResendOtpComponent/ResendOtpRenderer";
 import BackButtonRenderer from "./BackButtonComponent/BackButtonRenderer";
 import CaptchaRenderer from "./CaptchaComponent/CaptchaRenderer";
 
+import SbiCustomComponent from "./SbiComponent/SbiComponent";
+import ResendOtpComponent from "./ResendOtpComponent/ResendOtpComponent";
+import BackButtonComponent from "./BackButtonComponent/BackButtonComponent";
+import CaptchaComponent from "./CaptchaComponent/CaptchaComponent";
+
 export {
+  // export all renderers
   SbiCustomRenderer,
   ResendOtpRenderer,
   BackButtonRenderer,
   CaptchaRenderer,
+
+  // export all components
+  SbiCustomComponent,
+  ResendOtpComponent,
+  BackButtonComponent,
+  CaptchaComponent,
 };
 
+// export type from captcha model
 export type {
   CaptchaFlowComponent,
   CaptchaProvider,
   CaptchaComponentProps,
   CaptchaProps,
+  CaptchaComponentType,
 } from "./CaptchaComponent/CaptchaModel";
+
+// export type from resend otp model
+export type { ResendOtpFlowComponent } from "./ResendOtpComponent/ResendOtpModel";


### PR DESCRIPTION
- added captcha component in resend otp custom component, had to pass captcha provider and sitekey to the resend otp component in flow graph
- handle captcha component error, when sitekey or provider is not mention in the environment file
- added captcha provider error in i18n file as well
- added a new property called MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER, where we can add captcha provider name just like site key value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CAPTCHA providers can now be configured dynamically across supported authentication flows.
  - CAPTCHA validation is supported when resending OTPs, with clear prompts for missing or invalid configuration.
  - Added localized CAPTCHA configuration error messages across supported languages.
- **Bug Fixes**
  - Improved CAPTCHA error handling and display for unsupported or incomplete setups.
  - Updated consent denial handling to continue through the appropriate verification step instead of ending immediately.
- **Refactor**
  - Improved consistency and reuse across CAPTCHA and OTP resend components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->