### PR TITLE
Add pod-local pprof debug endpoint on 127.0.0.1:6060 (#2375)

### DIFF
--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -87,6 +87,7 @@ func main() {
 		}()
 		logger.Info(context.Background(), "redis connected",
 			applog.String("key_prefix", appCfg.Redis.KeyPrefix),
+			applog.String("connMaxLifetime", appCfg.Redis.ConnMaxLifetime.String()),
 		)
 	}
 

--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -9,8 +9,10 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -168,6 +170,10 @@ func main() {
 		thunderidengine.WithRuntimeCryptoProvider(engine.NewRuntimeCryptoProvider(appCfg, keyMgrSvc, sigSvc, cryptoSvc)),
 	)
 
+	if appCfg.PprofEnabled {
+		go startDebugServer(logger, newPoolConfigHandler(pgConn, appCfg))
+	}
+
 	addr := fmt.Sprintf(":%d", appCfg.Port)
 	handler := httpmiddleware.CorrelationID(httpmiddleware.AccessLog(mux))
 	srv := &http.Server{
@@ -234,6 +240,56 @@ func startMetricsServer(appCfg *config.AppConfig, logger *applog.Logger) *http.S
 		}
 	}()
 	return metricsSrv
+}
+
+func startDebugServer(logger *applog.Logger, poolConfigHandler http.Handler) {
+	const addr = "127.0.0.1:6060"
+	logger.Info(context.Background(), "starting debug pprof server", applog.String("addr", addr))
+	if err := http.ListenAndServe(addr, newDebugMux(poolConfigHandler)); err != nil {
+		logger.Warn(context.Background(), "debug pprof server stopped", applog.Error(err))
+	}
+}
+
+// dbStatter is the subset of *sql.DB used by newPoolConfigHandler; extracted
+// so the handler can be exercised in tests without a live database connection.
+type dbStatter interface {
+	Stats() sql.DBStats
+}
+
+// newPoolConfigHandler returns an HTTP handler that writes a JSON snapshot of
+// DB and Redis connection pool configuration and live counters.
+func newPoolConfigHandler(db dbStatter, appCfg *config.AppConfig) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		stats := db.Stats()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"db":{"connMaxLifetime":%q,"maxOpenConns":%d,"maxIdleConns":%d,"openConns":%d,"inUse":%d,"idle":%d},"redis":{"connMaxLifetime":%q,"enabled":%v}}`,
+			(time.Duration(appCfg.DB.Pool.ConnMaxLifetimeSecs)*time.Second).String(),
+			appCfg.DB.Pool.MaxOpenConns,
+			appCfg.DB.Pool.MaxIdleConns,
+			stats.OpenConnections,
+			stats.InUse,
+			stats.Idle,
+			appCfg.Redis.ConnMaxLifetime.String(),
+			appCfg.RuntimeDBType == "redis",
+		)
+	})
+}
+
+// newDebugMux builds the debug ServeMux with all pprof routes and
+// /debug/pool-config. Separated from startDebugServer so it can be
+// exercised in tests without binding a port.
+func newDebugMux(poolConfigHandler http.Handler) *http.ServeMux {
+	dbg := http.NewServeMux()
+	dbg.HandleFunc("/debug/pprof/", pprof.Index)
+	dbg.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	dbg.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	dbg.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	dbg.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	dbg.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	dbg.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	dbg.Handle("GET /debug/pool-config", poolConfigHandler)
+	return dbg
 }
 
 func getAppConfig() (*config.AppConfig, error) {

--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -265,7 +265,7 @@ func newPoolConfigHandler(db dbStatter, appCfg *config.AppConfig) http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprintf(w,
 			`{"db":{"connMaxLifetime":%q,"maxOpenConns":%d,"maxIdleConns":%d,"openConns":%d,"inUse":%d,"idle":%d},"redis":{"connMaxLifetime":%q,"enabled":%v}}`,
-			(time.Duration(appCfg.DB.Pool.ConnMaxLifetimeSecs)*time.Second).String(),
+			(time.Duration(appCfg.DB.Pool.ConnMaxLifetimeSecs) * time.Second).String(),
 			appCfg.DB.Pool.MaxOpenConns,
 			appCfg.DB.Pool.MaxIdleConns,
 			stats.OpenConnections,

--- a/esignet-service/cmd/esignet/main_test.go
+++ b/esignet-service/cmd/esignet/main_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -22,6 +23,117 @@ import (
 	applog "github.com/mosip/esignet/internal/log"
 	"github.com/mosip/esignet/internal/metrics"
 )
+
+// fakeDB implements dbStatter with configurable stats for testing.
+type fakeDB struct{ stats sql.DBStats }
+
+func (f fakeDB) Stats() sql.DBStats { return f.stats }
+
+func testHTTPClientConfig() config.HTTPClientConfig {
+	return config.HTTPClientConfig{
+		TimeoutSecs:               30,
+		DialTimeoutSecs:           5,
+		DialKeepAliveSecs:         30,
+		TLSHandshakeTimeoutSecs:   10,
+		ResponseHeaderTimeoutSecs: 10,
+		IdleConnTimeoutSecs:       90,
+		MaxConnsPerHost:           100,
+	}
+}
+
+func (ts *MainTestSuite) TestNewDebugMux() {
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux := newDebugMux(stub)
+
+	paths := []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/heap",
+		"/debug/pprof/symbol",
+		"/debug/pool-config",
+	}
+	for _, p := range paths {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+		ts.Equal(http.StatusOK, rec.Code, "path %s", p)
+	}
+}
+
+func (ts *MainTestSuite) TestNewDebugMux_BoundedProfileAndTrace() {
+	if testing.Short() {
+		ts.T().Skip("skipping blocking CPU/trace endpoints in short mode")
+	}
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux := newDebugMux(stub)
+
+	for _, p := range []string{"/debug/pprof/profile?seconds=1", "/debug/pprof/trace?seconds=1"} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+		ts.Equal(http.StatusOK, rec.Code, "path %s", p)
+	}
+}
+
+func (ts *MainTestSuite) TestPoolConfigHandler() {
+	db := fakeDB{stats: sql.DBStats{OpenConnections: 3, InUse: 1, Idle: 2}}
+	appCfg := &config.AppConfig{RuntimeDBType: "redis"}
+	appCfg.DB.Pool.ConnMaxLifetimeSecs = 1800
+	appCfg.DB.Pool.MaxOpenConns = 25
+	appCfg.DB.Pool.MaxIdleConns = 5
+	appCfg.Redis.ConnMaxLifetime = 30 * time.Minute
+
+	rec := httptest.NewRecorder()
+	newPoolConfigHandler(db, appCfg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pool-config", nil))
+
+	ts.Equal(http.StatusOK, rec.Code)
+	ts.Equal("application/json", rec.Header().Get("Content-Type"))
+	body := rec.Body.String()
+	ts.Contains(body, `"connMaxLifetime":"30m0s"`)
+	ts.Contains(body, `"maxOpenConns":25`)
+	ts.Contains(body, `"maxIdleConns":5`)
+	ts.Contains(body, `"openConns":3`)
+	ts.Contains(body, `"inUse":1`)
+	ts.Contains(body, `"idle":2`)
+	ts.Contains(body, `"enabled":true`)
+}
+
+func (ts *MainTestSuite) TestPoolConfigHandler_RedisDisabled() {
+	rec := httptest.NewRecorder()
+	newPoolConfigHandler(fakeDB{}, &config.AppConfig{RuntimeDBType: "inmemory"}).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pool-config", nil))
+	ts.Contains(rec.Body.String(), `"enabled":false`)
+}
+
+func (ts *MainTestSuite) TestPprofEnabled_DefaultOff() {
+	ts.False((&config.AppConfig{}).PprofEnabled, "pprof must be opt-in; default should be false")
+}
+
+func (ts *MainTestSuite) TestPprofEnabled_MuxReadyWhenEnabled() {
+	appCfg := &config.AppConfig{PprofEnabled: true}
+	mux := newDebugMux(newPoolConfigHandler(fakeDB{}, appCfg))
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	ts.Equal(http.StatusOK, rec.Code)
+}
+
+func (ts *MainTestSuite) TestNewHTTPClient() {
+	cfg := testHTTPClientConfig()
+	c := config.NewHTTPClient(cfg)
+	require.Equal(ts.T(), 30*time.Second, c.Timeout)
+
+	transport, ok := c.Transport.(*http.Transport)
+	require.True(ts.T(), ok)
+	require.Equal(ts.T(), 10*time.Second, transport.TLSHandshakeTimeout)
+	require.Equal(ts.T(), 10*time.Second, transport.ResponseHeaderTimeout)
+	require.Equal(ts.T(), 90*time.Second, transport.IdleConnTimeout)
+	require.Equal(ts.T(), 100, transport.MaxConnsPerHost)
+}
+
+func (ts *MainTestSuite) TestNewHTTPClientReturnsDistinctInstances() {
+	cfg := testHTTPClientConfig()
+	require.NotSame(ts.T(), config.NewHTTPClient(cfg), config.NewHTTPClient(cfg))
+}
 
 func (ts *MainTestSuite) TestGetSecurityMiddleware() {
 	logger := applog.GetLogger()

--- a/esignet-service/internal/config/app.go
+++ b/esignet-service/internal/config/app.go
@@ -109,6 +109,7 @@ type AppConfig struct {
 	InboundHTTPServer          InboundHTTPServerConfig          `yaml:"inbound_http_server"`
 	SupportedSigningAlgorithms []string                         `yaml:"supported_signing_algorithms"`
 	SupportedEncAlgorithms     []string                         `yaml:"supported_enc_algorithms"`
+	PprofEnabled               bool                             `yaml:"-"`
 }
 
 // SecurityConfig defines application security configuration
@@ -184,6 +185,7 @@ func applyDefaults(cfg *AppConfig) {
 	cfg.Issuer = envOrConfigOrDefault("MOSIP_ESIGNET_HOST", cfg.Issuer, fmt.Sprintf("http://localhost:%d", cfg.Port))
 	cfg.DataDir = envOrConfigOrDefault("DATA_DIR", cfg.DataDir, defaultDataDir)
 	cfg.MetricsPort = envIntOrDefault("METRICS_PORT", defaultMetricsPort)
+	cfg.PprofEnabled = envBool("MOSIP_ESIGNET_PPROF_ENABLED")
 	cfg.DB = loadDB(cfg.DB)
 
 	cacheType := envOrConfigOrDefault("MOSIP_ESIGNET_CACHE_TYPE", cfg.RuntimeDBType, "redis")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional performance diagnostics through Go profiling endpoints.
  - Diagnostics are disabled by default and can be enabled with the `MOSIP_ESIGNET_PPROF_ENABLED` setting.
  - When enabled, a local debugging server provides profiling data and database/Redis pool configuration details.
  - Added bounded profiling and tracing endpoints to help prevent long-running diagnostic requests.
  - Startup and shutdown errors for the diagnostic server are now logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->