### PR TITLE
fix: 2380 convert esignet chart extraEnvVars/extraEnvVarsAdditional to maps

### DIFF
--- a/deploy/esignet-with-plugins/install.sh
+++ b/deploy/esignet-with-plugins/install.sh
@@ -91,8 +91,7 @@ function installing_esignet_with_plugins() {
     pkcs12_env_file=$(mktemp)
     cat <<EOF > "$pkcs12_env_file"
 extraEnvVarsAdditional:
-  - name: MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE-TYPE
-    value: "PKCS12"
+  MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE-TYPE: "PKCS12"
 EOF
 
     PVC_CLAIM_NAME='esignet-pkcs12'
@@ -154,10 +153,10 @@ EOF
           read -p "Default (${urls[$key]}) - Provide custom value (if applicable) to override the default url: " user_input
         fi
         value="${user_input:-${urls[$key]}}"
-        extra_env_vars_additional+="  - name: \"$key\""$'\n'"    value: \"$value\""$'\n'
+        extra_env_vars_additional+="  \"$key\": \"$value\""$'\n'
       done
       # MOSIP_LICENSE_KEY references the existing esignet-misp-onboarder-key secret
-      extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_MISP_KEY\""$'\n'
+      extra_env_vars_additional+="  MOSIP_ESIGNET_MISP_KEY:"$'\n'
       extra_env_vars_additional+="    valueFrom:"$'\n'
       extra_env_vars_additional+="      secretKeyRef:"$'\n'
       extra_env_vars_additional+="        name: esignet-misp-onboarder-key"$'\n'
@@ -167,12 +166,12 @@ EOF
     elif [[ "$plugin_no" == "3" ]]; then
       plugin_name="sunbird-rc-plugin"
       read -p "Provide the URL for Sunbird registry: " sunbird_registry_url
-      extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL\""$'\n'"    value: \"$sunbird_registry_url\""$'\n'
-      extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL\""$'\n'"    value: \"$sunbird_registry_url/api/v1/Insurance/search\""$'\n'
-      extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_INTEGRATION_AUDIT_PLUGIN\""$'\n'"    value: \"LoggerAuditService\""$'\n'
-      extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_INTEGRATION_KEY_BINDER\""$'\n'"    value: \"NoOpKeyBinder\""$'\n'
-      extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_AUTHENTICATOR_DEFAULT_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD\""$'\n'"    value: \"\${mosip.esignet.authenticator.sunbird-rc.auth-factor.kbi.individual-id-field}\""$'\n'
-      extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_AUTHENTICATOR_DEFAULT_AUTH_FACTOR_KBI_FIELD_DETAILS\""$'\n'"    value: \"\${mosip.esignet.authenticator.sunbird-rc.auth-factor.kbi.field-details}\""$'\n'
+      extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL\": \"$sunbird_registry_url\""$'\n'
+      extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL\": \"$sunbird_registry_url/api/v1/Insurance/search\""$'\n'
+      extra_env_vars_additional+="  \"MOSIP_ESIGNET_INTEGRATION_AUDIT_PLUGIN\": \"LoggerAuditService\""$'\n'
+      extra_env_vars_additional+="  \"MOSIP_ESIGNET_INTEGRATION_KEY_BINDER\": \"NoOpKeyBinder\""$'\n'
+      extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_DEFAULT_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD\": \"\${mosip.esignet.authenticator.sunbird-rc.auth-factor.kbi.individual-id-field}\""$'\n'
+      extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_DEFAULT_AUTH_FACTOR_KBI_FIELD_DETAILS\": \"\${mosip.esignet.authenticator.sunbird-rc.auth-factor.kbi.field-details}\""$'\n'
       break
     else
       echo "Please provide the correct plugin number (1, 2, or 3)."
@@ -181,16 +180,14 @@ EOF
   done
 
   if kubectl get secret esignet-captcha -n "$NS" &>/dev/null; then
-    extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_CAPTCHA_SITE_KEY\""$'\n'
+    extra_env_vars_additional+="  MOSIP_ESIGNET_CAPTCHA_SITE_KEY:"$'\n'
     extra_env_vars_additional+="    valueFrom:"$'\n'
     extra_env_vars_additional+="      secretKeyRef:"$'\n'
     extra_env_vars_additional+="        name: esignet-captcha"$'\n'
     extra_env_vars_additional+="        key: esignet-captcha-site-key"$'\n'
   else
-    extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_CAPTCHA_REQUIRED\""$'\n'
-    extra_env_vars_additional+="    value: \"\""$'\n'
-    extra_env_vars_additional+="  - name: \"MOSIP_ESIGNET_CAPTCHA_SITE-KEY\""$'\n'
-    extra_env_vars_additional+="    value: \"\""$'\n'
+    extra_env_vars_additional+="  MOSIP_ESIGNET_CAPTCHA_REQUIRED: \"\""$'\n'
+    extra_env_vars_additional+="  \"MOSIP_ESIGNET_CAPTCHA_SITE-KEY\": \"\""$'\n'
   fi
 
 

--- a/deploy/esignet/install.sh
+++ b/deploy/esignet/install.sh
@@ -102,7 +102,7 @@ function installing_esignet() {
             --set persistence.mountDir=\"$volume_mount_path\" \
             --set persistence.pvc_claim_name=\"$PVC_CLAIM_NAME\"  \
             --set extraEnvVarsCM={'esignet-global','config-server-share','artifactory-share'} \
-            --set extraEnvVarsAdditional.MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE-TYPE="PKCS12" \
+            --set extraEnvVarsAdditional.MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE-TYPE=PKCS12 \
             "
   fi
   echo "ESIGNET HELM ARGS $ESIGNET_HELM_ARGS"

--- a/deploy/esignet/install.sh
+++ b/deploy/esignet/install.sh
@@ -102,8 +102,7 @@ function installing_esignet() {
             --set persistence.mountDir=\"$volume_mount_path\" \
             --set persistence.pvc_claim_name=\"$PVC_CLAIM_NAME\"  \
             --set extraEnvVarsCM={'esignet-global','config-server-share','artifactory-share'} \
-            --set extraEnvVarsAdditional[0].name="MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE-TYPE" \
-            --set extraEnvVarsAdditional[0].value="PKCS12" \
+            --set extraEnvVarsAdditional.MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE-TYPE="PKCS12" \
             "
   fi
   echo "ESIGNET HELM ARGS $ESIGNET_HELM_ARGS"

--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -116,11 +116,21 @@ spec:
             - name: active_profile_env
               value: {{ .Values.activeProfileEnv }}
             {{- end}}
-            {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- range $key, $val := .Values.extraEnvVars }}
+            - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- include "common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+              {{- else }}
+              value: {{ $val | quote }}
+              {{- end }}
             {{- end }}
-            {{- if .Values.extraEnvVarsAdditional }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsAdditional "context" $) | nindent 12 }}
+            {{- range $key, $val := .Values.extraEnvVarsAdditional }}
+            - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- include "common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+              {{- else }}
+              value: {{ $val | quote }}
+              {{- end }}
             {{- end }}
             {{- range $key, $val := .Values.domainConfig }}
             - name: {{ $key }}

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -234,132 +234,124 @@ customReadinessProbe: {}
 updateStrategy:
   type: RollingUpdate
 
-## Additional environment variables to set
+## Additional environment variables to set, keyed by env var name.
 ## Example:
 ## extraEnvVars:
-##   - name: FOO
-##     value: "bar"
+##   FOO: "bar"
+##   BAZ:
+##     valueFrom:
+##       configMapKeyRef:
+##         name: some-configmap
+##         key: some-key
 ##
 
-extraEnvVars: |
-  - name: KEYCLOAK_EXTERNAL_URL
+extraEnvVars:
+  KEYCLOAK_EXTERNAL_URL:
     valueFrom:
       configMapKeyRef:
         name: keycloak-host
         key: keycloak-external-url
-  - name: MOSIP_ESIGNET_AUTHN_PROVIDER
-    value: mosip
-  - name: MOSIP_API_INTERNAL_HOST
+  MOSIP_ESIGNET_AUTHN_PROVIDER: mosip
+  MOSIP_API_INTERNAL_HOST:
     valueFrom:
       configMapKeyRef:
         name: esignet-global
         key: mosip-api-internal-host
-  - name: MOSIP_ESIGNET_OIDC_UI_SCHEME
-    value: https
-  - name: MOSIP_ESIGNET_OIDC_UI_HOSTNAME
+  MOSIP_ESIGNET_OIDC_UI_SCHEME: https
+  MOSIP_ESIGNET_OIDC_UI_HOSTNAME:
     valueFrom:
       configMapKeyRef:
         name: esignet-global
         key: mosip-esignet-host
-  - name: MOSIP_ESIGNET_OIDC_UI_PORT
-    value: '443'
-  - name: MOSIP_ESIGNET_OIDC_UI_LOGIN_PATH
-    value: /signin
-  - name: MOSIP_ESIGNET_OIDC_UI_ERROR_PATH
-    value: /error
-  - name: KEYMANAGER_DB_SCHEMA
-    value: esignet
-  - name: KEYMANAGER_KEYSTORE_TYPE
-    value: PKCS11
-  - name: KEYMANAGER_PKCS11_MODULE_PATH
-    value: /usr/local/lib/softhsm/libpkcs11-proxy.so
-  - name: KEYMANAGER_PKCS11_TOKEN_LABEL
-    value: pkcs11-proxy
-  - name: KEYMANAGER_PKCS11_SLOT_ID
-    value: "0"
-  - name: KEYMANAGER_PKCS11_PIN
+  MOSIP_ESIGNET_OIDC_UI_PORT: '443'
+  MOSIP_ESIGNET_OIDC_UI_LOGIN_PATH: /signin
+  MOSIP_ESIGNET_OIDC_UI_ERROR_PATH: /error
+  KEYMANAGER_DB_SCHEMA: esignet
+  KEYMANAGER_KEYSTORE_TYPE: PKCS11
+  KEYMANAGER_PKCS11_MODULE_PATH: /usr/local/lib/softhsm/libpkcs11-proxy.so
+  KEYMANAGER_PKCS11_TOKEN_LABEL: pkcs11-proxy
+  KEYMANAGER_PKCS11_SLOT_ID: "0"
+  KEYMANAGER_PKCS11_PIN:
     valueFrom:
       secretKeyRef:
         name: esignet-softhsm
         key: security-pin
-  # PKCS12 (file-based) alternative to the PKCS11 block above; requires a CGO_ENABLED=0 build.
-  #  - name: KEYMANAGER_KEYSTORE_TYPE
-  #    value: PKCS12
-  #  - name: KEYMANAGER_PKCS12_FILE_PATH
-  #    value: /home/mosip/keys/secret/esignet.pfx
-  #  - name: KEYMANAGER_PKCS12_PASSWORD
-  #    valueFrom:
-  #      secretKeyRef:
-  #        name: esignet-keymanager
-  #        key: pkcs12-password
-  - name: REDIS_HOST
+  # PKCS12 (file-based) alternative to the PKCS11 keys above; requires a CGO_ENABLED=0 build.
+  # KEYMANAGER_KEYSTORE_TYPE: PKCS12
+  # KEYMANAGER_PKCS12_FILE_PATH: /home/mosip/keys/secret/esignet.pfx
+  # KEYMANAGER_PKCS12_PASSWORD:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: esignet-keymanager
+  #       key: pkcs12-password
+  REDIS_HOST:
     valueFrom:
       configMapKeyRef:
         name: redis-config
         key: redis-host
-  - name: REDIS_PORT
+  REDIS_PORT:
     valueFrom:
       configMapKeyRef:
         name: redis-config
         key: redis-port
-  - name: REDIS_PASSWORD
+  REDIS_PASSWORD:
     valueFrom:
       secretKeyRef:
         name: redis
         key: redis-password
-  - name: DATABASE_HOST
+  DATABASE_HOST:
     valueFrom:
       configMapKeyRef:
         name: postgres-config
         key: database-host
-  - name: DATABASE_PORT
+  DATABASE_PORT:
     valueFrom:
       configMapKeyRef:
         name: postgres-config
         key: database-port
-  - name: DATABASE_NAME
+  DATABASE_NAME:
     valueFrom:
       configMapKeyRef:
         name: postgres-config
         key: database-name
-  - name: DATABASE_USERNAME
+  DATABASE_USERNAME:
     valueFrom:
       configMapKeyRef:
         name: postgres-config
         key: database-username
-  - name: DB_DBUSER_PASSWORD
+  DB_DBUSER_PASSWORD:
     valueFrom:
       secretKeyRef:
         name: db-common-secrets
         key: db-dbuser-password
-  - name: SOFTHSM_ESIGNET_SECURITY_PIN
+  SOFTHSM_ESIGNET_SECURITY_PIN:
     valueFrom:
       secretKeyRef:
         name: esignet-softhsm
         key: security-pin
-  - name: MOSIP_ESIGNET_HOST
+  MOSIP_ESIGNET_HOST:
     valueFrom:
       configMapKeyRef:
         name: esignet-global
         key: mosip-esignet-host
-  - name: MOSIP_SIGNUP_HOST
+  MOSIP_SIGNUP_HOST:
     valueFrom:
       configMapKeyRef:
         name: esignet-global
         key: mosip-signup-host
-  - name: MOSIP_IDA_CLIENT_SECRET
+  MOSIP_IDA_CLIENT_SECRET:
     valueFrom:
       secretKeyRef:
         name: keycloak-client-secrets
         key: mosip_ida_client_secret
 
-#  - name: MOSIP_ESIGNET_MISP_KEY
-#    valueFrom:
-#      secretKeyRef:
-#        name: esignet-misp-onboarder-key
-#        key: mosip-esignet-misp-key
+  # MOSIP_ESIGNET_MISP_KEY:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: esignet-misp-onboarder-key
+  #       key: mosip-esignet-misp-key
 
-extraEnvVarsAdditional: []
+extraEnvVarsAdditional: {}
 
 ## ConfigMap with extra environment variables that used
 ##


### PR DESCRIPTION
## Summary
- Fixes #2380
- Converts `helm/esignet` chart's `extraEnvVars` and `extraEnvVarsAdditional` values from
  YAML lists to native YAML maps (keyed by env var name), and updates
  `templates/deployment.yaml` to render them with a `range $key, $val :=` loop that
  auto-detects a plain scalar (→ `value:`) vs. a `valueFrom` map (→ passed through
  `common.tplvalues.render`), matching the existing `domainConfig` map's rendering style in
  the same template.
- Root cause: Helm deep-merges map keys across values layers but replaces lists wholesale,
  so any downstream values file overriding even one entry of `extraEnvVars` had to
  re-declare the full ~26-entry list from scratch. This has been the source of repeated
  drift between the chart's defaults and downstream overrides.
- Chart-only change; the same list pattern exists in a few other MOSIP charts
  (`config-server`, `mock-identity-system`, `mock-relying-party-service`) but converting
  those is out of scope for this PR.

## Test plan
- [x] `helm lint helm/esignet` passes.
- [x] `helm template` rendered `env:` block compared before/after (list vs. map values.yaml)
      for all 26 real `extraEnvVars` entries plus the 4 static env vars — every name,
      `value`, and `valueFrom` ref matches exactly (only cosmetic diff: values are now
      explicitly quoted, e.g. `value: "mosip"` vs. previously unquoted `value: mosip`).
- [x] Verified against the current `develop-go` tip content (including the recent
      `MOSIP_ESIGNET_AUTHN_PROVIDER`/`MOSIP_ESIGNET_OIDC_UI_*` renames and the
      `pkcs11-proxy` PKCS11 module path/token label).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart environment variables can now be configured using a simpler keyed YAML map.
  * Supports both direct values and references to ConfigMaps or Secrets.
  * Additional environment variables can be supplied using the same map format.
  * Deployment scripts now use the updated map-based configuration for PKCS12, plugin, MISP, and CAPTCHA settings.

* **Breaking Changes**
  * Update existing `extraEnvVars` configurations from list-style YAML to keyed map syntax.
  * Change `extraEnvVarsAdditional` from an empty list (`[]`) to an empty map (`{}`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->