### PR TITLE
#2192 Fixed Biometric devices selection dropdown UI.

### DIFF
--- a/oidc-ui/src/App.css
+++ b/oidc-ui/src/App.css
@@ -254,3 +254,8 @@ input[type="password"]::-ms-clear {
 [data-testid="thunderid-signin"] .thunderid-typography:first-child {
   text-align: center !important;
 }
+
+/* SBI biometric device dropdown to render outside the login card. */
+.thunderid-signin.thunderid-card {
+  overflow: visible !important;
+}


### PR DESCRIPTION
**Related Issue**: #2192 
Screenshot after the fix: 
<img width="1918" height="918" alt="image (14)" src="https://github.com/user-attachments/assets/2aa982be-2fa8-41c5-ac87-7a6dd7847e43" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the SBI biometric device dropdown so it can open fully outside the sign-in card without being clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->