### PR TITLE
2360 - Duplicate client Id on client create returns HTTP 500 server error

### DIFF
--- a/.github/workflows/chart-lint-publish.yml
+++ b/.github/workflows/chart-lint-publish.yml
@@ -18,7 +18,7 @@ on:
         description: 'Chart publishing to gh-pages branch'
         required: false
         default: 'NO'
-        type: string
+        type: choice
         options:
           - YES
           - NO
@@ -26,7 +26,7 @@ on:
         description: 'Include all charts for Linting/Publishing (YES/NO)'
         required: false
         default: 'NO'
-        type: string
+        type: choice
         options:
           - YES
           - NO

--- a/esignet-service/internal/clientmgmt/handler_test.go
+++ b/esignet-service/internal/clientmgmt/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -139,7 +140,7 @@ func (ts *HandlerTestSuite) TestCreateClientHandler() {
 	})
 
 	t.Run("duplicate client id", func(t *testing.T) {
-		h := newTestHandler(&fakeQuerier{createErr: errors.New(`SQLSTATE 23505 pk_clntdtl_id`)})
+		h := newTestHandler(&fakeQuerier{createErr: &pgconn.PgError{Code: "23505", ConstraintName: "pk_clntdtl_id"}})
 		body := []byte(`{"requestTime":"2026-07-27T00:00:00.000Z","request":` + validCreateRequestJSON() + `}`)
 		req := httptest.NewRequest(http.MethodPost, "/client-mgmt/oidc-client", bytes.NewReader(body))
 		rec := httptest.NewRecorder()

--- a/esignet-service/internal/clientmgmt/service.go
+++ b/esignet-service/internal/clientmgmt/service.go
@@ -13,9 +13,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/mosip/esignet/internal/clientmgmt/db"
@@ -552,13 +552,15 @@ func unmarshalAdditionalConfig(s sql.NullString) (map[string]any, error) {
 }
 
 func isDuplicateClientID(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "23505") &&
-		(strings.Contains(msg, "pk_clntdtl_id") || strings.Contains(msg, "client_detail_pkey"))
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505" &&
+		(pgErr.ConstraintName == "pk_clntdtl_id" || pgErr.ConstraintName == "client_detail_pkey")
 }
 
 func isDuplicatePublicKeyHash(err error) bool {
-	return strings.Contains(err.Error(), "uk_clntdtl_public_key_hash")
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505" &&
+		pgErr.ConstraintName == "uk_clntdtl_public_key_hash"
 }
 
 func toResponse(row db.ClientDetail) (ClientResponse, error) {

--- a/esignet-service/internal/clientmgmt/service_test.go
+++ b/esignet-service/internal/clientmgmt/service_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -147,14 +148,14 @@ func (ts *ServiceTestSuite) TestCreateClient() {
 	})
 
 	t.Run("duplicate client id", func(t *testing.T) {
-		q := &fakeQuerier{createErr: errors.New(`pq: duplicate key value violates unique constraint "pk_clntdtl_id" (SQLSTATE 23505)`)}
+		q := &fakeQuerier{createErr: &pgconn.PgError{Code: "23505", ConstraintName: "pk_clntdtl_id"}}
 		s := NewServiceWithQuerier(q, nil, 0, nil)
 		_, err := s.CreateClient(context.Background(), ProfileOIDC, validCreateRequest())
 		require.ErrorIs(t, err, ErrDuplicateClientID)
 	})
 
 	t.Run("duplicate public key hash", func(t *testing.T) {
-		q := &fakeQuerier{createErr: errors.New(`pq: duplicate key value violates unique constraint "uk_clntdtl_public_key_hash"`)}
+		q := &fakeQuerier{createErr: &pgconn.PgError{Code: "23505", ConstraintName: "uk_clntdtl_public_key_hash"}}
 		s := NewServiceWithQuerier(q, nil, 0, nil)
 		_, err := s.CreateClient(context.Background(), ProfileOIDC, validCreateRequest())
 		var ve *ValidationError
@@ -333,7 +334,7 @@ func (ts *ServiceTestSuite) TestPatchClient() {
 	})
 
 	t.Run("duplicate public key hash on patch", func(t *testing.T) {
-		q := &fakeQuerier{getRow: existingClientRow(), patchErr: errors.New(`duplicate key value violates unique constraint "uk_clntdtl_public_key_hash"`)}
+		q := &fakeQuerier{getRow: existingClientRow(), patchErr: &pgconn.PgError{Code: "23505", ConstraintName: "uk_clntdtl_public_key_hash"}}
 		s := NewServiceWithQuerier(q, nil, 0, nil)
 		_, err := s.PatchClient(context.Background(), "client-1", PatchClientRequest{}, PatchFields{})
 		var ve *ValidationError
@@ -492,13 +493,15 @@ func (ts *ServiceTestSuite) TestMarshalUnmarshalHelpers() {
 	})
 
 	t.Run("isDuplicateClientID matches constraint variants", func(t *testing.T) {
-		require.True(t, isDuplicateClientID(errors.New(`SQLSTATE 23505 pk_clntdtl_id`)))
-		require.True(t, isDuplicateClientID(errors.New(`SQLSTATE 23505 client_detail_pkey`)))
+		require.True(t, isDuplicateClientID(&pgconn.PgError{Code: "23505", ConstraintName: "pk_clntdtl_id"}))
+		require.True(t, isDuplicateClientID(&pgconn.PgError{Code: "23505", ConstraintName: "client_detail_pkey"}))
+		require.False(t, isDuplicateClientID(&pgconn.PgError{Code: "23505", ConstraintName: "other_constraint"}))
 		require.False(t, isDuplicateClientID(errors.New("some other error")))
 	})
 
 	t.Run("isDuplicatePublicKeyHash", func(t *testing.T) {
-		require.True(t, isDuplicatePublicKeyHash(errors.New("uk_clntdtl_public_key_hash violation")))
+		require.True(t, isDuplicatePublicKeyHash(&pgconn.PgError{Code: "23505", ConstraintName: "uk_clntdtl_public_key_hash"}))
+		require.False(t, isDuplicatePublicKeyHash(&pgconn.PgError{Code: "23505", ConstraintName: "other_constraint"}))
 		require.False(t, isDuplicatePublicKeyHash(errors.New("some other error")))
 	})
 

--- a/ui-test/dependency-reduced-pom.xml
+++ b/ui-test/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.mosip.esignet</groupId>
   <artifactId>uitest-esignet</artifactId>
   <name>uitest-esignet</name>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.7.1-SNAPSHOT</version>
   <description>UI test automation project for MOSIP eSignet</description>
   <url>https://github.com/mosip/esignet</url>
   <developers>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate client IDs and public-key hashes.
  * Duplicate records are now recognized more accurately, reducing incorrect duplicate warnings and improving error responses.
  * KYC exchange responses now preserve signed JWT data as a complete raw value, improving integrity and consistency.

* **Tests**
  * Expanded coverage for recognized and unrecognized duplicate conditions.
  * Updated KYC exchange validation coverage.

* **Chores**
  * Updated the UI test project version to 1.7.1-SNAPSHOT.
  * Simplified chart publishing workflow selections with clear Yes/No options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->