### PR TITLE
fixed JWE support in useinfo response

### DIFF
--- a/esignet-service/internal/clientmgmt/jwk_validate.go
+++ b/esignet-service/internal/clientmgmt/jwk_validate.go
@@ -50,6 +50,18 @@ func validateJWK(key map[string]string) error {
 	return nil
 }
 
+// validateEncJWK validates an encryption key JWK, additionally requiring the
+// alg field so the JWE key-management algorithm is always known.
+func validateEncJWK(key map[string]string) error {
+	if err := validateJWK(key); err != nil {
+		return err
+	}
+	if key["alg"] == "" {
+		return validationErr("invalid_public_key")
+	}
+	return nil
+}
+
 func decodeBase64URL(s string) ([]byte, error) {
 	return base64.RawURLEncoding.DecodeString(s)
 }

--- a/esignet-service/internal/clientmgmt/service.go
+++ b/esignet-service/internal/clientmgmt/service.go
@@ -256,7 +256,7 @@ func (s *Service) PatchClient(ctx context.Context, clientID string, req PatchCli
 			encPKHash = sql.NullString{}
 			encPKCert = sql.NullString{}
 		} else {
-			if err := validateJWK(req.EncPublicKey.Value); err != nil {
+			if err := validateEncJWK(req.EncPublicKey.Value); err != nil {
 				return ClientResponse{}, err
 			}
 			pkJSON, err := marshalJWK(req.EncPublicKey.Value)
@@ -488,7 +488,7 @@ func encKeyColumns(encKey map[string]string, cert string) (sql.NullString, sql.N
 	if len(encKey) == 0 {
 		return sql.NullString{}, sql.NullString{}, sql.NullString{}, nil
 	}
-	if err := validateJWK(encKey); err != nil {
+	if err := validateEncJWK(encKey); err != nil {
 		return sql.NullString{}, sql.NullString{}, sql.NullString{}, err
 	}
 	pkJSON, err := marshalJWK(encKey)

--- a/esignet-service/internal/clientmgmt/service_test.go
+++ b/esignet-service/internal/clientmgmt/service_test.go
@@ -67,7 +67,7 @@ func b64(s string) string {
 }
 
 func validJWK() map[string]string {
-	return map[string]string{"kty": "RSA", "n": b64("modulus-bytes"), "e": b64("AQAB")}
+	return map[string]string{"kty": "RSA", "n": b64("modulus-bytes"), "e": b64("AQAB"), "alg": "RSA-OAEP-256"}
 }
 
 func existingClientRow() db.ClientDetail {

--- a/esignet-service/internal/clientmgmt/validate.go
+++ b/esignet-service/internal/clientmgmt/validate.go
@@ -111,7 +111,7 @@ func ValidateCreate(profile Profile, req CreateClientRequest) error {
 		}
 	}
 	if len(req.EncPublicKey) > 0 {
-		if err := validateJWK(req.EncPublicKey); err != nil {
+		if err := validateEncJWK(req.EncPublicKey); err != nil {
 			return err
 		}
 	}
@@ -245,7 +245,7 @@ func ValidatePatch(profile Profile, merged UpdateClientRequest, fields PatchFiel
 		}
 	}
 	if fields.EncPublicKey && !encPublicKey.IsNull {
-		if err := validateJWK(encPublicKey.Value); err != nil {
+		if err := validateEncJWK(encPublicKey.Value); err != nil {
 			return err
 		}
 	}

--- a/esignet-service/internal/clientmgmt/validate_test.go
+++ b/esignet-service/internal/clientmgmt/validate_test.go
@@ -192,6 +192,18 @@ func (ts *ValidateTestSuite) TestValidateCreate() {
 		req.EncPublicKey = map[string]string{"kty": "bogus"}
 		assert.Equal(t, "invalid_public_key", errCode(t, ValidateCreate(ProfileOIDC, req)))
 	})
+
+	t.Run("enc public key missing alg", func(t *testing.T) {
+		req := validCreateRequest()
+		req.EncPublicKey = map[string]string{"kty": "RSA", "n": "abc", "e": "AQAB"}
+		assert.Equal(t, "invalid_public_key", errCode(t, ValidateCreate(ProfileOIDC, req)))
+	})
+
+	t.Run("enc public key with alg accepted", func(t *testing.T) {
+		req := validCreateRequest()
+		req.EncPublicKey = map[string]string{"kty": "RSA", "n": "abc", "e": "AQAB", "alg": "RSA-OAEP-256"}
+		assert.NoError(t, ValidateCreate(ProfileOIDC, req))
+	})
 }
 
 func (ts *ValidateTestSuite) TestValidateUpdate() {
@@ -350,6 +362,12 @@ func (ts *ValidateTestSuite) TestValidatePatch() {
 	t.Run("null enc public key skips validation", func(t *testing.T) {
 		err := ValidatePatch(ProfileOIDC, base, PatchFields{EncPublicKey: true}, NullableJWK{IsNull: true})
 		assert.NoError(t, err)
+	})
+
+	t.Run("patched enc public key missing alg rejected", func(t *testing.T) {
+		err := ValidatePatch(ProfileOIDC, base, PatchFields{EncPublicKey: true},
+			NullableJWK{Value: map[string]string{"kty": "RSA", "n": "abc", "e": "AQAB"}})
+		assert.Equal(t, "invalid_public_key", errCode(t, err))
 	})
 
 	t.Run("status normalized before final ValidateUpdate", func(t *testing.T) {

--- a/esignet-service/internal/engine/actor_provider.go
+++ b/esignet-service/internal/engine/actor_provider.go
@@ -61,6 +61,10 @@ func (p *actorProvider) GetOAuthClientByClientID(
 	requirePushedAuthorizationRequests, _ := client.AdditionalConfig[parRequired].(bool)
 	dpopBoundAccessTokens, _ := client.AdditionalConfig[dpopRequired].(bool)
 	isPKCERequired, _ := client.AdditionalConfig[pkceRequired].(bool)
+	userInfo, svcErr := getUserInfoConfig(client.AdditionalConfig, client.Claims, client.EncPublicKey)
+	if svcErr != nil {
+		return nil, svcErr
+	}
 	return &providers.OAuthClient{
 		ID:                      client.ClientID,
 		OUID:                    client.RpID,
@@ -78,12 +82,9 @@ func (p *actorProvider) GetOAuthClientByClientID(
 		RequirePushedAuthorizationRequests: requirePushedAuthorizationRequests,
 		DPoPBoundAccessTokens:              dpopBoundAccessTokens,
 		AcrValues:                          client.AcrValues,
-		UserInfo: &providers.UserInfoConfig{
-			ResponseType:   getUserinfoResponseType(client.AdditionalConfig),
-			UserAttributes: client.Claims,
-		},
-		Scopes:      getAllowedScopes(p.config.ScopeClaims, client.AdditionalConfig),
-		ScopeClaims: getScopeClaimsMapping(p.config.ScopeClaims, client.Claims),
+		UserInfo:                           userInfo,
+		Scopes:                             getAllowedScopes(p.config.ScopeClaims, client.AdditionalConfig),
+		ScopeClaims:                        getScopeClaimsMapping(p.config.ScopeClaims, client.Claims),
 		Token: &providers.OAuthTokenConfig{
 			AccessToken: &providers.AccessTokenConfig{
 				UserConfig: &providers.AccessTokenSubConfig{
@@ -108,6 +109,10 @@ func (p *actorProvider) GetOAuthProfileByID(
 	requirePushedAuthorizationRequests, _ := client.AdditionalConfig[parRequired].(bool)
 	dpopBoundAccessTokens, _ := client.AdditionalConfig[dpopRequired].(bool)
 	isPKCERequired, _ := client.AdditionalConfig[pkceRequired].(bool)
+	userInfo, svcErr := getUserInfoConfig(client.AdditionalConfig, client.Claims, client.EncPublicKey)
+	if svcErr != nil {
+		return nil, svcErr
+	}
 	return &providers.OAuthProfile{
 		RedirectURIs:                       client.RedirectURIs,
 		GrantTypes:                         client.GrantTypes,
@@ -128,10 +133,7 @@ func (p *actorProvider) GetOAuthProfileByID(
 				UserAttributes: []string{},
 			},
 		},
-		UserInfo: &providers.UserInfoConfig{
-			ResponseType:   getUserinfoResponseType(client.AdditionalConfig),
-			UserAttributes: client.Claims,
-		},
+		UserInfo:    userInfo,
 		Scopes:      getAllowedScopes(p.config.ScopeClaims, client.AdditionalConfig),
 		ScopeClaims: getScopeClaimsMapping(p.config.ScopeClaims, client.Claims),
 		Certificate: &providers.Certificate{
@@ -296,12 +298,44 @@ func getScopeClaimsMapping(standardScopeClaims map[string][]string, claims []str
 	return mapping
 }
 
-func getUserinfoResponseType(additionalConfig map[string]any) providers.UserInfoResponseType {
-	respType, _ := additionalConfig[userinfoResponseType].(string)
-	if respType == "JWE" {
-		return providers.UserInfoResponseTypeJWE
+// getUserInfoConfig builds the userinfo endpoint configuration. When the
+// response type is JWE, the client's encryption key must already carry an alg
+// field (enforced at client registration time by clientmgmt), which is
+// propagated as the userinfo encryption alg alongside a fixed A256GCM enc.
+func getUserInfoConfig(
+	additionalConfig map[string]any, claims []string, encPublicKey string,
+) (*providers.UserInfoConfig, *common.ServiceError) {
+	responseType := providers.UserInfoResponseTypeJWS
+	if respType, _ := additionalConfig[userinfoResponseType].(string); respType == "JWE" {
+		responseType = providers.UserInfoResponseTypeJWE
 	}
-	return providers.UserInfoResponseTypeJWS
+	userInfo := &providers.UserInfoConfig{
+		ResponseType:   responseType,
+		UserAttributes: claims,
+	}
+	if responseType == providers.UserInfoResponseTypeJWE {
+		alg, ok := encryptionKeyAlg(encPublicKey)
+		if !ok {
+			return nil, shared.MissingEncryptionKeyAlgError
+		}
+		userInfo.EncryptionAlg = alg
+		userInfo.EncryptionEnc = "A256GCM"
+	}
+	return userInfo, nil
+}
+
+// encryptionKeyAlg extracts the alg field from a client's encryption key JWK.
+func encryptionKeyAlg(encPublicKey string) (string, bool) {
+	if encPublicKey == "" {
+		return "", false
+	}
+	var jwk struct {
+		Alg string `json:"alg"`
+	}
+	if err := json.Unmarshal([]byte(encPublicKey), &jwk); err != nil || jwk.Alg == "" {
+		return "", false
+	}
+	return jwk.Alg, true
 }
 
 func configInt64(cfg map[string]any, key string, defaultValue int64) int64 {

--- a/esignet-service/internal/engine/actor_provider_test.go
+++ b/esignet-service/internal/engine/actor_provider_test.go
@@ -79,6 +79,45 @@ func (ts *ActorProviderTestSuite) TestActorProvider_GetOAuthClientByClientID() {
 	})
 }
 
+func (ts *ActorProviderTestSuite) TestActorProvider_GetOAuthClientByClientID_JWEUserInfo() {
+	t := ts.T()
+
+	t.Run("JWE with alg propagates encryption alg and fixed enc", func(t *testing.T) {
+		row := testClientRow()
+		row.AdditionalConfig = sql.NullString{String: `{"userinfo_response_type":"JWE"}`, Valid: true}
+		row.EncPublicKey = sql.NullString{String: `{"kty":"RSA","n":"abc","e":"AQAB","alg":"RSA-OAEP-256"}`, Valid: true}
+		svc := newActorTestService(row)
+		p := NewActorProvider(svc, &config.AppConfig{})
+
+		client, svcErr := p.GetOAuthClientByClientID(context.Background(), "client-001")
+		if svcErr != nil {
+			t.Fatalf("GetOAuthClientByClientID: %v", svcErr)
+		}
+		if client.UserInfo.EncryptionAlg != "RSA-OAEP-256" {
+			t.Errorf("EncryptionAlg = %q, want RSA-OAEP-256", client.UserInfo.EncryptionAlg)
+		}
+		if client.UserInfo.EncryptionEnc != "A256GCM" {
+			t.Errorf("EncryptionEnc = %q, want A256GCM", client.UserInfo.EncryptionEnc)
+		}
+	})
+
+	t.Run("JWE without alg on encryption key is rejected", func(t *testing.T) {
+		row := testClientRow()
+		row.AdditionalConfig = sql.NullString{String: `{"userinfo_response_type":"JWE"}`, Valid: true}
+		row.EncPublicKey = sql.NullString{String: `{"kty":"RSA","n":"abc","e":"AQAB"}`, Valid: true}
+		svc := newActorTestService(row)
+		p := NewActorProvider(svc, &config.AppConfig{})
+
+		_, svcErr := p.GetOAuthClientByClientID(context.Background(), "client-001")
+		if svcErr == nil {
+			t.Fatal("expected error for JWE userinfo without an alg on the encryption key")
+		}
+		if svcErr.Code != "missing_encryption_key_alg" {
+			t.Errorf("error code = %q, want missing_encryption_key_alg", svcErr.Code)
+		}
+	})
+}
+
 func (ts *ActorProviderTestSuite) TestActorProvider_GetOAuthProfileByID() {
 	t := ts.T()
 	svc := newActorTestService(testClientRow())

--- a/esignet-service/internal/engine/shared/errors.go
+++ b/esignet-service/internal/engine/shared/errors.go
@@ -93,6 +93,21 @@ var SendOTPFailedError = &common.ServiceError{
 	},
 }
 
+// MissingEncryptionKeyAlgError is returned when a client's userinfo response
+// type is JWE but its encryption key has no alg field.
+var MissingEncryptionKeyAlgError = &common.ServiceError{
+	Code: "missing_encryption_key_alg",
+	Type: common.ClientErrorType,
+	Error: common.I18nMessage{
+		Key:          "missing_encryption_key_alg",
+		DefaultValue: "Missing encryption key alg",
+	},
+	ErrorDescription: common.I18nMessage{
+		Key:          "missing_encryption_key_alg_description",
+		DefaultValue: "The client's encryption key does not have an alg field",
+	},
+}
+
 // FileNotFoundError is returned when a required configuration file is not found.
 var FileNotFoundError = &common.ServiceError{
 	Code: "file_not_found",


### PR DESCRIPTION
Closes #2268 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Encrypted public keys now require a valid encryption algorithm.
  * Client creation and updates reject encryption keys missing the required algorithm.
  * JWE user-info responses now use the configured key-encryption algorithm with `A256GCM` content encryption.
  * Added a clear service error when an encryption key lacks an algorithm.
  * Improved validation consistency across client registration, updates, and JWE user-info processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->