### PR TITLE
fix: pass normalized claims locales in authorize call to id system

### DIFF
--- a/esignet-service/internal/engine/mock/authenticator.go
+++ b/esignet-service/internal/engine/mock/authenticator.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	utcDateTimeFormat  = "2006-01-02T15:04:05.000Z"
-	defaultClaimLocale = "eng"
 	runtimeKeyClientID = "initiator_query_client_id"
 
 	// Credential/identifier keys sent by the esignet flows (see data/flows/flow-esignet.yaml).
@@ -136,10 +135,7 @@ func (p *mockAuthnProvider) GetAttributes(ctx context.Context, attributeToken an
 	kycToken, individualID, transactionID := tokenParts[0], tokenParts[1], tokenParts[2]
 
 	acceptedClaims := acceptedClaimsFromRequest(consentedAttributes)
-	claimLocales := []string{defaultClaimLocale}
-	if metadata.Locale != "" {
-		claimLocales = []string{metadata.Locale}
-	}
+	claimLocales := shared.NormalizeClaimLocales(metadata.Locale)
 
 	kycExchangeRequest := &KycExchangeRequestDto{
 		RequestDateTime: getUTCDateTime(),

--- a/esignet-service/internal/engine/mock/authenticator_test.go
+++ b/esignet-service/internal/engine/mock/authenticator_test.go
@@ -9,6 +9,8 @@ package mock
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -298,6 +300,59 @@ func (ts *AuthenticatorTestSuite) TestGetAttributes() {
 			&providers.RequestedAttributes{}, getAttributesMetadataWithClientID("client-1"))
 		require.Nil(t, attrs)
 		require.Same(t, shared.AuthenticationFailedError, svcErr)
+	})
+
+	t.Run("uses requested claims_locales", func(t *testing.T) {
+		claims := jwt.MapClaims{"sub": "ind-1"}
+		signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-secret"))
+		require.NoError(t, err)
+
+		var capturedBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"response":{"kyc":"` + signed + `"}}`))
+		}))
+		defer server.Close()
+
+		p := newTestProvider(t, "http://unused", server.URL, "http://unused")
+		metadata := getAttributesMetadataWithClientID("client-1")
+		metadata.Locale = "en fr"
+		_, svcErr := p.GetAttributes(context.Background(), "kyc-token||ind-1||txn-1",
+			&providers.RequestedAttributes{}, metadata)
+		require.Nil(t, svcErr)
+
+		var req KycExchangeRequestDto
+		require.NoError(t, json.Unmarshal(capturedBody, &req))
+		require.Equal(t, []string{"eng", "fra"}, req.ClaimLocales)
+	})
+
+	t.Run("sends empty locales when claims_locales not requested", func(t *testing.T) {
+		claims := jwt.MapClaims{"sub": "ind-1"}
+		signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-secret"))
+		require.NoError(t, err)
+
+		var capturedBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"response":{"kyc":"` + signed + `"}}`))
+		}))
+		defer server.Close()
+
+		p := newTestProvider(t, "http://unused", server.URL, "http://unused")
+
+		// getAttributesMetadataWithClientID leaves Locale unset, i.e. the RP did
+		// not send claims_locales. eSignet must not inject an "eng" default here
+		// — an empty locales list lets IDA choose.
+		_, svcErr := p.GetAttributes(context.Background(), "kyc-token||ind-1||txn-1",
+			&providers.RequestedAttributes{}, getAttributesMetadataWithClientID("client-1"))
+		require.Nil(t, svcErr)
+
+		var req KycExchangeRequestDto
+		require.NoError(t, json.Unmarshal(capturedBody, &req))
+		require.NotNil(t, req.ClaimLocales)
+		require.Empty(t, req.ClaimLocales)
 	})
 }
 

--- a/esignet-service/internal/engine/mock/model.go
+++ b/esignet-service/internal/engine/mock/model.go
@@ -36,7 +36,7 @@ type KycExchangeRequestDto struct {
 	KycToken        string   `json:"kycToken,omitempty"`
 	IndividualID    string   `json:"individualId,omitempty"`
 	AcceptedClaims  []string `json:"acceptedClaims,omitempty"`
-	ClaimLocales    []string `json:"claimLocales,omitempty"`
+	ClaimLocales    []string `json:"claimLocales"`
 	RespType        string   `json:"respType,omitempty"`
 }
 

--- a/esignet-service/internal/engine/mosip/authenticator.go
+++ b/esignet-service/internal/engine/mosip/authenticator.go
@@ -246,7 +246,7 @@ func (p *mosipAuthnProvider) GetAttributes(ctx context.Context, attributeToken a
 		TransactionID:   transactionID,
 		KycToken:        kycToken,
 		ConsentObtained: keys,
-		Locales:         []string{"eng"},
+		Locales:         shared.NormalizeClaimLocales(metadata.Locale),
 		RespType:        "JWS",
 		IndividualID:    username,
 	}

--- a/esignet-service/internal/engine/mosip/authenticator_test.go
+++ b/esignet-service/internal/engine/mosip/authenticator_test.go
@@ -1146,6 +1146,72 @@ func (ts *AuthenticatorTestSuite) TestGetAttributesDefaultsToSubWhenNoAttributes
 	require.Equal(t, []string{"sub"}, req.ConsentObtained)
 }
 
+func (ts *AuthenticatorTestSuite) TestGetAttributesUsesRequestedClaimLocales() {
+	t := ts.T()
+	signKey, signCert := genRSAKeyAndCert(t, "signer")
+	p12Path := writeTestP12(t, signKey, signCert, "pw")
+
+	var capturedBody []byte
+	jwtStr := unsignedJWT(t, map[string]interface{}{"sub": "user-1"})
+	respBody, err := json.Marshal(map[string]interface{}{"response": map[string]string{"encryptedKyc": jwtStr}})
+	require.NoError(t, err)
+	exchangeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = readAll(r)
+		_, _ = w.Write(respBody)
+	}))
+	defer exchangeSrv.Close()
+
+	p := newProvider(newValidClientService())
+	p.cfg.P12Path = p12Path
+	p.cfg.P12Password = "pw"
+	p.cfg.KYCExchangeBaseURL = exchangeSrv.URL
+
+	attributeToken := strings.Join([]string{"kyctok", "user-1", "txn-1"}, "||")
+	metadata := getAttributesMetadataFor("client-1")
+	metadata.Locale = "en fr"
+
+	_, svcErr := p.GetAttributes(context.Background(), attributeToken, &providers.RequestedAttributes{}, metadata)
+	require.Nil(t, svcErr)
+
+	var req IdaKycExchangeRequest
+	require.NoError(t, json.Unmarshal(capturedBody, &req))
+	require.Equal(t, []string{"eng", "fra"}, req.Locales)
+}
+
+func (ts *AuthenticatorTestSuite) TestGetAttributesSendsEmptyLocalesWhenClaimsLocalesNotRequested() {
+	t := ts.T()
+	signKey, signCert := genRSAKeyAndCert(t, "signer")
+	p12Path := writeTestP12(t, signKey, signCert, "pw")
+
+	var capturedBody []byte
+	jwtStr := unsignedJWT(t, map[string]interface{}{"sub": "user-1"})
+	respBody, err := json.Marshal(map[string]interface{}{"response": map[string]string{"encryptedKyc": jwtStr}})
+	require.NoError(t, err)
+	exchangeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = readAll(r)
+		_, _ = w.Write(respBody)
+	}))
+	defer exchangeSrv.Close()
+
+	p := newProvider(newValidClientService())
+	p.cfg.P12Path = p12Path
+	p.cfg.P12Password = "pw"
+	p.cfg.KYCExchangeBaseURL = exchangeSrv.URL
+
+	attributeToken := strings.Join([]string{"kyctok", "user-1", "txn-1"}, "||")
+
+	// getAttributesMetadataFor leaves Locale unset, i.e. the RP did not send
+	// claims_locales. eSignet must not inject an "eng" default here — an empty
+	// locales list lets IDA choose.
+	_, svcErr := p.GetAttributes(context.Background(), attributeToken, &providers.RequestedAttributes{}, getAttributesMetadataFor("client-1"))
+	require.Nil(t, svcErr)
+
+	var req IdaKycExchangeRequest
+	require.NoError(t, json.Unmarshal(capturedBody, &req))
+	require.NotNil(t, req.Locales)
+	require.Empty(t, req.Locales)
+}
+
 // ---------------------------------------------------------------------------
 // NewMosipAuthnProvider
 // ---------------------------------------------------------------------------

--- a/esignet-service/internal/engine/mosip/model.go
+++ b/esignet-service/internal/engine/mosip/model.go
@@ -120,7 +120,7 @@ type IdaKycExchangeRequest struct {
 	TransactionID             string                   `json:"transactionID,omitempty"`
 	KycToken                  string                   `json:"kycToken,omitempty"`
 	ConsentObtained           []string                 `json:"consentObtained,omitempty"`
-	Locales                   []string                 `json:"locales,omitempty"`
+	Locales                   []string                 `json:"locales"`
 	RespType                  string                   `json:"respType,omitempty"`
 	IndividualID              string                   `json:"individualId,omitempty"`
 	Metadata                  map[string]interface{}   `json:"metadata,omitempty"`

--- a/esignet-service/internal/engine/shared/utils.go
+++ b/esignet-service/internal/engine/shared/utils.go
@@ -8,6 +8,9 @@ package shared
 
 import (
 	"crypto/rand"
+	"strings"
+
+	"golang.org/x/text/language"
 )
 
 const (
@@ -32,4 +35,30 @@ func GenerateTransactionID(runtimeMetadata map[string][]string) (string, error) 
 		b[i] = '0' + b[i]%10
 	}
 	return string(b), nil
+}
+
+// NormalizeClaimLocales parses a raw claims_locales value (a space-separated list
+// of BCP-47 language tags, per the OIDC spec) into IDA-compatible ISO 639-2/T
+// 3-letter codes. 2-letter codes are converted (e.g. "en" -> "eng"); 3-letter
+// codes pass through unchanged; codes that fail conversion are dropped. Returns
+// a non-nil empty slice when raw is empty or every token is dropped, so callers
+// get an empty (not omitted) locales list and let IDA choose the default language.
+func NormalizeClaimLocales(raw string) []string {
+	locales := make([]string, 0)
+	for tok := range strings.FieldsSeq(raw) {
+		if len(tok) == 3 { // already ISO 639-2/T (e.g. "eng", "fra")
+			locales = append(locales, tok)
+			continue
+		}
+		// Use Parse, not Make: Make guesses "en" for unrecognized input, which
+		// would silently coerce garbage codes to English.
+		if tag, err := language.Parse(tok); err == nil {
+			if base, conf := tag.Base(); conf >= language.High {
+				if iso3 := base.ISO3(); iso3 != "" {
+					locales = append(locales, iso3)
+				}
+			}
+		}
+	}
+	return locales
 }

--- a/esignet-service/internal/engine/shared/utils_test.go
+++ b/esignet-service/internal/engine/shared/utils_test.go
@@ -70,6 +70,43 @@ func (ts *UtilsTestSuite) TestGenerateTransactionIDIsRandomAcrossCalls() {
 	}
 }
 
+func (ts *UtilsTestSuite) TestNormalizeClaimLocales() {
+	t := ts.T()
+
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "empty input yields empty (non-nil) slice", raw: "", want: []string{}},
+		{name: "blank input yields empty (non-nil) slice", raw: "   ", want: []string{}},
+		{name: "single 2-letter code converts to ISO 639-2/T", raw: "en", want: []string{"eng"}},
+		{name: "already 3-letter code passes through unchanged", raw: "eng", want: []string{"eng"}},
+		{name: "space-separated multi-locale converts each token", raw: "en fr", want: []string{"eng", "fra"}},
+		{name: "extra/mixed whitespace between tokens is ignored", raw: "  en   hi ", want: []string{"eng", "hin"}},
+		{name: "unknown code that fails conversion is dropped", raw: "xx", want: []string{}},
+		{name: "unknown code among valid ones is dropped, valid ones kept", raw: "en xx fr", want: []string{"eng", "fra"}},
+		{name: "already-3-letter unknown code passes through unvalidated", raw: "abc", want: []string{"abc"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeClaimLocales(tt.raw)
+			if got == nil {
+				t.Fatalf("NormalizeClaimLocales(%q) returned nil, want non-nil slice", tt.raw)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("NormalizeClaimLocales(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("NormalizeClaimLocales(%q) = %v, want %v", tt.raw, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
 func assertTenDigitNumeric(t *testing.T, id string) {
 	t.Helper()
 	if len(id) != 10 {


### PR DESCRIPTION
Closes #2263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced language preference handling by normalizing requested locales into standard language codes for more consistent language-specific authentication responses.
  * Requests without specified language preferences now send an explicit empty locale list instead of applying an unintended default language.

* **Tests**
  * Added coverage for locale conversion, valid three-letter codes, mixed and invalid inputs, whitespace handling, and requests without language preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->