### PR TITLE
Update parameter types in chart-lint-publish.yml

### DIFF
--- a/.github/workflows/chart-lint-publish.yml
+++ b/.github/workflows/chart-lint-publish.yml
@@ -18,7 +18,7 @@ on:
         description: 'Chart publishing to gh-pages branch'
         required: false
         default: 'NO'
-        type: choice
+        type: string
         options:
           - YES
           - NO
@@ -26,7 +26,7 @@ on:
         description: 'Include all charts for Linting/Publishing (YES/NO)'
         required: false
         default: 'NO'
-        type: choice
+        type: string
         options:
           - YES
           - NO


### PR DESCRIPTION
Changed parameter types from 'choice' to 'string' for CHART_PUBLISH and INCLUDE_ALL_CHARTS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated chart workflow options to use text inputs while retaining the existing YES/NO values and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->