### PR TITLE
Set connection max-lifetime defaults (DB + Redis)  #2374

### DIFF
--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -93,21 +93,6 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
-	mux.HandleFunc("GET /debug/pool-config", func(w http.ResponseWriter, _ *http.Request) {
-		stats := pgConn.Stats()
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"db":{"connMaxLifetime":%q,"maxOpenConns":%d,"maxIdleConns":%d,"openConns":%d,"inUse":%d,"idle":%d},"redis":{"connMaxLifetime":%q,"enabled":%v}}`,
-			appCfg.DB.Pool.ConnMaxLifetime.String(),
-			appCfg.DB.Pool.MaxOpenConns,
-			appCfg.DB.Pool.MaxIdleConns,
-			stats.OpenConnections,
-			stats.InUse,
-			stats.Idle,
-			appCfg.Redis.ConnMaxLifetime.String(),
-			appCfg.RuntimeDBType == "redis",
-		)
-	})
-
 	// The runtime store is shared between the engine and the consent enforcer (which reads the
 	// engine's stored authorization requests from it), so both resolve the same keys. It's also
 	// used by clientSvc below to cache GetClient lookups.
@@ -115,7 +100,8 @@ func main() {
 
 	clientSvc := clientmgmt.NewService(pgConn, runtimeStore, appCfg.ClientCacheTTLSecs, appCfg.SupportedEncAlgorithms)
 	clientHandler := clientmgmt.NewHandler(clientSvc, logger)
-	clientHandler.RegisterRoutes(mux, getSecurityMiddleware(appCfg, logger))
+	securityMW := getSecurityMiddleware(appCfg, logger)
+	clientHandler.RegisterRoutes(mux, securityMW)
 
 	keyMgrSvc, sigSvc, cryptoSvc, ks, err := initializeKeyManager(sqlxConn)
 	if err != nil {
@@ -131,7 +117,23 @@ func main() {
 	}
 
 	keyMgrHandler := keymanager.NewHandler(keyMgrSvc, logger)
-	keyMgrHandler.RegisterRoutes(mux, getSecurityMiddleware(appCfg, logger))
+	keyMgrHandler.RegisterRoutes(mux, securityMW)
+	mux.Handle("GET /debug/pool-config", securityMW(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		stats := pgConn.Stats()
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"db":{"connMaxLifetime":%q,"maxOpenConns":%d,"maxIdleConns":%d,"openConns":%d,"inUse":%d,"idle":%d},"redis":{"connMaxLifetime":%q,"enabled":%v}}`,
+			appCfg.DB.Pool.ConnMaxLifetime.String(),
+			appCfg.DB.Pool.MaxOpenConns,
+			appCfg.DB.Pool.MaxIdleConns,
+			stats.OpenConnections,
+			stats.InUse,
+			stats.Idle,
+			appCfg.Redis.ConnMaxLifetime.String(),
+			appCfg.RuntimeDBType == "redis",
+		); err != nil {
+			logger.Warn(context.Background(), "write pool-config response", applog.Error(err))
+		}
+	})))
 
 	httpClient := newHTTPClient(appCfg.OutboundHTTPClient)
 

--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -57,7 +57,8 @@ func main() {
 	}
 	logger.Info(context.Background(), "postgres connected",
 		applog.Int("maxOpenConns", appCfg.DB.Pool.MaxOpenConns),
-		applog.Int("maxIdleConns", appCfg.DB.Pool.MaxIdleConns))
+		applog.Int("maxIdleConns", appCfg.DB.Pool.MaxIdleConns),
+		applog.String("connMaxLifetime", appCfg.DB.Pool.ConnMaxLifetime.String()))
 	defer func() {
 		if err := pgConn.Close(); err != nil {
 			logger.Warn(context.Background(), "close postgres", applog.Error(err))
@@ -83,6 +84,7 @@ func main() {
 		}()
 		logger.Info(context.Background(), "redis connected",
 			applog.String("key_prefix", appCfg.Redis.KeyPrefix),
+			applog.String("connMaxLifetime", appCfg.Redis.ConnMaxLifetime.String()),
 		)
 	}
 
@@ -90,6 +92,20 @@ func main() {
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("GET /debug/pool-config", func(w http.ResponseWriter, _ *http.Request) {
+		stats := pgConn.Stats()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"db":{"connMaxLifetime":%q,"maxOpenConns":%d,"maxIdleConns":%d,"openConns":%d,"inUse":%d,"idle":%d},"redis":{"connMaxLifetime":%q,"enabled":%v}}`,
+			appCfg.DB.Pool.ConnMaxLifetime.String(),
+			appCfg.DB.Pool.MaxOpenConns,
+			appCfg.DB.Pool.MaxIdleConns,
+			stats.OpenConnections,
+			stats.InUse,
+			stats.Idle,
+			appCfg.Redis.ConnMaxLifetime.String(),
+			appCfg.RuntimeDBType == "redis",
+		)
 	})
 
 	// The runtime store is shared between the engine and the consent enforcer (which reads the

--- a/esignet-service/internal/config/db.go
+++ b/esignet-service/internal/config/db.go
@@ -24,7 +24,7 @@ const (
 	defaultDBUser                = "postgres"
 	defaultDBMaxOpenConns        = 25
 	defaultDBMaxIdleConns        = 5
-	defaultDBConnMaxLifetimeSecs = 0 // no limit
+	defaultDBConnMaxLifetimeSecs = 1800 // 30 min (Hikari parity)
 	defaultDBConnMaxIdleTimeSecs = 60
 	dbPingTimeout                = 5 * time.Second
 )
@@ -100,7 +100,7 @@ func resolveDBDSN() string {
 //
 //	DB_MAX_OPEN_CONNS         — default 25
 //	DB_MAX_IDLE_CONNS         — default 5
-//	DB_CONN_MAX_LIFETIME_SECS — default 300
+//	DB_CONN_MAX_LIFETIME_SECS — default 1800
 //	DB_CONN_MAX_IDLE_TIME_SECS — default 60
 func loadDB() DB {
 	dsn := resolveDBDSN()
@@ -117,9 +117,8 @@ func loadDB() DB {
 	var lifetime time.Duration
 	if lifetimeSecs > 0 {
 		lifetime = time.Duration(lifetimeSecs) * time.Second
-	} else {
-		lifetime = defaultDBConnMaxLifetimeSecs
 	}
+	// lifetimeSecs == 0 leaves lifetime = 0 (no limit; explicit opt-out)
 	idleSecs := envIntOrDefault("DB_CONN_MAX_IDLE_TIME_SECS", defaultDBConnMaxIdleTimeSecs)
 	var idleTime time.Duration
 	if idleSecs > 0 {

--- a/esignet-service/internal/config/db_test.go
+++ b/esignet-service/internal/config/db_test.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -129,6 +130,12 @@ func TestLoadDB_PoolTuningOverrides(t *testing.T) {
 	require.Equal(t, 10, db.Pool.MaxIdleConns)
 	require.Equal(t, 600, int(db.Pool.ConnMaxLifetime.Seconds()))
 	require.Equal(t, 120, int(db.Pool.ConnMaxIdleTime.Seconds()))
+}
+
+func TestLoadDB_ZeroLifetimeOptOut(t *testing.T) {
+	t.Setenv("DB_CONN_MAX_LIFETIME_SECS", "0")
+	db := loadDB()
+	require.Equal(t, time.Duration(0), db.Pool.ConnMaxLifetime)
 }
 
 func TestLoadDB_NonPositivePoolValuesFallBackToDefaults(t *testing.T) {

--- a/esignet-service/internal/config/redis.go
+++ b/esignet-service/internal/config/redis.go
@@ -25,7 +25,7 @@ const (
 	defaultRedisDialTimeoutSecs     = 5
 	defaultRedisReadTimeoutSecs     = 3
 	defaultRedisWriteTimeoutSecs    = 3
-	defaultRedisConnMaxLifetimeSecs = 0 // no limit
+	defaultRedisConnMaxLifetimeSecs = 1800 // 30 min (Hikari parity)
 	defaultRedisKeyPrefix           = "esignet:"
 	redisPingTimeout                = 5 * time.Second
 	defaultRedisDB                  = 0
@@ -45,7 +45,7 @@ const (
 //	REDIS_POOL_SIZE             — default 10
 //	REDIS_MIN_IDLE_CONNS        — default 2
 //	REDIS_CONN_MAX_IDLE_TIME_SECS — default 300
-//	REDIS_CONN_MAX_LIFETIME_SECS  — default 0 (no limit)
+//	REDIS_CONN_MAX_LIFETIME_SECS  — default 1800
 //	REDIS_DIAL_TIMEOUT_SECS     — default 5
 //	REDIS_READ_TIMEOUT_SECS     — default 3
 //	REDIS_WRITE_TIMEOUT_SECS    — default 3

--- a/esignet-service/internal/config/redis_test.go
+++ b/esignet-service/internal/config/redis_test.go
@@ -81,6 +81,12 @@ func TestLoadRedis_EnvOverrides(t *testing.T) {
 	require.Equal(t, []string{"a:1", "b:2", "c:3"}, r.SentinelAddrs)
 }
 
+func TestLoadRedis_ZeroLifetimeOptOut(t *testing.T) {
+	t.Setenv("REDIS_CONN_MAX_LIFETIME_SECS", "0")
+	r := loadRedis()
+	require.Equal(t, time.Duration(0), r.ConnMaxLifetime)
+}
+
 func TestLoadRedis_NonPositivePoolValuesFallBackToDefaults(t *testing.T) {
 	t.Setenv("REDIS_POOL_SIZE", "0")
 	t.Setenv("REDIS_MIN_IDLE_CONNS", "-1")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic endpoint showing database pool settings, PostgreSQL connection statistics, and Redis connection configuration.
  * Connection logs now include configured connection lifetimes.

* **Improvements**
  * Database and Redis connections now default to a 30-minute maximum lifetime.
  * Setting a connection lifetime to `0` preserves unlimited lifetime behavior.

* **Tests**
  * Added coverage for unlimited-lifetime configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->