### PR TITLE
fix: convert consent_expire_in_mins to secs for LoginConsent.ValidityPeriod

### DIFF
--- a/esignet-service/internal/engine/actor_provider.go
+++ b/esignet-service/internal/engine/actor_provider.go
@@ -190,7 +190,7 @@ func (p *actorProvider) GetInboundClientByID(
 			UserAttributes: client.Claims,
 		},
 		LoginConsent: &providers.LoginConsentConfig{
-			ValidityPeriod: configInt64(client.AdditionalConfig, consentExpireInMins, 0),
+			ValidityPeriod: configInt64(client.AdditionalConfig, consentExpireInMins, 0) * 60,
 		},
 		Properties: properties,
 		IsReadOnly: false,

--- a/esignet-service/internal/engine/actor_provider_test.go
+++ b/esignet-service/internal/engine/actor_provider_test.go
@@ -268,8 +268,8 @@ func (ts *ActorProviderTestSuite) TestActorProvider_GetInboundClientByID() {
 	if client.AuthFlowID != "flow-1" || client.ThemeID != "theme-1" || client.LayoutID != "layout-1" {
 		t.Errorf("client = %+v, unexpected flow/theme/layout ids", client)
 	}
-	if client.LoginConsent.ValidityPeriod != 30 {
-		t.Errorf("LoginConsent.ValidityPeriod = %d, want 30", client.LoginConsent.ValidityPeriod)
+	if client.LoginConsent.ValidityPeriod != 30*60 {
+		t.Errorf("LoginConsent.ValidityPeriod = %d, want %d", client.LoginConsent.ValidityPeriod, 30*60)
 	}
 	if client.Properties["name"] != "Test App" {
 		t.Errorf("Properties[name] = %v, want Test App", client.Properties["name"])


### PR DESCRIPTION
Closes #2422 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected consent expiration timing so configured durations are accurately interpreted in seconds.
  * Updated related validation to reflect the corrected consent validity period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->