### PR TITLE
fix: 2369 make GOMAXPROCS container-aware, add optional GOMEMLIMIT

### DIFF
--- a/helm/esignet/templates/_helpers.tpl
+++ b/helm/esignet/templates/_helpers.tpl
@@ -20,6 +20,35 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+Return GOMEMLIMIT for the Go esignet-service binary.
+Uses additionalResources.goMemLimit verbatim if explicitly set. Otherwise derives
+~90% of resources.limits.memory on every render, so it can never go stale when the
+memory limit changes. Only Ki/Mi/Gi/Ti suffixes (or unitless bytes) are supported
+for auto-derivation, matching every memory value used across this chart's values
+files; anything else requires an explicit additionalResources.goMemLimit override.
+Returns "" if neither is set/derivable, meaning GOMEMLIMIT is omitted.
+*/}}
+{{- define "esignet.goMemLimit" -}}
+{{- $limits := (.Values.resources | default dict).limits | default dict -}}
+{{- if .Values.additionalResources.goMemLimit -}}
+{{- .Values.additionalResources.goMemLimit -}}
+{{- else if $limits.memory -}}
+{{- $mem := $limits.memory | toString -}}
+{{- $num := regexFind "^[0-9]+" $mem -}}
+{{- $unit := regexFind "[A-Za-z]+$" $mem -}}
+{{- if and $num (or (eq $unit "Ki") (eq $unit "Mi") (eq $unit "Gi") (eq $unit "Ti") (eq $unit "")) -}}
+{{- $suffix := "" -}}
+{{- if $unit -}}
+{{- $suffix = printf "%sB" $unit -}}
+{{- end -}}
+{{- printf "%d%s" (div (mul (atoi $num) 9) 10) $suffix -}}
+{{- else -}}
+{{- fail (printf "additionalResources.goMemLimit: cannot auto-derive GOMEMLIMIT from resources.limits.memory %q (unsupported unit %q); set additionalResources.goMemLimit explicitly instead, e.g. \"2025MiB\"" $mem $unit) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "esignet.serviceAccountName" -}}

--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -102,12 +102,8 @@ spec:
             - name: GOMEMLIMIT
               value: {{ .Values.additionalResources.goMemLimit | quote }}
             {{- end }}
-            {{- if .Values.additionalResources.javaOpts }}
             - name: SPRING_KAFKA_CONSUMER_GROUP_ID
               value: esignet-consumer-{{ .Release.Namespace }} # Using the namespace dynamically
-            - name: JDK_JAVA_OPTIONS
-              value: {{ .Values.additionalResources.javaOpts }}
-            {{- end }}
             {{- if .Values.springConfigNameEnv }}
             - name: spring_config_name_env
               value: {{ .Values.springConfigNameEnv }}

--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -98,9 +98,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-            {{- if .Values.additionalResources.goMemLimit }}
+            {{- $goMemLimit := include "esignet.goMemLimit" . }}
+            {{- if $goMemLimit }}
             - name: GOMEMLIMIT
-              value: {{ .Values.additionalResources.goMemLimit | quote }}
+              value: {{ $goMemLimit | quote }}
             {{- end }}
             - name: SPRING_KAFKA_CONSUMER_GROUP_ID
               value: esignet-consumer-{{ .Release.Namespace }} # Using the namespace dynamically

--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -94,6 +94,14 @@ spec:
           env:
             - name: container_user
               value: {{ .Values.containerSecurityContext.runAsUser }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            {{- if .Values.additionalResources.goMemLimit }}
+            - name: GOMEMLIMIT
+              value: {{ .Values.additionalResources.goMemLimit | quote }}
+            {{- end }}
             {{- if .Values.additionalResources.javaOpts }}
             - name: SPRING_KAFKA_CONSUMER_GROUP_ID
               value: esignet-consumer-{{ .Release.Namespace }} # Using the namespace dynamically

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -133,9 +133,6 @@ resources:
     memory: 1500Mi
 
 additionalResources:
-  ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources
-  ## Example: java_opts: "-Xms500M -Xmx500M"
-  javaOpts: "-Xms1500M -Xmx1500M"
   ## GOMEMLIMIT for the Go esignet-service binary. Should track resources.limits.memory
   ## above, set to ~90% of it to leave headroom for non-Go/GC overhead. Set to "" to
   ## disable (GOMAXPROCS above is always set, container-aware, independent of this).

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -136,6 +136,10 @@ additionalResources:
   ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources
   ## Example: java_opts: "-Xms500M -Xmx500M"
   javaOpts: "-Xms1500M -Xmx1500M"
+  ## GOMEMLIMIT for the Go esignet-service binary. Should track resources.limits.memory
+  ## above, set to ~90% of it to leave headroom for non-Go/GC overhead. Set to "" to
+  ## disable (GOMAXPROCS above is always set, container-aware, independent of this).
+  goMemLimit: "2025MiB"
 
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## Clamav container already runs as 'mosip' user, so we may not need to enable this

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -133,10 +133,12 @@ resources:
     memory: 1500Mi
 
 additionalResources:
-  ## GOMEMLIMIT for the Go esignet-service binary. Should track resources.limits.memory
-  ## above, set to ~90% of it to leave headroom for non-Go/GC overhead. Set to "" to
-  ## disable (GOMAXPROCS above is always set, container-aware, independent of this).
-  goMemLimit: "2025MiB"
+  ## GOMEMLIMIT for the Go esignet-service binary. Leave empty ("") to auto-derive
+  ## ~90% of resources.limits.memory above on every render, so it never goes stale if
+  ## you change the memory limit. Set explicitly (e.g. "2025MiB") to override the 90%
+  ## default, or if resources.limits.memory uses a unit auto-derivation can't parse
+  ## (only Ki/Mi/Gi/Ti and unitless bytes are supported).
+  goMemLimit: ""
 
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## Clamav container already runs as 'mosip' user, so we may not need to enable this


### PR DESCRIPTION
## Summary
- Fixes #2369
- Helm-only change (Option B from the issue): sets `GOMAXPROCS` via the Kubernetes downward
  API (`valueFrom.resourceFieldRef` on `limits.cpu`) so the Go runtime always sees the pod's
  actual CPU limit instead of the node's full core count. When no CPU limit is configured,
  this falls back to node capacity — same behavior as today, so no regression either way.
- Adds `GOMEMLIMIT`, auto-derived as ~90% of `resources.limits.memory` via a new
  `esignet.goMemLimit` template helper (`_helpers.tpl`), recomputed on every render so it
  can never go stale if the memory limit changes — including the dangerous case where a
  memory limit *decrease* isn't matched by a manual update, which would otherwise leave
  `GOMEMLIMIT` above the actual pod limit and defeat its purpose. An explicit
  `additionalResources.goMemLimit` value still overrides the derived default; if
  `resources.limits.memory` uses a unit the helper can't parse (only Ki/Mi/Gi/Ti and
  unitless bytes are supported — the only units used anywhere in this chart today), the
  render fails with a clear message instead of silently producing a wrong value.
- Removes `additionalResources.javaOpts` and the `JDK_JAVA_OPTIONS` env var it drove.
  `esignet-service` is a plain Go binary — no JVM in the container, no `java`/`jdk` anywhere
  in the `Dockerfile` — so this was dead config left over from the original Java-based chart.
  `SPRING_KAFKA_CONSUMER_GROUP_ID` (previously gated behind the same `javaOpts` toggle) stays,
  since Kafka remains an external platform dependency, and is now set unconditionally instead.

## Test plan
- [x] `helm lint helm/esignet` passes.
- [x] `helm template` renders `GOMAXPROCS`/`GOMEMLIMIT`/`SPRING_KAFKA_CONSUMER_GROUP_ID`
      correctly under the chart defaults, with `JDK_JAVA_OPTIONS` gone.
- [x] `kubectl apply --dry-run=client` against the full rendered manifest validates the
      `resourceFieldRef` shape.
- [x] `esignet.goMemLimit` helper tested against: chart defaults (2250Mi → 2025MiB), an
      overridden memory limit (4096Mi → 3686MiB, proving it no longer goes stale), an
      explicit `additionalResources.goMemLimit` override (still respected), a genuinely
      absent memory limit (`resources.limits.memory: null` → `GOMEMLIMIT` cleanly omitted,
      no error), and an unsupported unit (`2000M` → render fails with a clear message).
- [x] Confirmed no remaining `javaOpts`/`JDK_JAVA_OPTIONS` references in `helm/esignet`
      (a separate, unrelated `javaOpts` in `helm/oidc-ui` — a different chart/service — is
      untouched, out of scope for this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Go runtime resource management by aligning CPU usage with the container’s CPU limit.
  * Added optional memory limit configuration to help optimize application memory usage.
* **Configuration**
  * `GOMEMLIMIT` is now auto-derived from the configured memory limit (~90%), staying in
    sync automatically instead of relying on a hand-maintained value.
  * Removed unused JVM-oriented `JDK_JAVA_OPTIONS` configuration; the Kafka consumer group ID
    setting is now always applied instead of being conditional on it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->