### PR TITLE
Add DEFAULT_LANG env variable support and Fixed captcha widget design.

### DIFF
--- a/oidc-ui/public/theme/variables.css
+++ b/oidc-ui/public/theme/variables.css
@@ -1,6 +1,7 @@
 /* Default theme variables */
 :root {
   --primary-color: var(--thunderid-color-primary-main);
+  --secondary-color: var(--thunderid-color-secondary-main);
   --login-card-box-color: #bcc0c7;
   --login-card-box-hover-color: var(--primary-color);
   --login-card-box-focus-color: var(--primary-color);
@@ -162,6 +163,7 @@
   --no-record-banner-color: var(--primary-color);
   --no-record-banner-padding: 1em 1.5em;
   --selected_login_id_border_color: var(--primary-color);
+  --login_id_label_color: var(--secondary-color);
   --selected_login_id_color: var(--primary-color);
   --login_id_hover_border_color: var(--primary-color);
   --login_id_hover_color: var(--primary-color);

--- a/oidc-ui/src/App.css
+++ b/oidc-ui/src/App.css
@@ -220,9 +220,10 @@ input[type="password"]::-ms-clear {
     background-color: white !important;
   }
 
-  /* size of icon in ACR selection button */
+  /* size of icon in ACR selection and Multiple LoginID Types button */
   & .thunderid-button__start-icon > img {
     width: 24px !important;
+    height: auto !important;
   }
 }
 
@@ -242,12 +243,21 @@ input[type="password"]::-ms-clear {
 /* login ID button styles */
 .login-id-button {
   white-space: normal !important;
+  padding: 0.5rem !important;
+  color: var(--login_id_label_color) !important;
+  font-size: 0.875rem !important;
 }
 
 /* login ID button active state */
 .login-id-button--active {
   border-color: var(--primary-color) !important;
   color: var(--primary-color) !important;
+}
+
+/* center the Captcha Widget */
+.captcha-renderer {
+  display: flex;
+  justify-content: center;
 }
 
 /* Workaround: center consent timer text */

--- a/oidc-ui/src/main.tsx
+++ b/oidc-ui/src/main.tsx
@@ -17,7 +17,11 @@ const applicationId = searchParams.get("applicationId");
 // ui_locales (OIDC) is a space-separated, preference-ordered locale list; take
 // the most preferred one and let the backend fall back to English if unsupported.
 const uiLocales = searchParams.get("ui_locales");
-const initialLanguage = uiLocales?.trim().split(/\s+/)[0] || undefined;
+const uiLocalesLanguage = uiLocales?.trim().split(/\s+/)[0] || undefined;
+
+// Fallback to DEFAULT_LANG environment variable if ui_locales is not provided or empty.
+const defaultLanguage = (window as any)._env_?.DEFAULT_LANG || undefined;
+const initialLanguage = uiLocalesLanguage || defaultLanguage || undefined;
 
 const baseUrlRaw = import.meta.env.DEV
   ? import.meta.env.VITE_API_URL


### PR DESCRIPTION
**Related Issue**:

- #2280 - Captcha Widget Design Issue.
- #2325 - Multi Login ID Types Button design.
- #2313 - DEFAULT_LANG not supported issue.

**Fixes**: 
- Captcha Widget now renders in the center.
- The button design is resolved.
- If `ui_locales` is not passed, then default language of the application will be the value of `DEFAULT_LANG` env.

**Attaching Screenshot**:
<img width="1913" height="1018" alt="image" src="https://github.com/user-attachments/assets/81ccc668-23a4-425f-9ab4-2d6a3c8f197b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Improved styling for Login ID selection buttons, including spacing, color, and font sizing.
  * Centered the Captcha widget for a more consistent layout.
  * Updated ACR selection guidance to support multiple Login ID types.
  * Added configurable theme colors for secondary elements and Login ID labels.

* **Bug Fixes**
  * Improved language selection by correctly handling the first requested locale.
  * Added a fallback language when no locale is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->