### PR TITLE
Exposed pprof and metrics server port in Dockerfile.

### DIFF
--- a/esignet-service/Dockerfile
+++ b/esignet-service/Dockerfile
@@ -71,6 +71,9 @@ ENV DATA_DIR=${DATA_DIR_ENV} \
     PORT=8088
 
 EXPOSE 8088
+EXPOSE 9090
+EXPOSE 6060
+
 
 ENTRYPOINT ["/home/mosip/entrypoint.sh"]
 

--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -248,7 +248,7 @@ func startMetricsServer(pgConn *sql.DB, redisClient *redis.Client, appCfg *confi
 }
 
 func startDebugServer(appCfg *config.AppConfig, logger *applog.Logger) {
-	addr := fmt.Sprintf(":%d", appCfg.PProfConfig.Port)
+	addr := fmt.Sprintf("127.0.0.1:%d", appCfg.PProfConfig.Port)
 	logger.Info(context.Background(), "starting debug pprof server", applog.String("addr", addr))
 	if err := http.ListenAndServe(addr, newDebugMux()); err != nil {
 		logger.Warn(context.Background(), "debug pprof server stopped", applog.Error(err))

--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -96,10 +96,6 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
-	metrics.RegisterDBStats(pgConn)
-	if redisClient != nil {
-		metrics.RegisterRedisStats(redisClient)
-	}
 
 	commonHTTPClient := config.NewHTTPClient(appCfg.OutboundHTTPClient)
 
@@ -171,10 +167,6 @@ func main() {
 		thunderidengine.WithRuntimeCryptoProvider(engine.NewRuntimeCryptoProvider(appCfg, keyMgrSvc, sigSvc, cryptoSvc)),
 	)
 
-	if appCfg.PprofEnabled {
-		go startDebugServer(logger, newPoolConfigHandler(pgConn, appCfg))
-	}
-
 	addr := fmt.Sprintf(":%d", appCfg.Port)
 	handler := httpmiddleware.CorrelationID(httpmiddleware.AccessLog(mux))
 	srv := &http.Server{
@@ -193,7 +185,13 @@ func main() {
 		}
 	}()
 
-	metricsSrv := startMetricsServer(appCfg, logger)
+	// Start a private metrics listener — not routed through the public ingress; only reachable within the cluster by Prometheus.
+	metricsSrv := startMetricsServer(pgConn, redisClient, appCfg, logger)
+
+	// Start a debug pprof listener if enabled.
+	if appCfg.PProfConfig.Enabled {
+		go startDebugServer(appCfg, logger)
+	}
 
 	// Block until an orchestrator (Docker/Kubernetes) asks us to stop, then
 	// shut the HTTP server down gracefully — letting in-flight requests
@@ -222,7 +220,13 @@ func main() {
 // the public ingress; only reachable within the cluster by Prometheus.
 // Keeping it on a separate port means no authentication middleware is needed
 // and no scrape traffic reaches the main application mux.
-func startMetricsServer(appCfg *config.AppConfig, logger *applog.Logger) *http.Server {
+func startMetricsServer(pgConn *sql.DB, redisClient *redis.Client, appCfg *config.AppConfig,
+	logger *applog.Logger) *http.Server {
+	metrics.RegisterDBStats(pgConn)
+	if redisClient != nil {
+		metrics.RegisterRedisStats(redisClient)
+	}
+
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("GET /metrics", metrics.Handler())
 	metricsAddr := fmt.Sprintf(":%d", appCfg.MetricsPort)
@@ -243,44 +247,17 @@ func startMetricsServer(appCfg *config.AppConfig, logger *applog.Logger) *http.S
 	return metricsSrv
 }
 
-func startDebugServer(logger *applog.Logger, poolConfigHandler http.Handler) {
-	const addr = "127.0.0.1:6060"
+func startDebugServer(appCfg *config.AppConfig, logger *applog.Logger) {
+	addr := fmt.Sprintf(":%d", appCfg.PProfConfig.Port)
 	logger.Info(context.Background(), "starting debug pprof server", applog.String("addr", addr))
-	if err := http.ListenAndServe(addr, newDebugMux(poolConfigHandler)); err != nil {
+	if err := http.ListenAndServe(addr, newDebugMux()); err != nil {
 		logger.Warn(context.Background(), "debug pprof server stopped", applog.Error(err))
 	}
 }
 
-// dbStatter is the subset of *sql.DB used by newPoolConfigHandler; extracted
-// so the handler can be exercised in tests without a live database connection.
-type dbStatter interface {
-	Stats() sql.DBStats
-}
-
-// newPoolConfigHandler returns an HTTP handler that writes a JSON snapshot of
-// DB and Redis connection pool configuration and live counters.
-func newPoolConfigHandler(db dbStatter, appCfg *config.AppConfig) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		stats := db.Stats()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w,
-			`{"db":{"connMaxLifetime":%q,"maxOpenConns":%d,"maxIdleConns":%d,"openConns":%d,"inUse":%d,"idle":%d},"redis":{"connMaxLifetime":%q,"enabled":%v}}`,
-			(time.Duration(appCfg.DB.Pool.ConnMaxLifetimeSecs) * time.Second).String(),
-			appCfg.DB.Pool.MaxOpenConns,
-			appCfg.DB.Pool.MaxIdleConns,
-			stats.OpenConnections,
-			stats.InUse,
-			stats.Idle,
-			appCfg.Redis.ConnMaxLifetime.String(),
-			appCfg.RuntimeDBType == "redis",
-		)
-	})
-}
-
-// newDebugMux builds the debug ServeMux with all pprof routes and
-// /debug/pool-config. Separated from startDebugServer so it can be
-// exercised in tests without binding a port.
-func newDebugMux(poolConfigHandler http.Handler) *http.ServeMux {
+// newDebugMux builds the debug ServeMux with all pprof routes. Separated
+// from startDebugServer so it can be exercised in tests without binding a port.
+func newDebugMux() *http.ServeMux {
 	dbg := http.NewServeMux()
 	dbg.HandleFunc("/debug/pprof/", pprof.Index)
 	dbg.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -289,7 +266,6 @@ func newDebugMux(poolConfigHandler http.Handler) *http.ServeMux {
 	dbg.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	dbg.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
 	dbg.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-	dbg.Handle("GET /debug/pool-config", poolConfigHandler)
 	return dbg
 }
 

--- a/esignet-service/cmd/esignet/main_test.go
+++ b/esignet-service/cmd/esignet/main_test.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -24,11 +23,6 @@ import (
 	"github.com/mosip/esignet/internal/metrics"
 )
 
-// fakeDB implements dbStatter with configurable stats for testing.
-type fakeDB struct{ stats sql.DBStats }
-
-func (f fakeDB) Stats() sql.DBStats { return f.stats }
-
 func testHTTPClientConfig() config.HTTPClientConfig {
 	return config.HTTPClientConfig{
 		TimeoutSecs:               30,
@@ -42,8 +36,7 @@ func testHTTPClientConfig() config.HTTPClientConfig {
 }
 
 func (ts *MainTestSuite) TestNewDebugMux() {
-	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
-	mux := newDebugMux(stub)
+	mux := newDebugMux()
 
 	paths := []string{
 		"/debug/pprof/",
@@ -51,7 +44,6 @@ func (ts *MainTestSuite) TestNewDebugMux() {
 		"/debug/pprof/goroutine",
 		"/debug/pprof/heap",
 		"/debug/pprof/symbol",
-		"/debug/pool-config",
 	}
 	for _, p := range paths {
 		rec := httptest.NewRecorder()
@@ -64,8 +56,7 @@ func (ts *MainTestSuite) TestNewDebugMux_BoundedProfileAndTrace() {
 	if testing.Short() {
 		ts.T().Skip("skipping blocking CPU/trace endpoints in short mode")
 	}
-	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
-	mux := newDebugMux(stub)
+	mux := newDebugMux()
 
 	for _, p := range []string{"/debug/pprof/profile?seconds=1", "/debug/pprof/trace?seconds=1"} {
 		rec := httptest.NewRecorder()
@@ -74,44 +65,15 @@ func (ts *MainTestSuite) TestNewDebugMux_BoundedProfileAndTrace() {
 	}
 }
 
-func (ts *MainTestSuite) TestPoolConfigHandler() {
-	db := fakeDB{stats: sql.DBStats{OpenConnections: 3, InUse: 1, Idle: 2}}
-	appCfg := &config.AppConfig{RuntimeDBType: "redis"}
-	appCfg.DB.Pool.ConnMaxLifetimeSecs = 1800
-	appCfg.DB.Pool.MaxOpenConns = 25
-	appCfg.DB.Pool.MaxIdleConns = 5
-	appCfg.Redis.ConnMaxLifetime = 30 * time.Minute
-
-	rec := httptest.NewRecorder()
-	newPoolConfigHandler(db, appCfg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pool-config", nil))
-
-	ts.Equal(http.StatusOK, rec.Code)
-	ts.Equal("application/json", rec.Header().Get("Content-Type"))
-	body := rec.Body.String()
-	ts.Contains(body, `"connMaxLifetime":"30m0s"`)
-	ts.Contains(body, `"maxOpenConns":25`)
-	ts.Contains(body, `"maxIdleConns":5`)
-	ts.Contains(body, `"openConns":3`)
-	ts.Contains(body, `"inUse":1`)
-	ts.Contains(body, `"idle":2`)
-	ts.Contains(body, `"enabled":true`)
-}
-
-func (ts *MainTestSuite) TestPoolConfigHandler_RedisDisabled() {
-	rec := httptest.NewRecorder()
-	newPoolConfigHandler(fakeDB{}, &config.AppConfig{RuntimeDBType: "inmemory"}).
-		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pool-config", nil))
-	ts.Contains(rec.Body.String(), `"enabled":false`)
-}
-
 func (ts *MainTestSuite) TestPprofEnabled_DefaultOff() {
-	ts.False((&config.AppConfig{}).PprofEnabled, "pprof must be opt-in; default should be false")
+	ts.False((&config.AppConfig{}).PProfConfig.Enabled, "pprof must be opt-in; default should be false")
 }
 
 func (ts *MainTestSuite) TestPprofEnabled_MuxReadyWhenEnabled() {
-	appCfg := &config.AppConfig{PprofEnabled: true}
-	mux := newDebugMux(newPoolConfigHandler(fakeDB{}, appCfg))
+	appCfg := &config.AppConfig{PProfConfig: config.PProfConfig{Enabled: true}}
+	ts.True(appCfg.PProfConfig.Enabled)
 
+	mux := newDebugMux()
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
 	ts.Equal(http.StatusOK, rec.Code)

--- a/esignet-service/cmd/esignet/main_test.go
+++ b/esignet-service/cmd/esignet/main_test.go
@@ -12,9 +12,11 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -192,7 +194,11 @@ func (ts *MainTestSuite) TestStartMetricsServer() {
 			return false
 		}
 		defer func() { _ = resp.Body.Close() }()
-		return resp.StatusCode == http.StatusOK
+		body, err := io.ReadAll(resp.Body)
+		return err == nil &&
+			resp.StatusCode == http.StatusOK &&
+			strings.Contains(string(body), "esignet_db_open_connections") &&
+			strings.Contains(string(body), "esignet_redis_total_conns")
 	}, 2*time.Second, 20*time.Millisecond, "metrics server did not become ready")
 }
 

--- a/esignet-service/cmd/esignet/main_test.go
+++ b/esignet-service/cmd/esignet/main_test.go
@@ -8,6 +8,9 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -22,6 +26,28 @@ import (
 	applog "github.com/mosip/esignet/internal/log"
 	"github.com/mosip/esignet/internal/metrics"
 )
+
+// fakeDriver is a minimal database/sql driver that never actually connects.
+// sql.Open() only registers a name/dsn pair lazily, so this is enough to
+// exercise startMetricsServer's metrics.RegisterDBStats wiring without a
+// real database.
+type fakeDriver struct{}
+
+func (fakeDriver) Open(_ string) (driver.Conn, error) {
+	return nil, errors.New("fakeDriver: connections are not supported")
+}
+
+func init() {
+	sql.Register("esignet-cmd-fake-driver", fakeDriver{})
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	return ln.Addr().(*net.TCPAddr).Port
+}
 
 func testHTTPClientConfig() config.HTTPClientConfig {
 	return config.HTTPClientConfig{
@@ -137,6 +163,55 @@ func (ts *MainTestSuite) TestScopeEnforcementEnabled() {
 		SecurityConfig: config.SecurityConfig{IssuerURL: "https://issuer"},
 	}))
 	require.False(ts.T(), scopeEnforcementEnabled(&config.AppConfig{}))
+}
+
+func (ts *MainTestSuite) TestStartMetricsServer() {
+	t := ts.T()
+
+	db, err := sql.Open("esignet-cmd-fake-driver", "unused-dsn")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	redisClient := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
+	t.Cleanup(func() { _ = redisClient.Close() })
+
+	port := freePort(t)
+	appCfg := &config.AppConfig{MetricsPort: port}
+
+	srv := startMetricsServer(db, redisClient, appCfg, applog.GetLogger())
+	require.Equal(t, fmt.Sprintf(":%d", port), srv.Addr)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", port))
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 20*time.Millisecond, "metrics server did not become ready")
+}
+
+func (ts *MainTestSuite) TestStartDebugServer() {
+	t := ts.T()
+
+	port := freePort(t)
+	appCfg := &config.AppConfig{PProfConfig: config.PProfConfig{Enabled: true, Port: port}}
+
+	go startDebugServer(appCfg, applog.GetLogger())
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port))
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 20*time.Millisecond, "debug pprof server did not become ready")
 }
 
 func (ts *MainTestSuite) TestMetricsMuxRegistersMetricsRoute() {

--- a/esignet-service/data/deployment.yaml
+++ b/esignet-service/data/deployment.yaml
@@ -141,28 +141,34 @@ security_config:
   scope_mapping:
     - endpoint: "/client-mgmt/oidc-client"
       method: POST
-      scope: client_mgmt
+      scope: add_oidc_client
     - endpoint: "/client-mgmt/oidc-client/{client_id}"
       method: PUT
-      scope: client_mgmt
+      scope: update_oidc_client
     - endpoint: "/client-mgmt/oauth-client"
       method: POST
-      scope: client_mgmt
+      scope: add_oidc_client
     - endpoint: "/client-mgmt/oauth-client/{client_id}"
       method: PUT
-      scope: client_mgmt
+      scope: update_oidc_client
     - endpoint: "/client-mgmt/client"
       method: POST
-      scope: client_mgmt
+      scope: add_oidc_client
     - endpoint: "/client-mgmt/client/{client_id}"
       method: PUT
-      scope: client_mgmt
+      scope: update_oidc_client
     - endpoint: "/client-mgmt/client/{client_id}"
       method: PATCH
-      scope: client_mgmt
+      scope: update_oidc_client
     - endpoint: "/client-mgmt/client/{client_id}"
       method: GET
-      scope: client_mgmt
+      scope: get_oidc_client
+    - endpoint: "/system-info/certificate"
+      method: GET
+      scope: get_certificate
+    - endpoint: "/system-info/uploadCertificate"
+      method: POST
+      scope: upload_certificate
 
 scope_claims:
   openid:

--- a/esignet-service/internal/config/app.go
+++ b/esignet-service/internal/config/app.go
@@ -109,7 +109,13 @@ type AppConfig struct {
 	InboundHTTPServer          InboundHTTPServerConfig          `yaml:"inbound_http_server"`
 	SupportedSigningAlgorithms []string                         `yaml:"supported_signing_algorithms"`
 	SupportedEncAlgorithms     []string                         `yaml:"supported_enc_algorithms"`
-	PprofEnabled               bool                             `yaml:"-"`
+	PProfConfig                PProfConfig                      `yaml:"-"`
+}
+
+// PProfConfig defines application pprof configuration
+type PProfConfig struct {
+	Enabled bool `yaml:"enabled"`
+	Port    int  `yaml:"port"`
 }
 
 // SecurityConfig defines application security configuration
@@ -185,8 +191,12 @@ func applyDefaults(cfg *AppConfig) {
 	cfg.Issuer = envOrConfigOrDefault("MOSIP_ESIGNET_HOST", cfg.Issuer, fmt.Sprintf("http://localhost:%d", cfg.Port))
 	cfg.DataDir = envOrConfigOrDefault("DATA_DIR", cfg.DataDir, defaultDataDir)
 	cfg.MetricsPort = envIntOrDefault("METRICS_PORT", defaultMetricsPort)
-	cfg.PprofEnabled = envBool("MOSIP_ESIGNET_PPROF_ENABLED")
 	cfg.DB = loadDB(cfg.DB)
+
+	cfg.PProfConfig = PProfConfig{
+		Enabled: envBool("MOSIP_ESIGNET_PPROF_ENABLED"),
+		Port:    envIntOrDefault("MOSIP_ESIGNET_PPROF_PORT", 6060),
+	}
 
 	cacheType := envOrConfigOrDefault("MOSIP_ESIGNET_CACHE_TYPE", cfg.RuntimeDBType, "redis")
 	cfg.RuntimeDBType = cacheType

--- a/esignet-service/internal/keymanager/keystore/certparse_test.go
+++ b/esignet-service/internal/keymanager/keystore/certparse_test.go
@@ -1,0 +1,132 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package keystore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/cryptobyte"
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
+)
+
+// selfSignedDER builds a minimal self-signed certificate DER-encoded with
+// the given serial number, using Go's own (correct) ASN.1 encoder.
+func selfSignedDER(t *testing.T, serial *big.Int) []byte {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	return der
+}
+
+// stripSerialPadding rewrites a valid certificate's DER so the
+// TBSCertificate serialNumber INTEGER drops its leading 0x00 padding byte —
+// reproducing the malformed (but real-world) encoding some non-Go tooling
+// emits for a serial whose top content bit is set. This is the exact
+// inverse of certparse.go's reencodeNonNegativeSerial.
+func stripSerialPadding(t *testing.T, der []byte) []byte {
+	t.Helper()
+
+	input := cryptobyte.String(der)
+	var certSeq cryptobyte.String
+	require.True(t, input.ReadASN1(&certSeq, cryptobyte_asn1.SEQUENCE))
+
+	var tbs cryptobyte.String
+	require.True(t, certSeq.ReadASN1(&tbs, cryptobyte_asn1.SEQUENCE))
+	// certSeq now holds signatureAlgorithm + signatureValue, copied through
+	// unchanged; ParseCertificateTolerant doesn't verify the signature.
+
+	versionTag := cryptobyte_asn1.Tag(0).Constructed().ContextSpecific()
+	var versionContent cryptobyte.String
+	var hasVersion bool
+	require.True(t, tbs.ReadOptionalASN1(&versionContent, &hasVersion, versionTag))
+
+	var serialContent cryptobyte.String
+	require.True(t, tbs.ReadASN1(&serialContent, cryptobyte_asn1.INTEGER))
+	require.Len(t, serialContent, 2, "test fixture must produce a 1-byte serial padded to 2 bytes")
+	require.Equal(t, byte(0x00), serialContent[0])
+	require.NotZero(t, serialContent[1]&0x80, "second byte must have its top bit set to trigger the negative-serial path")
+	stripped := serialContent[1:]
+
+	var out cryptobyte.Builder
+	out.AddASN1(cryptobyte_asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+		b.AddASN1(cryptobyte_asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			if hasVersion {
+				b.AddASN1(versionTag, func(b *cryptobyte.Builder) {
+					b.AddBytes(versionContent)
+				})
+			}
+			b.AddASN1(cryptobyte_asn1.INTEGER, func(b *cryptobyte.Builder) {
+				b.AddBytes(stripped)
+			})
+			b.AddBytes(tbs)
+		})
+		b.AddBytes(certSeq)
+	})
+	malformed, err := out.Bytes()
+	require.NoError(t, err)
+	return malformed
+}
+
+func TestParseCertificateTolerant_WellFormedCertificate(t *testing.T) {
+	der := selfSignedDER(t, big.NewInt(42))
+
+	got, err := ParseCertificateTolerant(der)
+	require.NoError(t, err)
+
+	want, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	assert.Equal(t, want.SerialNumber, got.SerialNumber)
+	assert.Equal(t, want.Raw, got.Raw)
+	assert.Equal(t, want.RawTBSCertificate, got.RawTBSCertificate)
+}
+
+func TestParseCertificateTolerant_NegativeSerialNumber(t *testing.T) {
+	// Serial 0x80 (128) is DER-encoded by Go as [0x00, 0x80] (padded, since
+	// the top bit of 0x80 is set); stripping the padding reproduces the
+	// malformed two's-complement encoding this function tolerates.
+	valid := selfSignedDER(t, big.NewInt(0x80))
+	malformed := stripSerialPadding(t, valid)
+
+	_, err := x509.ParseCertificate(malformed)
+	require.EqualError(t, err, "x509: negative serial number", "test fixture must reproduce stdlib's rejection")
+
+	got, err := ParseCertificateTolerant(malformed)
+	require.NoError(t, err)
+
+	assert.Equal(t, big.NewInt(0x80), got.SerialNumber, "original serial magnitude must be recovered")
+	assert.Equal(t, malformed, got.Raw, "Raw must be the original malformed input, unmodified")
+
+	assert.NotEmpty(t, got.RawTBSCertificate)
+	assert.NotEqual(t, malformed, got.RawTBSCertificate, "RawTBSCertificate must be the inner TBS bytes, not the whole certificate")
+}
+
+func TestParseCertificateTolerant_OtherErrorsPassThrough(t *testing.T) {
+	_, err := ParseCertificateTolerant([]byte("not a certificate"))
+	require.Error(t, err)
+	assert.NotEqual(t, "x509: negative serial number", err.Error())
+}

--- a/esignet-service/internal/keymanager/keystore/certparse_test.go
+++ b/esignet-service/internal/keymanager/keystore/certparse_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/cryptobyte"
 	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 )
@@ -91,46 +92,54 @@ func stripSerialPadding(t *testing.T, der []byte) []byte {
 	return malformed
 }
 
-func TestParseCertificateTolerant_WellFormedCertificate(t *testing.T) {
-	der := selfSignedDER(t, big.NewInt(42))
-
-	got, err := ParseCertificateTolerant(der)
-	require.NoError(t, err)
-
-	want, err := x509.ParseCertificate(der)
-	require.NoError(t, err)
-
-	assert.Equal(t, want.SerialNumber, got.SerialNumber)
-	assert.Equal(t, want.Raw, got.Raw)
-	assert.Equal(t, want.RawTBSCertificate, got.RawTBSCertificate)
+type CertParseTestSuite struct {
+	suite.Suite
 }
 
-func TestParseCertificateTolerant_NegativeSerialNumber(t *testing.T) {
+func TestCertParseTestSuite(t *testing.T) {
+	suite.Run(t, new(CertParseTestSuite))
+}
+
+func (ts *CertParseTestSuite) TestParseCertificateTolerant_WellFormedCertificate() {
+	der := selfSignedDER(ts.T(), big.NewInt(42))
+
+	got, err := ParseCertificateTolerant(der)
+	require.NoError(ts.T(), err)
+
+	want, err := x509.ParseCertificate(der)
+	require.NoError(ts.T(), err)
+
+	assert.Equal(ts.T(), want.SerialNumber, got.SerialNumber)
+	assert.Equal(ts.T(), want.Raw, got.Raw)
+	assert.Equal(ts.T(), want.RawTBSCertificate, got.RawTBSCertificate)
+}
+
+func (ts *CertParseTestSuite) TestParseCertificateTolerant_NegativeSerialNumber() {
 	// Serial 0x80 (128) is DER-encoded by Go as [0x00, 0x80] (padded, since
 	// the top bit of 0x80 is set); stripping the padding reproduces the
 	// malformed two's-complement encoding this function tolerates.
-	valid := selfSignedDER(t, big.NewInt(0x80))
-	malformed := stripSerialPadding(t, valid)
+	valid := selfSignedDER(ts.T(), big.NewInt(0x80))
+	malformed := stripSerialPadding(ts.T(), valid)
 
 	_, err := x509.ParseCertificate(malformed)
-	require.EqualError(t, err, "x509: negative serial number", "test fixture must reproduce stdlib's rejection")
+	require.EqualError(ts.T(), err, "x509: negative serial number", "test fixture must reproduce stdlib's rejection")
 
 	got, err := ParseCertificateTolerant(malformed)
-	require.NoError(t, err)
+	require.NoError(ts.T(), err)
 
-	assert.Equal(t, big.NewInt(0x80), got.SerialNumber, "original serial magnitude must be recovered")
-	assert.Equal(t, malformed, got.Raw, "Raw must be the original malformed input, unmodified")
+	assert.Equal(ts.T(), big.NewInt(0x80), got.SerialNumber, "original serial magnitude must be recovered")
+	assert.Equal(ts.T(), malformed, got.Raw, "Raw must be the original malformed input, unmodified")
 
 	wantTBS, err := extractTBSCertificate(malformed)
-	require.NoError(t, err)
-	assert.Equal(t, wantTBS, got.RawTBSCertificate)
+	require.NoError(ts.T(), err)
+	assert.Equal(ts.T(), wantTBS, got.RawTBSCertificate)
 }
 
-func TestParseCertificateTolerant_OtherErrorsPassThrough(t *testing.T) {
+func (ts *CertParseTestSuite) TestParseCertificateTolerant_OtherErrorsPassThrough() {
 	input := []byte("not a certificate")
 	_, wantErr := x509.ParseCertificate(input)
-	require.Error(t, wantErr)
+	require.Error(ts.T(), wantErr)
 
 	_, err := ParseCertificateTolerant(input)
-	require.EqualError(t, err, wantErr.Error())
+	require.EqualError(ts.T(), err, wantErr.Error())
 }

--- a/esignet-service/internal/keymanager/keystore/certparse_test.go
+++ b/esignet-service/internal/keymanager/keystore/certparse_test.go
@@ -121,12 +121,16 @@ func TestParseCertificateTolerant_NegativeSerialNumber(t *testing.T) {
 	assert.Equal(t, big.NewInt(0x80), got.SerialNumber, "original serial magnitude must be recovered")
 	assert.Equal(t, malformed, got.Raw, "Raw must be the original malformed input, unmodified")
 
-	assert.NotEmpty(t, got.RawTBSCertificate)
-	assert.NotEqual(t, malformed, got.RawTBSCertificate, "RawTBSCertificate must be the inner TBS bytes, not the whole certificate")
+	wantTBS, err := extractTBSCertificate(malformed)
+	require.NoError(t, err)
+	assert.Equal(t, wantTBS, got.RawTBSCertificate)
 }
 
 func TestParseCertificateTolerant_OtherErrorsPassThrough(t *testing.T) {
-	_, err := ParseCertificateTolerant([]byte("not a certificate"))
-	require.Error(t, err)
-	assert.NotEqual(t, "x509: negative serial number", err.Error())
+	input := []byte("not a certificate")
+	_, wantErr := x509.ParseCertificate(input)
+	require.Error(t, wantErr)
+
+	_, err := ParseCertificateTolerant(input)
+	require.EqualError(t, err, wantErr.Error())
 }

--- a/esignet-service/internal/keymanager/keystore/keystore_test.go
+++ b/esignet-service/internal/keymanager/keystore/keystore_test.go
@@ -1,0 +1,119 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package keystore
+
+import (
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCertificateTemplate(t *testing.T) {
+	notBefore := time.Now()
+	notAfter := notBefore.AddDate(1, 0, 0)
+	params := CertificateParameters{
+		CommonName:       "MOSIP Root CA",
+		OrganizationUnit: "unit",
+		Organization:     "org",
+		Location:         "loc",
+		State:            "state",
+		Country:          "IN",
+		NotBefore:        notBefore,
+		NotAfter:         notAfter,
+	}
+
+	tmpl, err := BuildCertificateTemplate(params)
+	require.NoError(t, err)
+
+	assert.Equal(t, "MOSIP Root CA", tmpl.Subject.CommonName)
+	assert.Equal(t, []string{"unit"}, tmpl.Subject.OrganizationalUnit)
+	assert.Equal(t, []string{"org"}, tmpl.Subject.Organization)
+	assert.Equal(t, []string{"loc"}, tmpl.Subject.Locality)
+	assert.Equal(t, []string{"state"}, tmpl.Subject.Province)
+	assert.Equal(t, []string{"IN"}, tmpl.Subject.Country)
+	assert.Equal(t, notBefore, tmpl.NotBefore)
+	assert.Equal(t, notAfter, tmpl.NotAfter)
+	assert.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment, tmpl.KeyUsage)
+	assert.Empty(t, tmpl.ExtKeyUsage, "signing/encryption keys must not carry TLS ExtKeyUsage")
+	require.NotNil(t, tmpl.SerialNumber)
+	assert.NotZero(t, tmpl.SerialNumber.Sign(), "serial number must not be zero")
+}
+
+func TestBuildCertificateTemplate_SerialNumbersAreUnique(t *testing.T) {
+	tmpl1, err := BuildCertificateTemplate(CertificateParameters{})
+	require.NoError(t, err)
+	tmpl2, err := BuildCertificateTemplate(CertificateParameters{})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, tmpl1.SerialNumber, tmpl2.SerialNumber)
+}
+
+// stubKeyStore is a minimal KeyStore implementation used to verify that
+// Register/New wire a factory through correctly, without depending on a
+// real PKCS#11/PKCS#12 backend.
+type stubKeyStore struct{}
+
+func (stubKeyStore) GetPrivateKey(_ string) (crypto.PrivateKey, error)  { return nil, nil }
+func (stubKeyStore) GetPublicKey(_ string) (crypto.PublicKey, error)    { return nil, nil }
+func (stubKeyStore) GetCertificate(_ string) (*x509.Certificate, error) { return nil, nil }
+func (stubKeyStore) GetSymmetricKey(_ string) ([]byte, error)           { return nil, nil }
+func (stubKeyStore) GetAsymmetricKey(_ string) (*KeyPairEntry, error)   { return nil, nil }
+func (stubKeyStore) GetAllAlias() ([]string, error)                     { return nil, nil }
+func (stubKeyStore) GenerateAndStoreSymmetricKey(_ string) error        { return nil }
+func (stubKeyStore) GenerateAndStoreAsymmetricKey(_, _ string, _ CertificateParameters, _, _ string) error {
+	return nil
+}
+func (stubKeyStore) DeleteKey(_ string) error { return nil }
+func (stubKeyStore) StoreCertificate(_ string, _ crypto.PrivateKey, _ *x509.Certificate) error {
+	return nil
+}
+func (stubKeyStore) ProviderName() string { return "stub" }
+func (stubKeyStore) Close() error         { return nil }
+
+func TestRegisterAndNew(t *testing.T) {
+	const typeName = "test-keystore-type"
+
+	var gotParams map[string]string
+	stub := &stubKeyStore{}
+	Register(typeName, func(p map[string]string) (KeyStore, error) {
+		gotParams = p
+		return stub, nil
+	})
+	t.Cleanup(func() { delete(registry, typeName) })
+
+	params := map[string]string{"path": "/tmp/keystore"}
+	ks, err := New(typeName, params)
+	require.NoError(t, err)
+	assert.Same(t, stub, ks)
+	assert.Equal(t, params, gotParams)
+}
+
+func TestNew_UnsupportedType(t *testing.T) {
+	ks, err := New("NOT-A-REAL-TYPE", nil)
+	require.Error(t, err)
+	assert.Nil(t, ks)
+	assert.Contains(t, err.Error(), "NOT-A-REAL-TYPE")
+}
+
+func TestRegister_FactoryErrorPropagates(t *testing.T) {
+	const typeName = "test-keystore-type-error"
+
+	wantErr := errors.New("boom")
+	Register(typeName, func(_ map[string]string) (KeyStore, error) {
+		return nil, wantErr
+	})
+	t.Cleanup(func() { delete(registry, typeName) })
+
+	ks, err := New(typeName, nil)
+	assert.Nil(t, ks)
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/esignet-service/internal/keymanager/keystore/keystore_test.go
+++ b/esignet-service/internal/keymanager/keystore/keystore_test.go
@@ -15,47 +15,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
-
-func TestBuildCertificateTemplate(t *testing.T) {
-	notBefore := time.Now()
-	notAfter := notBefore.AddDate(1, 0, 0)
-	params := CertificateParameters{
-		CommonName:       "MOSIP Root CA",
-		OrganizationUnit: "unit",
-		Organization:     "org",
-		Location:         "loc",
-		State:            "state",
-		Country:          "IN",
-		NotBefore:        notBefore,
-		NotAfter:         notAfter,
-	}
-
-	tmpl, err := BuildCertificateTemplate(params)
-	require.NoError(t, err)
-
-	assert.Equal(t, "MOSIP Root CA", tmpl.Subject.CommonName)
-	assert.Equal(t, []string{"unit"}, tmpl.Subject.OrganizationalUnit)
-	assert.Equal(t, []string{"org"}, tmpl.Subject.Organization)
-	assert.Equal(t, []string{"loc"}, tmpl.Subject.Locality)
-	assert.Equal(t, []string{"state"}, tmpl.Subject.Province)
-	assert.Equal(t, []string{"IN"}, tmpl.Subject.Country)
-	assert.Equal(t, notBefore, tmpl.NotBefore)
-	assert.Equal(t, notAfter, tmpl.NotAfter)
-	assert.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment, tmpl.KeyUsage)
-	assert.Empty(t, tmpl.ExtKeyUsage, "signing/encryption keys must not carry TLS ExtKeyUsage")
-	require.NotNil(t, tmpl.SerialNumber)
-	assert.NotZero(t, tmpl.SerialNumber.Sign(), "serial number must not be zero")
-}
-
-func TestBuildCertificateTemplate_SerialNumbersAreUnique(t *testing.T) {
-	tmpl1, err := BuildCertificateTemplate(CertificateParameters{})
-	require.NoError(t, err)
-	tmpl2, err := BuildCertificateTemplate(CertificateParameters{})
-	require.NoError(t, err)
-
-	assert.NotEqual(t, tmpl1.SerialNumber, tmpl2.SerialNumber)
-}
 
 // stubKeyStore is a minimal KeyStore implementation used to verify that
 // Register/New wire a factory through correctly, without depending on a
@@ -79,7 +40,55 @@ func (stubKeyStore) StoreCertificate(_ string, _ crypto.PrivateKey, _ *x509.Cert
 func (stubKeyStore) ProviderName() string { return "stub" }
 func (stubKeyStore) Close() error         { return nil }
 
-func TestRegisterAndNew(t *testing.T) {
+type KeystoreTestSuite struct {
+	suite.Suite
+}
+
+func TestKeystoreTestSuite(t *testing.T) {
+	suite.Run(t, new(KeystoreTestSuite))
+}
+
+func (ts *KeystoreTestSuite) TestBuildCertificateTemplate() {
+	notBefore := time.Now()
+	notAfter := notBefore.AddDate(1, 0, 0)
+	params := CertificateParameters{
+		CommonName:       "MOSIP Root CA",
+		OrganizationUnit: "unit",
+		Organization:     "org",
+		Location:         "loc",
+		State:            "state",
+		Country:          "IN",
+		NotBefore:        notBefore,
+		NotAfter:         notAfter,
+	}
+
+	tmpl, err := BuildCertificateTemplate(params)
+	require.NoError(ts.T(), err)
+
+	assert.Equal(ts.T(), "MOSIP Root CA", tmpl.Subject.CommonName)
+	assert.Equal(ts.T(), []string{"unit"}, tmpl.Subject.OrganizationalUnit)
+	assert.Equal(ts.T(), []string{"org"}, tmpl.Subject.Organization)
+	assert.Equal(ts.T(), []string{"loc"}, tmpl.Subject.Locality)
+	assert.Equal(ts.T(), []string{"state"}, tmpl.Subject.Province)
+	assert.Equal(ts.T(), []string{"IN"}, tmpl.Subject.Country)
+	assert.Equal(ts.T(), notBefore, tmpl.NotBefore)
+	assert.Equal(ts.T(), notAfter, tmpl.NotAfter)
+	assert.Equal(ts.T(), x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment, tmpl.KeyUsage)
+	assert.Empty(ts.T(), tmpl.ExtKeyUsage, "signing/encryption keys must not carry TLS ExtKeyUsage")
+	require.NotNil(ts.T(), tmpl.SerialNumber)
+	assert.NotZero(ts.T(), tmpl.SerialNumber.Sign(), "serial number must not be zero")
+}
+
+func (ts *KeystoreTestSuite) TestBuildCertificateTemplate_SerialNumbersAreUnique() {
+	tmpl1, err := BuildCertificateTemplate(CertificateParameters{})
+	require.NoError(ts.T(), err)
+	tmpl2, err := BuildCertificateTemplate(CertificateParameters{})
+	require.NoError(ts.T(), err)
+
+	assert.NotEqual(ts.T(), tmpl1.SerialNumber, tmpl2.SerialNumber)
+}
+
+func (ts *KeystoreTestSuite) TestRegisterAndNew() {
 	const typeName = "test-keystore-type"
 
 	var gotParams map[string]string
@@ -88,32 +97,32 @@ func TestRegisterAndNew(t *testing.T) {
 		gotParams = p
 		return stub, nil
 	})
-	t.Cleanup(func() { delete(registry, typeName) })
+	ts.T().Cleanup(func() { delete(registry, typeName) })
 
 	params := map[string]string{"path": "/tmp/keystore"}
 	ks, err := New(typeName, params)
-	require.NoError(t, err)
-	assert.Same(t, stub, ks)
-	assert.Equal(t, params, gotParams)
+	require.NoError(ts.T(), err)
+	assert.Same(ts.T(), stub, ks)
+	assert.Equal(ts.T(), params, gotParams)
 }
 
-func TestNew_UnsupportedType(t *testing.T) {
+func (ts *KeystoreTestSuite) TestNew_UnsupportedType() {
 	ks, err := New("NOT-A-REAL-TYPE", nil)
-	require.Error(t, err)
-	assert.Nil(t, ks)
-	assert.Contains(t, err.Error(), "NOT-A-REAL-TYPE")
+	require.Error(ts.T(), err)
+	assert.Nil(ts.T(), ks)
+	assert.Contains(ts.T(), err.Error(), "NOT-A-REAL-TYPE")
 }
 
-func TestRegister_FactoryErrorPropagates(t *testing.T) {
+func (ts *KeystoreTestSuite) TestRegister_FactoryErrorPropagates() {
 	const typeName = "test-keystore-type-error"
 
 	wantErr := errors.New("boom")
 	Register(typeName, func(_ map[string]string) (KeyStore, error) {
 		return nil, wantErr
 	})
-	t.Cleanup(func() { delete(registry, typeName) })
+	ts.T().Cleanup(func() { delete(registry, typeName) })
 
 	ks, err := New(typeName, nil)
-	assert.Nil(t, ks)
-	assert.ErrorIs(t, err, wantErr)
+	assert.Nil(ts.T(), ks)
+	assert.ErrorIs(ts.T(), err, wantErr)
 }

--- a/esignet-service/internal/metrics/metrics_test.go
+++ b/esignet-service/internal/metrics/metrics_test.go
@@ -1,0 +1,96 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package metrics
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDriver is a minimal database/sql driver that never actually connects.
+// sql.Open() only registers a name/dsn pair lazily, and *sql.DB.Stats() reads
+// pool counters without requiring a live connection, so this is sufficient
+// to exercise RegisterDBStats without a real database.
+type fakeDriver struct{}
+
+func (fakeDriver) Open(_ string) (driver.Conn, error) {
+	return nil, errors.New("fakeDriver: connections are not supported")
+}
+
+func init() {
+	sql.Register("esignet-metrics-fake-driver", fakeDriver{})
+}
+
+func scrape(t *testing.T) string {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	rr := httptest.NewRecorder()
+	Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, 200, rr.Code)
+
+	body, err := io.ReadAll(rr.Result().Body)
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+func TestHandler_ServesPrometheusTextFormat(t *testing.T) {
+	body := scrape(t)
+
+	assert.Contains(t, body, "go_goroutines")
+}
+
+func TestRegisterDBStats_ExposesPoolGauges(t *testing.T) {
+	db, err := sql.Open("esignet-metrics-fake-driver", "unused-dsn")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	RegisterDBStats(db)
+
+	body := scrape(t)
+
+	for _, metric := range []string{
+		"esignet_db_open_connections",
+		"esignet_db_in_use",
+		"esignet_db_idle",
+		"esignet_db_wait_count_total",
+		"esignet_db_wait_duration_seconds_total",
+	} {
+		assert.Contains(t, body, metric, "expected %s to be registered", metric)
+	}
+
+	assert.True(t, strings.Contains(body, "esignet_db_open_connections 0"))
+}
+
+func TestRegisterRedisStats_ExposesPoolGauges(t *testing.T) {
+	client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
+	t.Cleanup(func() { _ = client.Close() })
+
+	RegisterRedisStats(client)
+
+	body := scrape(t)
+
+	for _, metric := range []string{
+		"esignet_redis_total_conns",
+		"esignet_redis_idle_conns",
+		"esignet_redis_pool_timeouts_total",
+		"esignet_redis_stale_conns_total",
+	} {
+		assert.Contains(t, body, metric, "expected %s to be registered", metric)
+	}
+}


### PR DESCRIPTION
Improves #2375 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable pprof diagnostics with enablement and port settings.
  * Exposed dedicated ports for metrics and diagnostics services.
  * Added operation-specific access scopes for client management and certificate retrieval or upload.

* **Bug Fixes**
  * Removed the database pool configuration endpoint from debug routes.
  * Streamlined metrics registration to use current database and cache connections.
  * Improved handling of certificates with nonstandard serial number formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->