### PR TITLE
fix: 2288 correct oidc-ui CORS headers, DEFAULT_WELLKNOWN, and esignet probe delays

### DIFF
--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -77,7 +77,7 @@ startupProbe:
   httpGet:
     path: /health
     port: 8088
-  initialDelaySeconds: 180
+  initialDelaySeconds: 35
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 60
@@ -88,7 +88,7 @@ livenessProbe:
   httpGet:
     path: /health
     port: 8088
-  initialDelaySeconds: 200
+  initialDelaySeconds: 35
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
@@ -99,7 +99,7 @@ readinessProbe:
   httpGet:
     path: /health
     port: 8088
-  initialDelaySeconds: 180
+  initialDelaySeconds: 35
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6

--- a/helm/oidc-ui/templates/configmap.yaml
+++ b/helm/oidc-ui/templates/configmap.yaml
@@ -80,9 +80,6 @@ data:
           proxy_set_header   X-Forwarded-Host $server_name;
           add_header Content-Security-Policy "default-src 'none'" always;
           add_header Referrer-Policy "no-referrer" always;
-          add_header 'Access-Control-Allow-Origin' $cors_allowed_origin always;
-          add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
-          add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
           types {
             text/plain log cer json txt;
           }

--- a/helm/oidc-ui/values.yaml
+++ b/helm/oidc-ui/values.yaml
@@ -425,7 +425,7 @@ oidc_ui:
       REACT_APP_SBI_DOMAIN_URI: "http://esignet.$NS"
       OIDC_UI_PUBLIC_URL: ""
       SIGN_IN_WITH_ESIGNET_PLUGIN_URL: ""
-      DEFAULT_WELLKNOWN: "%5B%7B%22name%22%3A%22OpenID%20Configuration%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-configuration%22%7D%2C%7B%22name%22%3A%22Jwks%20Json%22%2C%22value%22%3A%22%2F.well-known%2Fjwks.json%22%7D%2C%7B%22name%22%3A%22Authorization%20Server%22%2C%22value%22%3A%22%2F.well-known%2Foauth-authorization-server%22%7D%2C%7B%22name%22%3A%22OpenID%20Credential%20Issuer%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-credential-issuer%22%7D%5D"
+      DEFAULT_WELLKNOWN: ""
       DEFAULT_THEME: ""
       DEFAULT_LANG: "en"
       DEFAULT_FAVICON: "favicon.ico"

--- a/helm/oidc-ui/values.yaml
+++ b/helm/oidc-ui/values.yaml
@@ -425,7 +425,7 @@ oidc_ui:
       REACT_APP_SBI_DOMAIN_URI: "http://esignet.$NS"
       OIDC_UI_PUBLIC_URL: ""
       SIGN_IN_WITH_ESIGNET_PLUGIN_URL: ""
-      DEFAULT_WELLKNOWN: ""
+      DEFAULT_WELLKNOWN: "%5B%7B%22name%22%3A%22OpenID%20Configuration%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-configuration%22%7D%2C%7B%22name%22%3A%22Jwks%20Json%22%2C%22value%22%3A%22%2F.well-known%2Fjwks.json%22%7D%2C%7B%22name%22%3A%22Authorization%20Server%22%2C%22value%22%3A%22%2F.well-known%2Foauth-authorization-server%22%7D%5D"
       DEFAULT_THEME: ""
       DEFAULT_LANG: "en"
       DEFAULT_FAVICON: "favicon.ico"


### PR DESCRIPTION
## Summary
- Remove duplicate CORS headers from the oidc-ui nginx configmap (already set elsewhere, conflicting on the openid-config location)
- Drop the OpenID Credential Issuer entry from `DEFAULT_WELLKNOWN`
- Lower esignet startup/liveness/readiness probe `initialDelaySeconds` to 35s

Fixes #2288

## Test plan
- [ ] `helm template helm/esignet` and `helm template helm/oidc-ui` render without errors
- [ ] Deploy and confirm `/.well-known/openid-configuration` responses no longer include the Credential Issuer entry
- [ ] Confirm no duplicate `Access-Control-Allow-*` headers on well-known/openid-config responses
- [ ] Confirm probes report ready within the new 35s `initialDelaySeconds` window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the delay before startup, liveness, and readiness health checks begin.
  * Updated OpenID Connect discovery responses to remove unnecessary cross-origin headers.
  * Refined the default discovery endpoint configuration to include only the OpenID Configuration, JWKS, and Authorization Server endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->