### PR TITLE
Re-decode the ASN.1 TBSCertificate to accept a negative/mis-encoded serial number

### DIFF
--- a/esignet-service/internal/keymanager/certparse.go
+++ b/esignet-service/internal/keymanager/certparse.go
@@ -1,0 +1,86 @@
+package keymanager
+
+import (
+	"crypto/x509"
+	"errors"
+	"math/big"
+
+	"golang.org/x/crypto/cryptobyte"
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
+)
+
+// parseCertificateTolerant parses a DER-encoded certificate like
+// x509.ParseCertificate, but also accepts certificates whose serial number
+// is DER-encoded as a negative two's-complement INTEGER (top bit of the
+// first content byte set, no leading 0x00 padding). RFC 5280 §4.1.2.2
+// requires a non-negative serial, and Go's stdlib rejects the malformed
+// encoding outright ("x509: negative serial number"), but OpenSSL and Java
+// both parse it leniently, and some CA tooling (including at least one
+// MOSIP partner cert we've seen in the wild) still produces it. The
+// returned certificate's Raw is always the original, unmodified input, so
+// callers hashing/storing Raw (cert_thumbprint, key_store.certificate_data)
+// see exactly the bytes that were uploaded.
+func parseCertificateTolerant(der []byte) (*x509.Certificate, error) {
+	cert, err := x509.ParseCertificate(der)
+	if err == nil || err.Error() != "x509: negative serial number" {
+		return cert, err
+	}
+	fixed, fixErr := reencodeNonNegativeSerial(der)
+	if fixErr != nil {
+		return nil, err // fix-up failed; surface the original stdlib error
+	}
+	cert, err = x509.ParseCertificate(fixed)
+	if err != nil {
+		return nil, err
+	}
+	cert.Raw = der
+	return cert, nil
+}
+
+// reencodeNonNegativeSerial rebuilds a certificate's DER with its
+// TBSCertificate serialNumber re-encoded as a non-negative INTEGER, treating
+// the original (malformed) content bytes as an unsigned magnitude — i.e.
+// adding the DER-mandated 0x00 padding byte a correct encoder would have
+// written. Every other field is copied through byte-for-byte.
+func reencodeNonNegativeSerial(der []byte) ([]byte, error) {
+	input := cryptobyte.String(der)
+	var certSeq cryptobyte.String
+	if !input.ReadASN1(&certSeq, cryptobyte_asn1.SEQUENCE) {
+		return nil, errors.New("malformed certificate")
+	}
+
+	var tbs cryptobyte.String
+	if !certSeq.ReadASN1(&tbs, cryptobyte_asn1.SEQUENCE) {
+		return nil, errors.New("malformed tbs certificate")
+	}
+	// certSeq now holds exactly signatureAlgorithm + signatureValue.
+
+	versionTag := cryptobyte_asn1.Tag(0).Constructed().ContextSpecific()
+	var versionContent cryptobyte.String
+	var hasVersion bool
+	if !tbs.ReadOptionalASN1(&versionContent, &hasVersion, versionTag) {
+		return nil, errors.New("malformed version")
+	}
+
+	var serialContent cryptobyte.String
+	if !tbs.ReadASN1(&serialContent, cryptobyte_asn1.INTEGER) {
+		return nil, errors.New("malformed serial number")
+	}
+	serial := new(big.Int).SetBytes(serialContent)
+	// tbs now holds every TBSCertificate field after serialNumber.
+
+	var out cryptobyte.Builder
+	out.AddASN1(cryptobyte_asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+		b.AddASN1(cryptobyte_asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			if hasVersion {
+				b.AddASN1(versionTag, func(b *cryptobyte.Builder) {
+					b.AddBytes(versionContent)
+				})
+			}
+			b.AddASN1BigInt(serial)
+			b.AddBytes(tbs)
+		})
+		b.AddBytes(certSeq)
+	})
+	return out.Bytes()
+}

--- a/esignet-service/internal/keymanager/certparse.go
+++ b/esignet-service/internal/keymanager/certparse.go
@@ -34,7 +34,30 @@ func parseCertificateTolerant(der []byte) (*x509.Certificate, error) {
 		return nil, err
 	}
 	cert.Raw = der
+	// x509.ParseCertificate(fixed) set RawTBSCertificate from the re-encoded
+	// (padded-serial) bytes, not the originally signed ones. CheckSignatureFrom
+	// hashes RawTBSCertificate, so it must reflect exactly what the CA signed.
+	originalTBS, tbsErr := extractTBSCertificate(der)
+	if tbsErr != nil {
+		return nil, tbsErr
+	}
+	cert.RawTBSCertificate = originalTBS
 	return cert, nil
+}
+
+// extractTBSCertificate returns the tbsCertificate SEQUENCE's exact DER
+// encoding (tag, length, and content bytes) as it appears in der, byte-for-byte.
+func extractTBSCertificate(der []byte) ([]byte, error) {
+	input := cryptobyte.String(der)
+	var certSeq cryptobyte.String
+	if !input.ReadASN1(&certSeq, cryptobyte_asn1.SEQUENCE) {
+		return nil, errors.New("malformed certificate")
+	}
+	var tbs cryptobyte.String
+	if !certSeq.ReadASN1Element(&tbs, cryptobyte_asn1.SEQUENCE) {
+		return nil, errors.New("malformed tbs certificate")
+	}
+	return tbs, nil
 }
 
 // reencodeNonNegativeSerial rebuilds a certificate's DER with its

--- a/esignet-service/internal/keymanager/certparse_test.go
+++ b/esignet-service/internal/keymanager/certparse_test.go
@@ -1,0 +1,58 @@
+package keymanager_test
+
+import (
+	"crypto/sha256"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mosip/esignet/internal/keymanager"
+)
+
+// negativeSerialCertPEM is a real partner-uploaded certificate whose ASN.1
+// serial number is encoded without the leading 0x00 padding byte DER
+// requires when the magnitude's top bit is set — making it a negative
+// two's-complement INTEGER per the spec. OpenSSL and Java parse it (and
+// print/return a negative serial); Go's crypto/x509 rejects it outright with
+// "x509: negative serial number". parseCertPEM/ParseCertPEM must tolerate
+// this instead of failing the upload.
+const negativeSerialCertPEM = `-----BEGIN CERTIFICATE-----
+MIIDwDCCAqigAwIBAgII3/XjDTHdq18wDQYJKoZIhvcNAQELBQAwdjELMAkGA1UE
+BhMCSU4xCzAJBgNVBAgMAktBMRIwEAYDVQQHDAlCQU5HQUxPUkUxDTALBgNVBAoM
+BElJVEIxIDAeBgNVBAsMF01PU0lQLVRFQ0gtQ0VOVEVSIChQTVMpMRUwEwYDVQQD
+DAx3d3cubW9zaXAuaW8wHhcNMjYwODA3MTQyMjAyWhcNMjcwODA3MTQyMjAyWjCB
+hTELMAkGA1UEBhMCSU4xCzAJBgNVBAgMAktBMRIwEAYDVQQHDAlCYW5nYWxvcmUx
+DjAMBgNVBAoMBUlJSVRCMRYwFAYDVQQLDA1tb3NpcC1lc2lnbmV0MS0wKwYDVQQD
+DCR3d3cubW9zaXAuaW8gKE9JRENfUEFSVE5FUl9SU0FfMjA0OCkwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7GhEiTWZljEfny+EEx3JqLNQcVKyf7G+Z
+wVhq5a++gPBNpGQS072Z6SEIpC8jmYeeulT2DVZhvc8qKr+Uftq5DJPCZ5ybr5XR
+zV9a7oPYB6qKKq21F/W4yhlIuwxxxXhRkJ+DZ8bAsjOgxxbcQfOdQIG5RYIQcH2q
+xs0+tgwYsZZOTzSk41N6DLs5iOzM6qtbcDaLXlpSEsc6G3/e+MUQUbH3QFpfOCO4
+Nx6DcQLcrQC7lOHFfoucTDkpZraEbWkNipTyfOq55xMW6k8UYMgWZcmfK1zlNKDw
+AcTm32wMzp4rScRHok4s7zQAid3b6ZaW0h47V2D5EKCeQVtiHI4jAgMBAAGjQjBA
+MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFIFAz7DgRrwgwfcAmNlMr9q02WO7
+MA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAM0+3n5/7sW/pnur9
+cNZjUij2NQspCZEkv5Xq5kxbeOKQsKt7EFaludxyNkvXsmpuJ2p18RdLYmu2mkkF
+i7zDrtuDpdjpbsGLsrsokwj0Wt7lmIuSqGro4QD3xfST01bBF2h5Hh/DZl0UI4qG
+mZAWNgmZndxDTnKdlTqb28phXuOPL6vSTGzveDmwEXpPKcS1JbrQOEseZTOHMYuV
+lLva3ufHTkOLCkU1YJTr9rex+R+h9+2b0H2JDAgRvgKZ55smUhJ3nUPueX73A88T
+wBGpbi7Lh3H9PoowJ+5/S2WUJ5X88psNl3xXJNoZDAoWCUu+0ZvcJpbylfLz0ISQ
+aMPW9g==
+-----END CERTIFICATE-----`
+
+func TestParseCertPEM_ToleratesNegativeSerialNumber(t *testing.T) {
+	block, _ := pem.Decode([]byte(negativeSerialCertPEM))
+	require.NotNil(t, block)
+	wantSum := sha256.Sum256(block.Bytes)
+
+	cert, err := keymanager.ParseCertPEM(negativeSerialCertPEM)
+	require.NoError(t, err)
+	require.Equal(t, "www.mosip.io (OIDC_PARTNER_RSA_2048)", cert.Subject.CommonName)
+
+	// Raw must be exactly the original uploaded bytes — thumbprinting
+	// (sha256 of Raw) and stored certificate_data both depend on this, and
+	// must match what a Java peer computes from the same bytes.
+	gotSum := sha256.Sum256(cert.Raw)
+	require.Equal(t, wantSum, gotSum, "cert.Raw must equal the original DER, not a re-encoded copy")
+}

--- a/esignet-service/internal/keymanager/certparse_test.go
+++ b/esignet-service/internal/keymanager/certparse_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/cryptobyte"
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 
 	"github.com/mosip/esignet/internal/keymanager"
 )
@@ -55,4 +57,23 @@ func TestParseCertPEM_ToleratesNegativeSerialNumber(t *testing.T) {
 	// must match what a Java peer computes from the same bytes.
 	gotSum := sha256.Sum256(cert.Raw)
 	require.Equal(t, wantSum, gotSum, "cert.Raw must equal the original DER, not a re-encoded copy")
+
+	// RawTBSCertificate must be the original signed bytes (with the
+	// unpadded serial), not the re-encoded ones — CheckSignatureFrom hashes
+	// RawTBSCertificate, and it must match what the CA actually signed.
+	wantTBS := extractTBSCertificateForTest(t, block.Bytes)
+	require.Equal(t, wantTBS, cert.RawTBSCertificate, "RawTBSCertificate must equal the original TBSCertificate DER, not a re-encoded copy")
+}
+
+// extractTBSCertificateForTest independently extracts the tbsCertificate
+// SEQUENCE's raw DER bytes from a certificate, mirroring what a correct
+// implementation must preserve after re-encoding the serial number.
+func extractTBSCertificateForTest(t *testing.T, der []byte) []byte {
+	t.Helper()
+	input := cryptobyte.String(der)
+	var certSeq cryptobyte.String
+	require.True(t, input.ReadASN1(&certSeq, cryptobyte_asn1.SEQUENCE))
+	var tbs cryptobyte.String
+	require.True(t, certSeq.ReadASN1Element(&tbs, cryptobyte_asn1.SEQUENCE))
+	return tbs
 }

--- a/esignet-service/internal/keymanager/service.go
+++ b/esignet-service/internal/keymanager/service.go
@@ -1161,9 +1161,9 @@ func encodePEM(tag string, der []byte) string {
 func parseCertPEM(data string) (*x509.Certificate, error) {
 	block, _ := pem.Decode([]byte(data))
 	if block == nil {
-		return x509.ParseCertificate([]byte(data)) // tolerate raw DER too
+		return parseCertificateTolerant([]byte(data)) // tolerate raw DER too
 	}
-	return x509.ParseCertificate(block.Bytes)
+	return parseCertificateTolerant(block.Bytes)
 }
 
 // ParseCertPEM is the exported form of parseCertPEM, for cryptomanager's


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate processing to accept certificates with negative-encoded serial numbers.
  * Preserved the original certificate bytes, ensuring consistent certificate fingerprints.
  * Continued returning clear parsing errors for malformed certificates.

* **Tests**
  * Added regression coverage for partner certificates using negative ASN.1 serial numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->