### PR TITLE
MOSIP-45312 - Automated esignet test cases

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/utils/EsignetUtil.java
@@ -257,7 +257,12 @@ public class EsignetUtil extends AdminTestUtil {
 				throw new SkipException(GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
 			}
 		}
-		
+
+		if (!isFapi2ServerProfile()
+				&& "TC_ESignet_FAPI_OauthDetails_NegTC_02".equals(testCaseDTO.getUniqueIdentifier())) {
+			throw new SkipException(GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
+		}
+
 		if (getIdentityPluginNameFromEsignetActuator().toLowerCase().contains("mockauthenticationservice")) {
 			// TO DO - need to conform whether esignet distinguishes between UIN and VID. BAsed on that need to remove VID test case from YAML.
 			BaseTestCase.setSupportedIdTypes(Arrays.asList("UIN"));
@@ -916,6 +921,17 @@ public class EsignetUtil extends AdminTestUtil {
 				jwkKey = JWKKeyUtil.getJWKKey(OIDC_JWK_FOR_FAPI);
 			}
 			jsonString = replaceKeywordValue(jsonString, "$OIDC_JWK_KEY_FAPI$", jwkKey);
+		}
+
+		if (jsonString.contains("$OIDC_JWK_KEY_FAPI_NONFAPICLIENT$")) {
+			String jwkKey = "";
+			if (getTriggerESignetKeyGenForFAPINonFapiClient()) {
+				jwkKey = JWKKeyUtil.generateAndCacheJWKKey(OIDC_JWK_FOR_FAPI_NON_FAPI_CLIENT);
+				setTriggerESignetKeyGenForFAPINonFapiClient(false);
+			} else {
+				jwkKey = JWKKeyUtil.getJWKKey(OIDC_JWK_FOR_FAPI_NON_FAPI_CLIENT);
+			}
+			jsonString = replaceKeywordValue(jsonString, "$OIDC_JWK_KEY_FAPI_NONFAPICLIENT$", jwkKey);
 		}
 
 		if (jsonString.contains("$OIDCJWKKEY2$")) {
@@ -2190,6 +2206,7 @@ public class EsignetUtil extends AdminTestUtil {
 	protected static final String OIDC_JWK_FOR_FAPI = "oidcJWKForFAPI";
 	protected static final String OIDC_JWK_FOR_FAPI_JWE = "oidcJWKForFAPIJWE";
 	protected static final String OIDC_JWK_FOR_PKCE_JWE = "oidcJWKForPKCEJWE";
+	protected static final String OIDC_JWK_FOR_FAPI_NON_FAPI_CLIENT = "oidcJWKForFAPINonFapiClient";
 	
 	protected static RSAKey oidcJWKKey1 = null;
 	protected static RSAKey oidcJWKKey3 = null;
@@ -2252,7 +2269,8 @@ public class EsignetUtil extends AdminTestUtil {
 	protected static boolean triggerESignetKeyGenForFAPI = true;
 	protected static boolean triggerESignetKeyGenForFAPIJWE = true;
 	protected static boolean triggerESignetKeyGenForPKCEJWE = true;
-	
+	protected static boolean triggerESignetKeyGenForFAPINonFapiClient = true;
+
 	private static String getFapiJwkKeyName(String testCaseName) {
 		if (testCaseName != null
 				&& (testCaseName.contains("forUserInfoJWE") || testCaseName.contains("_GetUserInfoJWE_"))) {
@@ -2371,6 +2389,14 @@ public class EsignetUtil extends AdminTestUtil {
 	
 	private static void setTriggerESignetKeyGenForFAPIJWE(boolean value) {
 		triggerESignetKeyGenForFAPIJWE = value;
+	}
+
+	private static boolean getTriggerESignetKeyGenForFAPINonFapiClient() {
+		return triggerESignetKeyGenForFAPINonFapiClient;
+	}
+
+	private static void setTriggerESignetKeyGenForFAPINonFapiClient(boolean value) {
+		triggerESignetKeyGenForFAPINonFapiClient = value;
 	}
 
 	private static boolean getTriggerESignetKeyGenForPKCEJWE() {

--- a/api-test/src/main/resources/config/testCaseInterDependency_mock.json
+++ b/api-test/src/main/resources/config/testCaseInterDependency_mock.json
@@ -1752,6 +1752,7 @@
         "TC_ESignet_OAuthDetailsRequestConsent_08"
     ],
     "TC_ESignet_OAuthDetailsRequestV3VerifiedClaims_01": ["TC_ESignet_OIDCClientV3VerifiedClaims_01"],
+    "TC_ESignet_OAuthDetailsDifferentScopeLanguageClaimsSce_28": ["TC_ESignet_DifferentScopeLanguageClaimsSce_OIDCClientV3_01"],
     "TC_ESignet_AuthorizationCodeConsent_06": [
         "TC_ESignet_AuthenticateUserConsent_11",
         "TC_ESignet_OAuthDetailsRequestConsent_08"

--- a/api-test/src/main/resources/esignet/DifferentScopeLanguageClaimsSce/OAuthDetails/OAuthDetailsRequest.yml
+++ b/api-test/src/main/resources/esignet/DifferentScopeLanguageClaimsSce/OAuthDetails/OAuthDetailsRequest.yml
@@ -707,3 +707,32 @@ OAuthDetailsDifferentScopeLanguageClaimsSce:
     }
   ]
 }'
+   ESignet_OAuthDetailsDifferentScopeLanguageClaimsSce_AuthToken_Xsrf_VerifiedClaim_InvalidEvidenceType_Neg:
+      endPoint: /v1/esignet/authorization/v3/oauth-details
+      uniqueIdentifier: TC_ESignet_OAuthDetailsDifferentScopeLanguageClaimsSce_28
+      description: Verified claims request where one evidence.type is an invalid document type
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/DifferentScopeLanguageClaimsSce/OAuthDetails/OAuthDetailsVerifiedClaimsInvalidEvidenceType
+      outputTemplate: esignet/error
+      input: '{
+        "requestTime": "$TIMESTAMP$",
+        "clientId": "$ID:OIDCClient_DifferentScopeLanguageClaimsSce_sid_clientId$",
+        "scope": "openid",
+        "responseType": "code",
+        "redirectUri": "$IDPREDIRECTURI$",
+        "display": "popup",
+        "prompt": "consent",
+        "acrValues": "mosip:idp:acr:generated-code",
+        "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+        "state": "eree2311",
+        "claimsLocales": "en"
+}'
+      output: '{
+       	"errors": [
+    {
+      "errorCode": "invalid_claim"
+    }
+  ]
+}'

--- a/api-test/src/main/resources/esignet/DifferentScopeLanguageClaimsSce/OAuthDetails/OAuthDetailsVerifiedClaimsInvalidEvidenceType.hbs
+++ b/api-test/src/main/resources/esignet/DifferentScopeLanguageClaimsSce/OAuthDetails/OAuthDetailsVerifiedClaimsInvalidEvidenceType.hbs
@@ -1,0 +1,43 @@
+{
+    "requestTime": "{{requestTime}}",
+    "request": {
+        "clientId": "{{clientId}}",
+        "scope": "{{scope}}",
+        "responseType": "{{responseType}}",
+        "redirectUri": "{{redirectUri}}",
+        "display": "{{display}}",
+        "prompt": "{{prompt}}",
+        "acrValues": "{{acrValues}}",
+        "claims": {
+            "userinfo": {
+                "verified_claims": [
+                    {
+                        "verification": {
+                            "trust_framework": { "value": "de_aml" },
+                            "evidence": [
+                                { "type": { "value": "document" } }
+                            ]
+                        },
+                        "claims": {
+                            "given_name": { "value": "John" },
+                            "birthdate": { "value": "1990-01-01" }
+                        }
+                    },
+                    {
+                        "verification": {
+                            "trust_framework": { "value": "us_trust" },
+                            "evidence": [
+                                { "type": { "value": "invalid" } }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "id_token": {}
+        },
+        "nonce" : "{{nonce}}",
+        "state" : "{{state}}",
+        "claimsLocales" : "{{claimsLocales}}",
+        "uiLocales" : "{{uiLocales}}"
+    }
+}

--- a/api-test/src/main/resources/esignet/DifferentScopeLanguageClaimsSce/OAuthDetails/OAuthDetailsVerifiedClaimsInvalidEvidenceType.hbs
+++ b/api-test/src/main/resources/esignet/DifferentScopeLanguageClaimsSce/OAuthDetails/OAuthDetailsVerifiedClaimsInvalidEvidenceType.hbs
@@ -37,7 +37,6 @@
         },
         "nonce" : "{{nonce}}",
         "state" : "{{state}}",
-        "claimsLocales" : "{{claimsLocales}}",
-        "uiLocales" : "{{uiLocales}}"
+        "claimsLocales" : "{{claimsLocales}}"
     }
 }

--- a/api-test/src/main/resources/esignet/FAPI/FAPICreateOIDCClientV3/FAPICreateOIDCClient.yml
+++ b/api-test/src/main/resources/esignet/FAPI/FAPICreateOIDCClientV3/FAPICreateOIDCClient.yml
@@ -40,6 +40,46 @@ FAPICreateOIDCClientV3:
     output: '{
       "status": "ACTIVE"
 }'
+  ESignet_CreateOIDCClientFAPI_NonFapiConfig_Smoke_sid:
+    endPoint: /v1/esignet/client-mgmt/client
+    uniqueIdentifier: TC_ESignet_FAPI_CreateOIDCClient_03
+    description: Create an OIDC client without PAR, DPoP, or PKCE configuration, for TC_ESignet_FAPI_OauthDetails_NegTC_02 to confirm it is rejected under an active fapi2.0 server profile
+    role: partner
+    restMethod: post
+    inputTemplate: esignet/FAPI/FAPICreateOIDCClientV3/FAPICreateOIDCClient
+    outputTemplate: esignet/FAPI/FAPICreateOIDCClientV3/FAPICreateOIDCClientResult
+    input: '{
+      "requestTime": "$TIMESTAMP$",
+      "clientId": "$RANDOMPARTNERID$",
+      "clientName": "MOSIP OIDC Client",
+      "logoUri": "https://health-services.com/logo.png",
+      "relyingPartyId": "mock-relying-party-id",
+      "redirectUris": "$IDPREDIRECTURI$",
+      "publicKey": "$OIDC_JWK_KEY_FAPI_NONFAPICLIENT$",
+      "userClaims1": "name",
+      "userClaims2": "email",
+      "userClaims3": "gender",
+      "userClaims4": "phone_number",
+      "userClaims5": "birthdate",
+      "authContextRefs": [{"acrValues": "mosip:idp:acr:static-code"},{"acrValues": "mosip:idp:acr:generated-code"},{"acrValues": "mosip:idp:acr:biometrics"}],
+      "grantTypes": "authorization_code",
+      "clientAuthMethods": "private_key_jwt",
+      "keyLang1": "$1STLANG$",
+      "clientNameLang": "MOSIP OIDC Client",
+      "userinfo_response_type": "JWS",
+      "purpose_title": "title",
+      "purpose_type": "verify",
+      "purpose_subTitle": "subtitle",
+      "signup_banner_required": true,
+      "forgot_pwd_link_required": true,
+      "consent_expire_in_mins": 120,
+      "require_pushed_authorization_requests": false,
+      "dpop_bound_access_tokens": false,
+      "require_pkce": false
+}'
+    output: '{
+      "status": "ACTIVE"
+}'
   ESignet_CreateOIDCClientFAPI_all_Valid_forUserInfoJWE_Smoke_sid:
     endPoint: /v1/esignet/client-mgmt/client
     uniqueIdentifier: TC_ESignet_FAPI_CreateOIDCClient_02

--- a/api-test/src/main/resources/esignet/FAPI/FAPIOauthDetailsNegTC/FAPIOauthDetailsNegTC.yml
+++ b/api-test/src/main/resources/esignet/FAPI/FAPIOauthDetailsNegTC/FAPIOauthDetailsNegTC.yml
@@ -19,3 +19,32 @@ FAPIOauthDetailsNegTC:
     }
   ]
 }'
+   ESignet_OAuthDetailsRequest_V3_NonFapiClient_UnderFapiProfile_Neg:
+      endPoint: /v1/esignet/authorization/v3/oauth-details
+      uniqueIdentifier: TC_ESignet_FAPI_OauthDetails_NegTC_02
+      description: Verify that a client without PAR, DPoP, or PKCE configuration is rejected by the normal (non-PAR) oauth-details endpoint when the fapi2.0 server profile is active - expected, invalid_request error
+      role: resident
+      restMethod: post
+      additionalDependencies: TC_ESignet_FAPI_CreateOIDCClient_03
+      inputTemplate: esignet/OAuthDetailsRequest/OAuthDetailsRequest
+      outputTemplate: esignet/error
+      input: '{
+        "requestTime": "$TIMESTAMP$",
+        "clientId": "$ID:CreateOIDCClientFAPI_NonFapiConfig_Smoke_sid_clientId$",
+        "scope": "openid profile",
+        "responseType": "code",
+        "redirectUri": "$IDPREDIRECTURI$",
+        "display": "popup",
+        "prompt": "consent",
+        "acrValues": "mosip:idp:acr:generated-code",
+        "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+        "state": "eree2311",
+        "claimsLocales": "en"
+}'
+      output: '{
+        "errors": [
+    {
+      "errorCode": "invalid_request"
+    }
+  ]
+}'


### PR DESCRIPTION
MOSIP-45312 - Automated esignet test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage for OAuth details requests involving non-FAPI clients under the FAPI 2.0 profile.
  * Added support for testing non-FAPI client signing keys.
  * Added validation for invalid evidence document types in verified claims.

* **Bug Fixes**
  * Tests now skip FAPI-specific scenarios when FAPI 2.0 is not enabled.

* **Tests**
  * Added negative test coverage for expected `invalid_request` and `invalid_claim` responses.
  * Added test dependencies for scope, language, and claims scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->