### PR TITLE
Support to publish ID-system public keys in the jwks well-known

### DIFF
--- a/esignet-service/.env.example
+++ b/esignet-service/.env.example
@@ -189,6 +189,7 @@ MOSIP_ESIGNET_AUTHN_PROVIDER=mock
 # unless overridden individually below.
 MOSIP_API_INTERNAL_HOST=https://api-internal.test.mosip.net
 MOSIP_ESIGNET_MISP_KEY=sample-license-key
+MOSIP_IDA_CLIENT_SECRET=test
 
 # IDA request metadata (domainUri defaults to MOSIP_API_INTERNAL_HOST; env defaults to Staging)
 # MOSIP_ESIGNET_DOMAIN_URL=https://api-internal.test.mosip.net

--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -171,7 +171,7 @@ func main() {
 		thunderidengine.WithTransactioner(engine.NewNoOpTransactioner()),
 		thunderidengine.WithAttestationProvider(engine.NewAttestationProvider(appCfg)),
 		thunderidengine.WithCaptchaValidationProvider(engine.NewCaptchaProvider(&appCfg.CaptchaConfig, commonHTTPClient)),
-		thunderidengine.WithRuntimeCryptoProvider(engine.NewRuntimeCryptoProvider(appCfg, keyMgrSvc, sigSvc, cryptoSvc)),
+		thunderidengine.WithRuntimeCryptoProvider(engine.NewRuntimeCryptoProvider(appCfg, keyMgrSvc, sigSvc, cryptoSvc, authnProvider)),
 		thunderidengine.WithOriginConfig(originConfig),
 	)
 

--- a/esignet-service/data/flows/flow-esignet.yaml
+++ b/esignet-service/data/flows/flow-esignet.yaml
@@ -375,7 +375,7 @@ nodes:
       - inputs: *otp_inputs
         action:
           ref: submit_uin
-          nextNode: send_mosip_otp
+          nextNode: send_mosip_otp_uin
       - action:
           ref: login_id_mobile
           nextNode: prompt_mobile_otp
@@ -408,7 +408,7 @@ nodes:
       - inputs: *otp_inputs
         action:
           ref: submit_uin
-          nextNode: send_mosip_otp
+          nextNode: send_mosip_otp_mobile
       - action:
           ref: login_id_uin
           nextNode: prompt_uin_otp
@@ -441,7 +441,7 @@ nodes:
       - inputs: *otp_inputs
         action:
           ref: submit_uin
-          nextNode: send_mosip_otp
+          nextNode: send_mosip_otp_email
       - action:
           ref: login_id_uin
           nextNode: prompt_uin_otp
@@ -474,7 +474,7 @@ nodes:
       - inputs: *otp_inputs
         action:
           ref: submit_uin
-          nextNode: send_mosip_otp
+          nextNode: send_mosip_otp_nrc
       - action:
           ref: login_id_uin
           nextNode: prompt_uin_otp
@@ -488,11 +488,43 @@ nodes:
           ref: BACK_BUTTON
           nextNode: prompt_acr
 
+  - id: send_mosip_otp_uin
+    type: TASK_EXECUTION
+    executor:
+      name: eSignetOtpExecutor
+    onSuccess: prompt_otp
+    onIncomplete: prompt_uin_otp
+
+  - id: send_mosip_otp_mobile
+    type: TASK_EXECUTION
+    executor:
+      name: eSignetOtpExecutor
+    onSuccess: prompt_otp
+    onIncomplete: prompt_mobile_otp
+
+  - id: send_mosip_otp_email
+    type: TASK_EXECUTION
+    executor:
+      name: eSignetOtpExecutor
+    onSuccess: prompt_otp
+    onIncomplete: prompt_email_otp
+
+  - id: send_mosip_otp_nrc
+    type: TASK_EXECUTION
+    executor:
+      name: eSignetOtpExecutor
+    onSuccess: prompt_otp
+    onIncomplete: prompt_nrc_otp
+
+  # Dedicated to the RESEND_OTP action from prompt_otp: the user is already on the OTP-entry
+  # screen at that point (not one of the four identifier prompts above), so a failed resend
+  # routes back to prompt_otp itself rather than to a channel-specific prompt.
   - id: send_mosip_otp
     type: TASK_EXECUTION
     executor:
       name: eSignetOtpExecutor
     onSuccess: prompt_otp
+    onIncomplete: prompt_otp
 
   - id: prompt_otp
     type: PROMPT
@@ -570,6 +602,7 @@ nodes:
           type: OTP_INPUT
           required: true
     onSuccess: authorization_check
+    onIncomplete: prompt_otp
 
   - id: prompt_uin_credentials
     type: PROMPT
@@ -593,7 +626,7 @@ nodes:
       - inputs: *password_inputs
         action:
           ref: password_authenticate
-          nextNode: basic_cred_auth
+          nextNode: basic_cred_auth_uin
       - action:
           ref: login_id_mobile
           nextNode: prompt_mobile_credentials
@@ -629,7 +662,7 @@ nodes:
       - inputs: *password_inputs
         action:
           ref: password_authenticate
-          nextNode: basic_cred_auth
+          nextNode: basic_cred_auth_mobile
       - action:
           ref: login_id_uin
           nextNode: prompt_uin_credentials
@@ -665,7 +698,7 @@ nodes:
       - inputs: *password_inputs
         action:
           ref: password_authenticate
-          nextNode: basic_cred_auth
+          nextNode: basic_cred_auth_email
       - action:
           ref: login_id_uin
           nextNode: prompt_uin_credentials
@@ -701,7 +734,7 @@ nodes:
       - inputs: *password_inputs
         action:
           ref: password_authenticate
-          nextNode: basic_cred_auth
+          nextNode: basic_cred_auth_nrc
       - action:
           ref: login_id_uin
           nextNode: prompt_uin_credentials
@@ -715,7 +748,7 @@ nodes:
           ref: BACK_BUTTON
           nextNode: prompt_acr
 
-  - id: basic_cred_auth
+  - id: basic_cred_auth_uin
     type: TASK_EXECUTION
     executor:
       name: CredentialsAuthExecutor
@@ -733,6 +766,67 @@ nodes:
           type: PASSWORD_INPUT
           required: true
     onSuccess: authorization_check
+    onIncomplete: prompt_uin_credentials
+
+  - id: basic_cred_auth_mobile
+    type: TASK_EXECUTION
+    executor:
+      name: CredentialsAuthExecutor
+      inputs:
+        - ref: username_input
+          identifier: username
+          type: TEXT_INPUT
+          required: true
+        - ref: password_input
+          identifier: password
+          type: PASSWORD_INPUT
+          required: true
+        - ref: CAPTCHA_BOX
+          identifier: captcha_token
+          type: PASSWORD_INPUT
+          required: true
+    onSuccess: authorization_check
+    onIncomplete: prompt_mobile_credentials
+
+  - id: basic_cred_auth_email
+    type: TASK_EXECUTION
+    executor:
+      name: CredentialsAuthExecutor
+      inputs:
+        - ref: username_input
+          identifier: username
+          type: TEXT_INPUT
+          required: true
+        - ref: password_input
+          identifier: password
+          type: PASSWORD_INPUT
+          required: true
+        - ref: CAPTCHA_BOX
+          identifier: captcha_token
+          type: PASSWORD_INPUT
+          required: true
+    onSuccess: authorization_check
+    onIncomplete: prompt_email_credentials
+
+  - id: basic_cred_auth_nrc
+    type: TASK_EXECUTION
+    executor:
+      name: CredentialsAuthExecutor
+      inputs:
+        - ref: username_input
+          identifier: username
+          type: TEXT_INPUT
+          required: true
+        - ref: password_input
+          identifier: password
+          type: PASSWORD_INPUT
+          required: true
+        - ref: CAPTCHA_BOX
+          identifier: captcha_token
+          type: PASSWORD_INPUT
+          required: true
+    onSuccess: authorization_check
+    onIncomplete: prompt_nrc_credentials
 
   - id: prompt_uin_bio
     type: PROMPT
@@ -922,6 +1016,7 @@ nodes:
           type: PASSWORD_INPUT
           required: true
     onSuccess: authorization_check
+    onIncomplete: prompt_biometric
 
   - id: prompt_kbi_details
     type: PROMPT
@@ -1000,6 +1095,7 @@ nodes:
           type: PASSWORD_INPUT
           required: true
     onSuccess: authorization_check
+    onIncomplete: prompt_kbi_details
 
   - id: authorization_check
     type: TASK_EXECUTION
@@ -1011,6 +1107,7 @@ nodes:
     type: TASK_EXECUTION
     properties:
       timeout: "120"
+      failOnDeny: true
     executor:
       name: ConsentExecutor
       inputs:

--- a/esignet-service/data/flows/flow-esignet.yaml
+++ b/esignet-service/data/flows/flow-esignet.yaml
@@ -287,8 +287,14 @@ interceptors:
     mode: PRE_NODE
     scope: SELECTED
     applyto:
-      - send_mosip_otp
-      - basic_cred_auth
+      - send_mosip_otp_email
+      - send_mosip_otp_mobile
+      - send_mosip_otp_uin
+      - send_mosip_otp_nrc
+      - basic_cred_auth_uin
+      - basic_cred_auth_mobile
+      - basic_cred_auth_email
+      - basic_cred_auth_nrc
       - basic_kbi_auth
 
 nodes:

--- a/esignet-service/internal/engine/executors/otp_executor.go
+++ b/esignet-service/internal/engine/executors/otp_executor.go
@@ -84,9 +84,13 @@ func (e *otpExecutor) Execute(ctx *providers.NodeContext) (*providers.ExecutorRe
 	if serviceError != nil {
 		// username is the individual's identity number and must not be logged.
 		applog.GetLogger().Warn(ctx.Context, "failed to send OTP", applog.String("errorCode", serviceError.Code))
-		// Return ExecFailure so the engine surfaces the error to the user without terminating the flow session
+		// Return ExecUserInputRequired (not ExecFailure) so the flow stays alive and re-prompts for
+		// the individual ID: ExecFailure maps to NodeStatusFailure, and since this node has no
+		// onFailure target configured, that would terminate the flow session (flowStatus: ERROR)
+		// instead of letting the user correct a mistyped username and retry.
 		if serviceError.Type == common.ClientErrorType {
-			execResp.Status = providers.ExecFailure
+			execResp.Status = providers.ExecUserInputRequired
+			execResp.Inputs = []providers.Input{individualIDInput}
 			execResp.Error = serviceError
 			return execResp, nil
 		}

--- a/esignet-service/internal/engine/executors/otp_executor_test.go
+++ b/esignet-service/internal/engine/executors/otp_executor_test.go
@@ -64,6 +64,10 @@ func (f *fakeAuthnProvider) SendOTP(_ context.Context, identifiers map[string]in
 	return f.sendOTPResult, f.sendOTPErr
 }
 
+func (f *fakeAuthnProvider) GetSigningCertificates(_ context.Context) ([]shared.CertificateData, *common.ServiceError) {
+	return nil, nil
+}
+
 func newOtpNodeContext(userInputs, runtimeData map[string]string) *providers.NodeContext {
 	if runtimeData == nil {
 		runtimeData = map[string]string{}
@@ -199,7 +203,7 @@ func (ts *OtpExecutorTestSuite) TestExecuteSuccessViaRuntimeData() {
 	}
 }
 
-func (ts *OtpExecutorTestSuite) TestExecuteClientErrorReturnsFailureStatus() {
+func (ts *OtpExecutorTestSuite) TestExecuteClientErrorReturnsUserInputRequiredStatus() {
 	t := ts.T()
 	provider := &fakeAuthnProvider{sendOTPErr: shared.SendOTPFailedError}
 	e := NewOtpExecutor(provider)
@@ -209,8 +213,13 @@ func (ts *OtpExecutorTestSuite) TestExecuteClientErrorReturnsFailureStatus() {
 	if err != nil {
 		t.Fatalf("Execute() error = %v, want nil (client error surfaces via response)", err)
 	}
-	if resp.Status != providers.ExecFailure {
-		t.Errorf("Status = %q, want %q", resp.Status, providers.ExecFailure)
+	// ExecUserInputRequired (not ExecFailure) keeps the flow session alive so the user can
+	// correct the individual ID and retry, instead of terminating with flowStatus: ERROR.
+	if resp.Status != providers.ExecUserInputRequired {
+		t.Errorf("Status = %q, want %q", resp.Status, providers.ExecUserInputRequired)
+	}
+	if len(resp.Inputs) != 1 || resp.Inputs[0].Identifier != usernameAttr {
+		t.Errorf("Inputs = %v, want [%s]", resp.Inputs, usernameAttr)
 	}
 	if resp.Error != shared.SendOTPFailedError {
 		t.Errorf("Error = %v, want %v", resp.Error, shared.SendOTPFailedError)

--- a/esignet-service/internal/engine/mock/authenticator.go
+++ b/esignet-service/internal/engine/mock/authenticator.go
@@ -211,6 +211,49 @@ func (p *mockAuthnProvider) SendOTP(ctx context.Context, identifiers map[string]
 	return result, nil
 }
 
+func (p *mockAuthnProvider) GetSigningCertificates(ctx context.Context) ([]shared.CertificateData, *common.ServiceError) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.cfg.CertificateURL, nil)
+	if err != nil {
+		applog.GetLogger().Error(ctx, "Failed to certificates create request", applog.Error(err))
+		return nil, shared.CertificateFetchFailed
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		applog.GetLogger().Error(ctx, "Failed to fetch certificates", applog.Error(err))
+		return nil, shared.CertificateFetchFailed
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// check the response status code before parsing the body
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		applog.GetLogger().Error(ctx, "Failed to parse certificate response",
+			applog.Any("statusCode", resp.StatusCode))
+		return nil, shared.CertificateFetchFailed
+	}
+
+	// Parse response
+	var wrapper CertificateResponseWrapper
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		applog.GetLogger().Error(ctx, "Failed to parse certificate response", applog.Error(err))
+		return nil, shared.CertificateFetchFailed
+	}
+
+	// Success path
+	if wrapper.Response != nil {
+		certs := make([]shared.CertificateData, 0, len(wrapper.Response.AllCertificates))
+		for _, certData := range wrapper.Response.AllCertificates {
+			certs = append(certs, shared.CertificateData{
+				KeyId:       certData.KeyId,
+				Certificate: certData.CertificateData})
+		}
+		return certs, nil
+	}
+
+	return nil, shared.CertificateFetchFailed
+}
+
 // setChallenge inspects identifiers and credentials for a supported auth factor and
 // populates the corresponding field on the kyc-auth request. Only otp/password (which
 // arrive as sensitive PASSWORD_INPUT/OTP_INPUT flow inputs) reach the credentials map;

--- a/esignet-service/internal/engine/mock/authenticator.go
+++ b/esignet-service/internal/engine/mock/authenticator.go
@@ -245,7 +245,7 @@ func (p *mockAuthnProvider) GetSigningCertificates(ctx context.Context) ([]share
 		certs := make([]shared.CertificateData, 0, len(wrapper.Response.AllCertificates))
 		for _, certData := range wrapper.Response.AllCertificates {
 			certs = append(certs, shared.CertificateData{
-				KeyId:       certData.KeyId,
+				KeyID:       certData.KeyID,
 				Certificate: certData.CertificateData})
 		}
 		return certs, nil

--- a/esignet-service/internal/engine/mock/authenticator_test.go
+++ b/esignet-service/internal/engine/mock/authenticator_test.go
@@ -416,6 +416,90 @@ func (ts *AuthenticatorTestSuite) TestSendOTP() {
 	})
 }
 
+func (ts *AuthenticatorTestSuite) TestGetSigningCertificates() {
+	t := ts.T()
+
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"response":{"allCertificates":[
+				{"keyId":"key-1","certificateData":"cert-1"},
+				{"keyId":"key-2","certificateData":"cert-2"}
+			]}}`))
+		}))
+		defer server.Close()
+
+		p := newTestProvider(t, "http://unused", "http://unused", "http://unused")
+		p.cfg.CertificateURL = server.URL
+		certs, svcErr := p.GetSigningCertificates(context.Background())
+		require.Nil(t, svcErr)
+		require.Equal(t, []shared.CertificateData{
+			{KeyID: "key-1", Certificate: "cert-1"},
+			{KeyID: "key-2", Certificate: "cert-2"},
+		}, certs)
+	})
+
+	t.Run("request creation error", func(t *testing.T) {
+		p := newTestProvider(t, "http://unused", "http://unused", "http://unused")
+		p.cfg.CertificateURL = "://bad-url"
+		certs, svcErr := p.GetSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("connection error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		server.Close()
+
+		p := newTestProvider(t, "http://unused", "http://unused", "http://unused")
+		p.cfg.CertificateURL = server.URL
+		certs, svcErr := p.GetSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("non-2xx status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		p := newTestProvider(t, "http://unused", "http://unused", "http://unused")
+		p.cfg.CertificateURL = server.URL
+		certs, svcErr := p.GetSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("invalid json body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("not json"))
+		}))
+		defer server.Close()
+
+		p := newTestProvider(t, "http://unused", "http://unused", "http://unused")
+		p.cfg.CertificateURL = server.URL
+		certs, svcErr := p.GetSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("error response with no certificates", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"errors":[{"errorCode":"IDA-003","message":"fetch failed"}]}`))
+		}))
+		defer server.Close()
+
+		p := newTestProvider(t, "http://unused", "http://unused", "http://unused")
+		p.cfg.CertificateURL = server.URL
+		certs, svcErr := p.GetSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+}
+
 func (ts *AuthenticatorTestSuite) TestNoOpMethods() {
 	t := ts.T()
 	p := newTestProvider(t, "http://unused", "http://unused", "http://unused")

--- a/esignet-service/internal/engine/mock/config.go
+++ b/esignet-service/internal/engine/mock/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	KycExchangeV3URL string
 	SendOtpURL       string
 	OtpChannels      []string
+	CertificateURL   string
 }
 
 // LoadConfig reads mock-identity-system settings from environment variables.
@@ -38,6 +39,9 @@ func LoadConfig() Config {
 		),
 		SendOtpURL: envOrDefault(
 			"MOSIP_ESIGNET_MOCK_SEND_OTP_URL", base+"/send-otp",
+		),
+		CertificateURL: envOrDefault(
+			"MOSIP_ESIGNET_MOCK_AUTHENTICATOR_SIGNING_KEYS_URL", base+"/keys.json",
 		),
 		OtpChannels: []string{"email", "phone"},
 	}

--- a/esignet-service/internal/engine/mock/model.go
+++ b/esignet-service/internal/engine/mock/model.go
@@ -75,6 +75,7 @@ type Error struct {
 	Message   string `json:"message,omitempty"`
 }
 
+// CertificateResponseWrapper is the getAllCertificates API response envelope.
 type CertificateResponseWrapper struct {
 	ID           string                      `json:"id,omitempty"`
 	Version      string                      `json:"version,omitempty"`
@@ -83,11 +84,14 @@ type CertificateResponseWrapper struct {
 	Errors       []Error                     `json:"errors,omitempty"`
 }
 
+// GetAllCertificatesResponse is the getAllCertificates API success payload.
 type GetAllCertificatesResponse struct {
 	AllCertificates []KycSigningCertificateData `json:"allCertificates"`
 }
 
+// KycSigningCertificateData is a single signing certificate entry returned
+// by the getAllCertificates API.
 type KycSigningCertificateData struct {
-	KeyId           string `json:"keyId"`
-	CertificateData string `json:"certificateData"` //X509 certificate
+	KeyID           string `json:"keyId"`
+	CertificateData string `json:"certificateData"` // X509 certificate
 }

--- a/esignet-service/internal/engine/mock/model.go
+++ b/esignet-service/internal/engine/mock/model.go
@@ -74,3 +74,20 @@ type Error struct {
 	ErrorCode string `json:"errorCode,omitempty"`
 	Message   string `json:"message,omitempty"`
 }
+
+type CertificateResponseWrapper struct {
+	ID           string                      `json:"id,omitempty"`
+	Version      string                      `json:"version,omitempty"`
+	ResponseTime string                      `json:"responsetime,omitempty"` // usually ISO8601 / RFC3339
+	Response     *GetAllCertificatesResponse `json:"response,omitempty"`
+	Errors       []Error                     `json:"errors,omitempty"`
+}
+
+type GetAllCertificatesResponse struct {
+	AllCertificates []KycSigningCertificateData `json:"allCertificates"`
+}
+
+type KycSigningCertificateData struct {
+	KeyId           string `json:"keyId"`
+	CertificateData string `json:"certificateData"` //X509 certificate
+}

--- a/esignet-service/internal/engine/mosip/auditor.go
+++ b/esignet-service/internal/engine/mosip/auditor.go
@@ -49,19 +49,14 @@ type auditor struct {
 
 // NewAuditor builds an audit-manager observability provider. It fails if no
 // audit manager endpoint is configured.
-func NewAuditor(client *http.Client) (providers.ObservabilityProvider, error) {
-	auditCfg, err := LoadAuditConfig()
-	if err != nil {
-		return nil, err
-	}
-
+func NewAuditor(client *http.Client, pluginConfig Config, tokenProvider *tokenProvider) (providers.ObservabilityProvider, error) {
 	hostName, err := os.Hostname()
 	if err != nil || hostName == "" {
 		hostName = defaultHost
 	}
 
 	return &auditor{
-		client:   NewClient(auditCfg, client),
+		client:   NewClient(pluginConfig, client, tokenProvider),
 		hostName: hostName,
 		log:      applog.GetLogger(),
 	}, nil
@@ -177,19 +172,19 @@ func firstNonEmpty(values ...string) string {
 
 // Client posts audit records to mosip-audit-manager.
 type Client struct {
-	cfg    AuditConfig
-	client *http.Client
-	token  *tokenProvider
-	log    *applog.Logger
+	cfg           Config
+	client        *http.Client
+	tokenProvider *tokenProvider
+	log           *applog.Logger
 }
 
 // NewClient builds an audit manager client from the given config and HTTP client.
-func NewClient(cfg AuditConfig, client *http.Client) *Client {
+func NewClient(cfg Config, client *http.Client, tokenProvider *tokenProvider) *Client {
 	return &Client{
-		cfg:    cfg,
-		client: client,
-		token:  newTokenProvider(cfg, client),
-		log:    applog.GetLogger(),
+		cfg:           cfg,
+		client:        client,
+		tokenProvider: tokenProvider,
+		log:           applog.GetLogger(),
 	}
 }
 
@@ -215,7 +210,7 @@ func (c *Client) Post(ctx context.Context, audit AuditRequest) error {
 	if status == http.StatusUnauthorized || status == http.StatusForbidden {
 		c.log.Warn(ctx, "audit: auth rejected by audit manager, refreshing token",
 			applog.Int("status", status))
-		c.token.Purge()
+		c.tokenProvider.Purge()
 		if status, err = c.send(ctx, body); err != nil {
 			return err
 		}
@@ -237,7 +232,7 @@ func (c *Client) send(ctx context.Context, body []byte) (int, error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	token, tErr := c.token.GetAuthToken(ctx)
+	token, tErr := c.tokenProvider.GetAuthToken(ctx)
 	if tErr != nil {
 		return 0, fmt.Errorf("acquire audit auth token: %w", tErr)
 	}

--- a/esignet-service/internal/engine/mosip/auditor_test.go
+++ b/esignet-service/internal/engine/mosip/auditor_test.go
@@ -41,11 +41,17 @@ func newTestAuditor(t *testing.T) (providers.ObservabilityProvider, <-chan Audit
 	}))
 	t.Cleanup(tokenSrv.Close)
 
-	t.Setenv("MOSIP_ESIGNET_AUDIT_MANAGER_URL", srv.URL)
-	t.Setenv("MOSIP_ESIGNET_AUTH_TOKEN_URL", tokenSrv.URL)
-	t.Setenv("MOSIP_ESIGNET_IDA_CLIENT_SECRET", "secret")
+	client := &http.Client{}
+	cfg := Config{
+		AuditManagerURL: srv.URL,
+		AuthTokenURL:    tokenSrv.URL,
+		SecretKey:       "secret",
+		ClientID:        defaultClientID,
+		AppID:           defaultAppID,
+	}
+	tokenProvider := newTokenProvider(cfg, client)
 
-	p, err := NewAuditor(&http.Client{})
+	p, err := NewAuditor(client, cfg, tokenProvider)
 	if err != nil {
 		t.Fatalf("NewAuditor: %v", err)
 	}
@@ -138,13 +144,15 @@ func (ts *AuditorTestSuite) TestClientPostSendsWrappedBodyAndCookie() {
 	}))
 	defer auditSrv.Close()
 
-	c := NewClient(AuditConfig{
+	client := &http.Client{}
+	cfg := Config{
 		AuditManagerURL: auditSrv.URL,
 		AuthTokenURL:    tokenSrv.URL,
 		SecretKey:       "secret",
 		ClientID:        "cid",
 		AppID:           "ida",
-	}, &http.Client{})
+	}
+	c := NewClient(cfg, client, newTokenProvider(cfg, client))
 
 	err := c.Post(context.Background(), AuditRequest{EventID: "FLOW_FAILED", EventType: "ERROR"})
 	if err != nil {
@@ -185,11 +193,13 @@ func (ts *AuditorTestSuite) TestClientPostPurgesAndRetriesOn401() {
 	}))
 	defer auditSrv.Close()
 
-	c := NewClient(AuditConfig{
+	client := &http.Client{}
+	cfg := Config{
 		AuditManagerURL: auditSrv.URL,
 		AuthTokenURL:    tokenSrv.URL,
 		SecretKey:       "secret",
-	}, &http.Client{})
+	}
+	c := NewClient(cfg, client, newTokenProvider(cfg, client))
 
 	if err := c.Post(context.Background(), AuditRequest{}); err != nil {
 		t.Fatalf("Post: %v", err)
@@ -210,7 +220,9 @@ func (ts *AuditorTestSuite) TestClientPostFailsWithoutAuthTokenURL() {
 	}))
 	defer auditSrv.Close()
 
-	c := NewClient(AuditConfig{AuditManagerURL: auditSrv.URL}, &http.Client{})
+	client := &http.Client{}
+	cfg := Config{AuditManagerURL: auditSrv.URL}
+	c := NewClient(cfg, client, newTokenProvider(cfg, client))
 	if err := c.Post(context.Background(), AuditRequest{}); err == nil {
 		t.Fatal("Post: want error when auth token URL is not configured")
 	}

--- a/esignet-service/internal/engine/mosip/authenticator.go
+++ b/esignet-service/internal/engine/mosip/authenticator.go
@@ -66,12 +66,13 @@ const (
 )
 
 type mosipAuthnProvider struct {
-	appConfig *config.AppConfig
-	client    *http.Client
-	clientSvc *clientmgmt.Service
-	svc       *keymanager.Service
-	sigSvc    *signature.Service
-	cfg       Config
+	appConfig     *config.AppConfig
+	client        *http.Client
+	clientSvc     *clientmgmt.Service
+	svc           *keymanager.Service
+	sigSvc        *signature.Service
+	cfg           Config
+	tokenProvider *tokenProvider
 
 	// certMu guards cachedCert, the last IDA partner certificate fetched by
 	// fetchIDAPartnerCertificate. Cached until it nears its own NotAfter, so
@@ -85,14 +86,16 @@ type mosipAuthnProvider struct {
 // OIDC_PARTNER / RSA_2048 component master key via svc/sigSvc (see
 // getRequestSignature).
 func NewMosipAuthnProvider(cfg *config.AppConfig, clientSvc *clientmgmt.Service, client *http.Client,
-	svc *keymanager.Service, sigSvc *signature.Service) (shared.ConsolidatedAuthnProvider, error) {
+	svc *keymanager.Service, sigSvc *signature.Service, pluginConfig Config,
+	tokenProvider *tokenProvider) (shared.ConsolidatedAuthnProvider, error) {
 	provider := &mosipAuthnProvider{
-		appConfig: cfg,
-		client:    client,
-		clientSvc: clientSvc,
-		svc:       svc,
-		sigSvc:    sigSvc,
-		cfg:       LoadConfig(),
+		appConfig:     cfg,
+		client:        client,
+		clientSvc:     clientSvc,
+		svc:           svc,
+		sigSvc:        sigSvc,
+		cfg:           pluginConfig,
+		tokenProvider: tokenProvider,
 	}
 	return provider, nil
 }
@@ -100,38 +103,16 @@ func NewMosipAuthnProvider(cfg *config.AppConfig, clientSvc *clientmgmt.Service,
 func (p *mosipAuthnProvider) Authenticate(ctx context.Context, identifiers, credentials map[string]interface{},
 	metadata *providers.AuthnMetadata) (*providers.AuthnResult, *common.ServiceError) {
 
-	clientDtl, err := p.getApplicationAndClientID(ctx, metadata.RuntimeMetadata)
-	if err != nil {
-		return nil, shared.ClientNotFoundError
-	}
-
 	individualID, ok := identifiers["username"].(string)
 	if !ok || individualID == "" {
 		return nil, shared.InvalidIndividualIDError
 	}
 
-	transactionID, err := shared.GenerateTransactionID(metadata.RuntimeMetadata)
-	if err != nil {
-		return nil, shared.InvalidRequestError
-	}
-
-	claimsMetadataRequired := false
-	requestTime := GetUTCDateTime()
-	idaKycAuthRequest := &IdaKycAuthRequest{
-		ID:                     mosipKycAuthRequestID,
-		Version:                mosipRequestVersion,
-		RequestTime:            requestTime,
-		DomainURI:              p.cfg.DomainURI,
-		Env:                    p.cfg.Env,
-		ConsentObtained:        true,
-		IndividualID:           individualID,
-		TransactionID:          transactionID,
-		ClaimsMetadataRequired: &claimsMetadataRequired,
-	}
-
 	if len(credentials) == 0 {
 		return nil, shared.InvalidRequestError
 	}
+
+	requestTime := GetUTCDateTime()
 	authRequest := &AuthRequest{
 		Timestamp: requestTime,
 	}
@@ -163,6 +144,44 @@ func (p *mosipAuthnProvider) Authenticate(ctx context.Context, identifiers, cred
 	if !credentialSet {
 		return nil, shared.InvalidRequestError
 	}
+
+	transactionID, err := shared.GenerateTransactionID(metadata.RuntimeMetadata)
+	if err != nil {
+		return nil, shared.InvalidRequestError
+	}
+
+	claimsMetadataRequired := false
+	idaKycAuthRequest := &IdaKycAuthRequest{
+		ID:                     mosipKycAuthRequestID,
+		Version:                mosipRequestVersion,
+		RequestTime:            requestTime,
+		DomainURI:              p.cfg.DomainURI,
+		Env:                    p.cfg.Env,
+		ConsentObtained:        true,
+		IndividualID:           individualID,
+		TransactionID:          transactionID,
+		ClaimsMetadataRequired: &claimsMetadataRequired,
+	}
+
+	// Resolve the client and fetch the IDA partner certificate concurrently
+	// with each other and with the request-encryption work below: neither
+	// depends on the other's result, and both only gate performKycAuth at
+	// the end. clientErr takes precedence over any later error, matching
+	// the sequential lookup-then-validate order this replaces.
+	var (
+		clientDtl     clientmgmt.ClientResponse
+		clientErr     error
+		generatedCert *x509.Certificate
+		certErr       error
+		wg            sync.WaitGroup
+	)
+	wg.Go(func() {
+		clientDtl, clientErr = p.getApplicationAndClientID(ctx, metadata.RuntimeMetadata)
+	})
+	wg.Go(func() {
+		generatedCert, certErr = p.fetchIDAPartnerCertificate(ctx)
+	})
+
 	authRequestBytes, err := json.Marshal(authRequest)
 	if err != nil {
 		applog.GetLogger().Error(ctx, "Auth request marshal failed", applog.Error(err))
@@ -199,9 +218,13 @@ func (p *mosipAuthnProvider) Authenticate(ctx context.Context, identifiers, cred
 		applog.GetLogger().Error(ctx, "Auth request hash encryption failed", applog.Error(err))
 		return nil, shared.AuthenticationFailedError
 	}
-	generatedCert, err := p.fetchIDAPartnerCertificate(ctx)
-	if err != nil {
-		applog.GetLogger().Error(ctx, "IDA partner certificate fetch failed", applog.Error(err))
+
+	wg.Wait()
+	if clientErr != nil {
+		return nil, shared.ClientNotFoundError
+	}
+	if certErr != nil {
+		applog.GetLogger().Error(ctx, "IDA partner certificate fetch failed", applog.Error(certErr))
 		return nil, shared.AuthenticationFailedError
 	}
 
@@ -238,17 +261,37 @@ func (p *mosipAuthnProvider) GetAttributes(ctx context.Context, attributeToken a
 		return nil, shared.InvalidRequestError
 	}
 
-	clientDtl, err := p.getApplicationAndClientID(ctx, metadata.RuntimeMetadata)
-	if err != nil {
-		return nil, shared.ClientNotFoundError
+	// Resolve the client concurrently with building, marshaling and signing
+	// the KYC exchange request below: the client lookup is only needed for
+	// the final IDA call, so it can overlap with everything up to that
+	// point. clientFailed still takes precedence over any attributeToken
+	// issue, matching the sequential lookup-then-validate order this
+	// replaces.
+	var (
+		clientDtl clientmgmt.ClientResponse
+		clientErr error
+		wg        sync.WaitGroup
+	)
+	wg.Go(func() {
+		clientDtl, clientErr = p.getApplicationAndClientID(ctx, metadata.RuntimeMetadata)
+	})
+	clientFailed := func() bool {
+		wg.Wait()
+		return clientErr != nil
 	}
 
 	if attributeToken == nil || attributeToken == "" {
+		if clientFailed() {
+			return nil, shared.ClientNotFoundError
+		}
 		return nil, nil
 	}
 
 	tokenParts := strings.Split(attributeToken.(string), "||") // Extract KYC token, username and transaction ID from token (format "kycToken||username||transactionID")
 	if len(tokenParts) != 3 {
+		if clientFailed() {
+			return nil, shared.ClientNotFoundError
+		}
 		return nil, shared.AuthenticationFailedError
 	}
 	kycToken, username, transactionID := tokenParts[0], tokenParts[1], tokenParts[2]
@@ -277,12 +320,22 @@ func (p *mosipAuthnProvider) GetAttributes(ctx context.Context, attributeToken a
 
 	requestBytes, err := json.Marshal(idaKycExchangeRequest)
 	if err != nil {
+		if clientFailed() {
+			return nil, shared.ClientNotFoundError
+		}
 		return nil, shared.InvalidRequestError
 	}
 
 	requestSignature, err := p.getRequestSignature(ctx, requestBytes)
 	if err != nil {
+		if clientFailed() {
+			return nil, shared.ClientNotFoundError
+		}
 		return nil, shared.InvalidRequestError
+	}
+
+	if clientFailed() {
+		return nil, shared.ClientNotFoundError
 	}
 	attributesResponse, err := p.callKycExchangeEndpoint(ctx, requestBytes, requestSignature, clientDtl.RpID, clientDtl.ClientID)
 	if err != nil {
@@ -347,6 +400,63 @@ func (p *mosipAuthnProvider) SendOTP(ctx context.Context, identifiers map[string
 
 	sendOTPResult.TransactionID = transactionID
 	return sendOTPResult, nil
+}
+
+func (p *mosipAuthnProvider) GetSigningCertificates(ctx context.Context) ([]shared.CertificateData, *common.ServiceError) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.cfg.IDACertificateURL, nil)
+	if err != nil {
+		applog.GetLogger().Error(ctx, "Failed to certificates create request", applog.Error(err))
+		return nil, shared.CertificateFetchFailed
+	}
+	token, tErr := p.tokenProvider.GetAuthToken(ctx)
+	if tErr != nil {
+		applog.GetLogger().Error(ctx, "Failed to fetch auth token", applog.Error(tErr))
+		return nil, shared.AuthTokenFetchFailed
+	}
+	req.Header.Set("Cookie", "Authorization="+token)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		applog.GetLogger().Error(ctx, "Failed to fetch certificates", applog.Error(err))
+		return nil, shared.CertificateFetchFailed
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		p.tokenProvider.Purge()
+		return nil, shared.CertificateFetchFailed
+	}
+
+	// check the response status code before parsing the body
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		applog.GetLogger().Error(ctx, "Failed to parse certificate response",
+			applog.Any("statusCode", resp.StatusCode))
+		return nil, shared.CertificateFetchFailed
+	}
+
+	// Parse response
+	var wrapper CertificateResponseWrapper
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		applog.GetLogger().Error(ctx, "Failed to parse certificate response", applog.Error(err))
+		return nil, shared.CertificateFetchFailed
+	}
+
+	// Success path
+	if wrapper.Response != nil {
+		certs := make([]shared.CertificateData, 0, len(wrapper.Response.AllCertificates))
+		for _, certData := range wrapper.Response.AllCertificates {
+			certs = append(certs, shared.CertificateData{
+				KeyId:       certData.KeyId,
+				Certificate: certData.CertificateData})
+		}
+		return certs, nil
+	}
+
+	applog.GetLogger().Error(ctx, "IDA Get all certificate error response",
+		applog.Any("errorCodes", errorCodes(wrapper.Errors)))
+
+	return nil, shared.CertificateFetchFailed
 }
 
 func (p *mosipAuthnProvider) getApplicationAndClientID(ctx context.Context, runtimeMetadata map[string][]string) (clientmgmt.ClientResponse, error) {
@@ -521,7 +631,7 @@ func (p *mosipAuthnProvider) invalidateCachedIDAPartnerCertificate(ctx context.C
 // doFetchIDAPartnerCertificate performs the actual HTTP GET + PEM/X.509
 // parse against p.cfg.IDAPartnerCertificateURL, unconditionally.
 func (p *mosipAuthnProvider) doFetchIDAPartnerCertificate(ctx context.Context) (*x509.Certificate, error) {
-	req, err := http.NewRequest(http.MethodGet, p.cfg.IDAPartnerCertificateURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.cfg.IDAPartnerCertificateURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +761,7 @@ func (p *mosipAuthnProvider) callSendOtpEndpoint(
 		return nil, fmt.Errorf("invalid send OTP URL: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(requestBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create send OTP request: %w", err)
 	}
@@ -768,7 +878,7 @@ func (p *mosipAuthnProvider) callKycAuthEndpoint(
 		return "", "", err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(requestBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(requestBody))
 	if err != nil {
 		return "", "", err
 	}
@@ -836,7 +946,7 @@ func (p *mosipAuthnProvider) callKycExchangeEndpoint(
 		return nil, fmt.Errorf("invalid KYC exchange URL: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(requestBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KYC exchange request: %w", err)
 	}

--- a/esignet-service/internal/engine/mosip/authenticator.go
+++ b/esignet-service/internal/engine/mosip/authenticator.go
@@ -63,6 +63,17 @@ const (
 	// IDA partner certificate is treated as expired, so a refetch has time
 	// to land before IDA actually rejects encryption under the old cert.
 	idaPartnerCertExpiryBuffer = 5 * time.Minute
+
+	// signingCertsExpiryBuffer is how far ahead of the auth token's expiry a
+	// cached signing-certificate list is treated as expired: the list was
+	// fetched using that token, so there's no point caching it past the
+	// point where the token needs to be refreshed anyway.
+	signingCertsExpiryBuffer = 1 * time.Minute
+
+	// signingCertsDefaultTTL is the cache lifetime used when the auth
+	// token's expiry can't be determined (e.g. it isn't a JWT, or carries no
+	// exp claim).
+	signingCertsDefaultTTL = 5 * time.Minute
 )
 
 type mosipAuthnProvider struct {
@@ -79,6 +90,14 @@ type mosipAuthnProvider struct {
 	// Authenticate stops paying an HTTP round-trip per call.
 	certMu     sync.RWMutex
 	cachedCert *x509.Certificate
+
+	// certsMu guards cachedCerts, the last IDA signing-certificate list
+	// fetched by GetSigningCertificates. Cached until the auth token used to
+	// fetch it is due to expire, so JWKS/discovery calls stop paying an
+	// HTTP round-trip (plus an auth-token fetch) on every request.
+	certsMu     sync.RWMutex
+	cachedCerts []shared.CertificateData
+	certsExpiry time.Time
 }
 
 // NewMosipAuthnProvider creates a MOSIP providers.AuthnProviderManager with
@@ -402,7 +421,55 @@ func (p *mosipAuthnProvider) SendOTP(ctx context.Context, identifiers map[string
 	return sendOTPResult, nil
 }
 
+// GetSigningCertificates returns the ID system's signing certificates,
+// serving them from cache while the auth token they were fetched with
+// remains valid.
 func (p *mosipAuthnProvider) GetSigningCertificates(ctx context.Context) ([]shared.CertificateData, *common.ServiceError) {
+	p.certsMu.RLock()
+	cached := p.cachedCerts
+	expiry := p.certsExpiry
+	p.certsMu.RUnlock()
+	if cached != nil && time.Now().Before(expiry) {
+		return cached, nil
+	}
+
+	certs, svcErr := p.doFetchSigningCertificates(ctx)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	p.certsMu.Lock()
+	p.cachedCerts = certs
+	p.certsExpiry = p.signingCertsCacheExpiry()
+	p.certsMu.Unlock()
+
+	return certs, nil
+}
+
+// signingCertsCacheExpiry derives how long a just-fetched signing
+// certificate list should be cached for, tied to the auth token's own
+// expiry — falling back to a fixed TTL if that expiry can't be determined.
+func (p *mosipAuthnProvider) signingCertsCacheExpiry() time.Time {
+	if exp, ok := p.tokenProvider.TokenExpiry(); ok {
+		return exp.Add(-signingCertsExpiryBuffer)
+	}
+	return time.Now().Add(signingCertsDefaultTTL)
+}
+
+// invalidateCachedSigningCertificates drops the cached signing certificates,
+// forcing the next GetSigningCertificates call to fetch a fresh list instead
+// of reusing one IDA has just rejected.
+func (p *mosipAuthnProvider) invalidateCachedSigningCertificates(ctx context.Context) {
+	applog.GetLogger().Warn(ctx, "clearing cached IDA signing certificates after fetch rejection")
+	p.certsMu.Lock()
+	p.cachedCerts = nil
+	p.certsExpiry = time.Time{}
+	p.certsMu.Unlock()
+}
+
+// doFetchSigningCertificates performs the actual HTTP GET + JSON parse
+// against p.cfg.IDACertificateURL, unconditionally.
+func (p *mosipAuthnProvider) doFetchSigningCertificates(ctx context.Context) ([]shared.CertificateData, *common.ServiceError) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.cfg.IDACertificateURL, nil)
 	if err != nil {
 		applog.GetLogger().Error(ctx, "Failed to certificates create request", applog.Error(err))
@@ -425,6 +492,7 @@ func (p *mosipAuthnProvider) GetSigningCertificates(ctx context.Context) ([]shar
 
 	if resp.StatusCode == 401 || resp.StatusCode == 403 {
 		p.tokenProvider.Purge()
+		p.invalidateCachedSigningCertificates(ctx)
 		return nil, shared.CertificateFetchFailed
 	}
 
@@ -447,7 +515,7 @@ func (p *mosipAuthnProvider) GetSigningCertificates(ctx context.Context) ([]shar
 		certs := make([]shared.CertificateData, 0, len(wrapper.Response.AllCertificates))
 		for _, certData := range wrapper.Response.AllCertificates {
 			certs = append(certs, shared.CertificateData{
-				KeyId:       certData.KeyId,
+				KeyID:       certData.KeyID,
 				Certificate: certData.CertificateData})
 		}
 		return certs, nil

--- a/esignet-service/internal/engine/mosip/authenticator_test.go
+++ b/esignet-service/internal/engine/mosip/authenticator_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -596,6 +597,215 @@ func (ts *AuthenticatorTestSuite) TestInvalidateCachedIDAPartnerCertificateForce
 	require.NoError(t, err)
 
 	require.Equal(t, 2, hits, "a cleared cache should be refetched on the next call")
+}
+
+// newSigningCertsFixture starts a test IDA "getAllCertificates" server
+// returning a single certificate, and a test authmanager token server
+// returning a JWT whose exp claim is now+ttl. It wires both into a fresh
+// provider and returns hit counters for each.
+func newSigningCertsFixture(t *testing.T, tokenTTL time.Duration) (p *mosipAuthnProvider, certHits, tokenHits *int) {
+	t.Helper()
+	certHits = new(int)
+	tokenHits = new(int)
+
+	certSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*certHits++
+		wrapper := CertificateResponseWrapper{
+			Response: &GetAllCertificatesResponse{
+				AllCertificates: []KycSigningCertificateData{
+					{KeyID: "ida-signing", CertificateData: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(wrapper))
+	}))
+	t.Cleanup(certSrv.Close)
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*tokenHits++
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"exp": time.Now().Add(tokenTTL).Unix(),
+		})
+		signed, err := token.SignedString([]byte("test-signing-key"))
+		require.NoError(t, err)
+		w.Header().Set(authHeaderName, signed)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	cfg := Config{IDACertificateURL: certSrv.URL, AuthTokenURL: tokenSrv.URL}
+	p = newProvider(nil)
+	p.cfg = cfg
+	p.tokenProvider = newTokenProvider(cfg, certSrv.Client())
+	return p, certHits, tokenHits
+}
+
+func (ts *AuthenticatorTestSuite) TestGetSigningCertificatesCachesUntilTokenExpiry() {
+	t := ts.T()
+	p, certHits, tokenHits := newSigningCertsFixture(t, time.Hour) // well outside signingCertsExpiryBuffer
+
+	got1, svcErr := p.GetSigningCertificates(context.Background())
+	require.Nil(t, svcErr)
+	got2, svcErr := p.GetSigningCertificates(context.Background())
+	require.Nil(t, svcErr)
+
+	require.Equal(t, got1, got2)
+	require.Equal(t, 1, *certHits, "second call should be served from cache, not hit the server again")
+	require.Equal(t, 1, *tokenHits, "cached certs shouldn't need a fresh auth token either")
+}
+
+func (ts *AuthenticatorTestSuite) TestGetSigningCertificatesRefetchesNearTokenExpiry() {
+	t := ts.T()
+	// The token's exp falls inside signingCertsExpiryBuffer, so the cached
+	// certs should be treated as expired and refetched on the next call.
+	p, certHits, _ := newSigningCertsFixture(t, signingCertsExpiryBuffer/2)
+
+	_, svcErr := p.GetSigningCertificates(context.Background())
+	require.Nil(t, svcErr)
+	_, svcErr = p.GetSigningCertificates(context.Background())
+	require.Nil(t, svcErr)
+
+	require.Equal(t, 2, *certHits, "certs cached past the token's near-expiry window should be refetched")
+}
+
+func (ts *AuthenticatorTestSuite) TestGetSigningCertificatesFallsBackToDefaultTTLWithoutTokenExpiry() {
+	t := ts.T()
+	var certHits int
+	certSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		certHits++
+		wrapper := CertificateResponseWrapper{Response: &GetAllCertificatesResponse{
+			AllCertificates: []KycSigningCertificateData{{KeyID: "k", CertificateData: "c"}},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(wrapper))
+	}))
+	defer certSrv.Close()
+
+	// Token server returns a non-JWT token, so its expiry is unknown and the
+	// signingCertsDefaultTTL fallback applies.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(authHeaderName, "opaque-token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer tokenSrv.Close()
+
+	cfg := Config{IDACertificateURL: certSrv.URL, AuthTokenURL: tokenSrv.URL}
+	p := newProvider(nil)
+	p.cfg = cfg
+	p.tokenProvider = newTokenProvider(cfg, certSrv.Client())
+
+	_, svcErr := p.GetSigningCertificates(context.Background())
+	require.Nil(t, svcErr)
+	_, svcErr = p.GetSigningCertificates(context.Background())
+	require.Nil(t, svcErr)
+
+	require.Equal(t, 1, certHits, "unknown token expiry should still cache certs, via the default TTL")
+}
+
+func (ts *AuthenticatorTestSuite) TestGetSigningCertificatesInvalidatesCacheOn401() {
+	t := ts.T()
+	p, certHits, _ := newSigningCertsFixture(t, time.Hour)
+
+	_, svcErr := p.GetSigningCertificates(context.Background())
+	require.Nil(t, svcErr)
+	require.Equal(t, 1, *certHits)
+
+	// Force the next fetch to hit a 401, which should purge both the token
+	// and the certs cache.
+	rejectSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer rejectSrv.Close()
+	p.certsMu.Lock()
+	p.cachedCerts = nil // simulate the cache having already expired
+	p.certsMu.Unlock()
+	p.cfg.IDACertificateURL = rejectSrv.URL
+
+	_, svcErr = p.GetSigningCertificates(context.Background())
+	require.NotNil(t, svcErr)
+
+	p.certsMu.RLock()
+	cleared := p.cachedCerts == nil && p.certsExpiry.IsZero()
+	p.certsMu.RUnlock()
+	require.True(t, cleared, "a 401 should invalidate the signing-certs cache")
+}
+
+func (ts *AuthenticatorTestSuite) TestDoFetchSigningCertificatesErrors() {
+	t := ts.T()
+
+	t.Run("request creation error", func(t *testing.T) {
+		p := newProvider(nil)
+		p.cfg.IDACertificateURL = "://bad-url"
+		certs, svcErr := p.doFetchSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("auth token fetch error", func(t *testing.T) {
+		certSrv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Fatal("certificate endpoint should not be called when the token fetch fails")
+		}))
+		defer certSrv.Close()
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer tokenSrv.Close()
+
+		cfg := Config{IDACertificateURL: certSrv.URL, AuthTokenURL: tokenSrv.URL}
+		p := newProvider(nil)
+		p.cfg = cfg
+		p.tokenProvider = newTokenProvider(cfg, certSrv.Client())
+
+		certs, svcErr := p.doFetchSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.AuthTokenFetchFailed, svcErr)
+	})
+
+	t.Run("connection error", func(t *testing.T) {
+		p, _, _ := newSigningCertsFixture(t, time.Hour)
+		closedSrv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		closedSrv.Close()
+		p.cfg.IDACertificateURL = closedSrv.URL
+
+		certs, svcErr := p.doFetchSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("non-2xx status", func(t *testing.T) {
+		p, _, _ := newSigningCertsFixture(t, time.Hour)
+		nonOKSrv := httptest.NewServer(jsonHandler(http.StatusInternalServerError, "boom"))
+		defer nonOKSrv.Close()
+		p.cfg.IDACertificateURL = nonOKSrv.URL
+
+		certs, svcErr := p.doFetchSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("invalid json body", func(t *testing.T) {
+		p, _, _ := newSigningCertsFixture(t, time.Hour)
+		badJSONSrv := httptest.NewServer(jsonHandler(http.StatusOK, "not json"))
+		defer badJSONSrv.Close()
+		p.cfg.IDACertificateURL = badJSONSrv.URL
+
+		certs, svcErr := p.doFetchSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
+
+	t.Run("error response with no certificates", func(t *testing.T) {
+		p, _, _ := newSigningCertsFixture(t, time.Hour)
+		errSrv := httptest.NewServer(jsonHandler(http.StatusOK,
+			`{"errors":[{"errorCode":"IDA-003","errorMessage":"fetch failed"}]}`))
+		defer errSrv.Close()
+		p.cfg.IDACertificateURL = errSrv.URL
+
+		certs, svcErr := p.doFetchSigningCertificates(context.Background())
+		require.Nil(t, certs)
+		require.Same(t, shared.CertificateFetchFailed, svcErr)
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -1314,7 +1524,7 @@ func (ts *AuthenticatorTestSuite) TestNewMosipAuthnProviderWiresConfig() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-1")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
+	t.Setenv("MOSIP_IDA_CLIENT_SECRET", "shh")
 
 	pluginConfig, err := LoadConfig()
 	require.NoError(t, err)

--- a/esignet-service/internal/engine/mosip/authenticator_test.go
+++ b/esignet-service/internal/engine/mosip/authenticator_test.go
@@ -1314,8 +1314,13 @@ func (ts *AuthenticatorTestSuite) TestNewMosipAuthnProviderWiresConfig() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-1")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
 
-	provider, err := NewMosipAuthnProvider(&config.AppConfig{}, nil, &http.Client{}, nil, nil)
+	pluginConfig, err := LoadConfig()
+	require.NoError(t, err)
+
+	client := &http.Client{}
+	provider, err := NewMosipAuthnProvider(&config.AppConfig{}, nil, client, nil, nil, pluginConfig, newTokenProvider(pluginConfig, client))
 	require.NoError(t, err)
 	require.NotNil(t, provider)
 

--- a/esignet-service/internal/engine/mosip/config.go
+++ b/esignet-service/internal/engine/mosip/config.go
@@ -8,11 +8,15 @@
 package mosip
 
 import (
-	"fmt"
+	"errors"
 	"os"
 )
 
-const defaultMosipEnv = "Staging"
+const (
+	defaultMosipEnv = "Staging"
+	defaultAppID    = "ida"
+	defaultClientID = "mosip-ida-client"
+)
 
 // Config holds MOSIP IDA integration settings.
 type Config struct {
@@ -22,13 +26,30 @@ type Config struct {
 	KYCAuthBaseURL           string
 	KYCExchangeBaseURL       string
 	DomainURI                string
+	IDACertificateURL        string
 	Env                      string
+	AuthTokenURL             string
+	ClientID                 string
+	SecretKey                string
+	AppID                    string
+	AuditManagerURL          string
 }
 
 // LoadConfig reads MOSIP auth settings from environment variables.
-func LoadConfig() Config {
+func LoadConfig() (Config, error) {
 	licenseKey := envOrDefault("MOSIP_ESIGNET_MISP_KEY", "")
 	apiBase := trimTrailingSlash(envOrDefault("MOSIP_API_INTERNAL_HOST", ""))
+	clientSecret := trimTrailingSlash(envOrDefault("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", ""))
+
+	if clientSecret == "" {
+		return Config{}, errors.New("mosip: MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET is required")
+	}
+	if licenseKey == "" {
+		return Config{}, errors.New("mosip: MOSIP_ESIGNET_MISP_KEY is required")
+	}
+	if apiBase == "" {
+		return Config{}, errors.New("mosip: MOSIP_API_INTERNAL_HOST is required")
+	}
 
 	return Config{
 		LicenseKey: licenseKey,
@@ -48,9 +69,24 @@ func LoadConfig() Config {
 			"MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_EXCHANGE_URL",
 			apiBase+"/idauthentication/v1/kyc-exchange/delegated/"+licenseKey+"/",
 		),
+		IDACertificateURL: envOrDefault(
+			"MOSIP_ESIGNET_AUTHENTICATOR_IDA_GET_CERTIFICATES_URL",
+			apiBase+"/idauthentication/v1/internal/getAllCertificates?applicationId=IDA_KYC_EXCHANGE&referenceId= ",
+		),
+		AuthTokenURL: envOrDefault(
+			"MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH_TOKEN_URL",
+			apiBase+"/v1/authmanager/authenticate/clientidsecretkey",
+		),
+		AuditManagerURL: envOrDefault(
+			"MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT_MANAGER_URL",
+			apiBase+"/v1/auditmanager/audits",
+		),
 		DomainURI: envOrDefault("MOSIP_ESIGNET_DOMAIN_URL", apiBase),
 		Env:       envOrDefault("IDA_AUTHENTICATOR_ENV", defaultMosipEnv),
-	}
+		ClientID:  envOrDefault("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_ID", defaultClientID),
+		SecretKey: clientSecret,
+		AppID:     envOrDefault("MOSIP_ESIGNET_AUTHENTICATOR_IDA_APP_ID", defaultAppID),
+	}, nil
 }
 
 func envOrDefault(key, fallback string) string {
@@ -65,54 +101,4 @@ func trimTrailingSlash(value string) string {
 		value = value[:len(value)-1]
 	}
 	return value
-}
-
-// AuditConfig holds mosip-audit-manager integration settings.
-//
-// The auditor authenticates to MOSIP authmanager with a client-id/secret,
-// then POSTs an AuditRequest (wrapped in an AuditRequestWrapper) to the audit
-// manager. Authentication tokens are cached in memory and purged on 401/403
-// from the audit endpoint.
-type AuditConfig struct {
-	// AuditManagerURL is the audit ingestion endpoint (POST).
-	AuditManagerURL string
-	// AuthTokenURL is the authmanager clientidsecretkey endpoint (POST).
-	AuthTokenURL string
-	// ClientID, SecretKey and AppID are the authmanager client credentials.
-	ClientID  string
-	SecretKey string
-	AppID     string
-}
-
-const (
-	auditDefaultClientID = "mosip-ida-client"
-	auditDefaultAppID    = "ida"
-)
-
-// LoadAuditConfig reads audit settings from environment variables. URLs are
-// derived from MOSIP_API_INTERNAL_HOST unless overridden individually. It
-// fails if no audit manager endpoint can be resolved.
-func LoadAuditConfig() (AuditConfig, error) {
-	apiBase := trimTrailingSlash(os.Getenv("MOSIP_API_INTERNAL_HOST"))
-
-	auditURL := os.Getenv("MOSIP_ESIGNET_AUDIT_MANAGER_URL")
-	if auditURL == "" && apiBase != "" {
-		auditURL = apiBase + "/v1/auditmanager/audits"
-	}
-	if auditURL == "" {
-		return AuditConfig{}, fmt.Errorf("audit manager not configured: set MOSIP_ESIGNET_AUDIT_MANAGER_URL or MOSIP_API_INTERNAL_HOST")
-	}
-
-	tokenURL := os.Getenv("MOSIP_ESIGNET_AUTH_TOKEN_URL")
-	if tokenURL == "" && apiBase != "" {
-		tokenURL = apiBase + "/v1/authmanager/authenticate/clientidsecretkey"
-	}
-
-	return AuditConfig{
-		AuditManagerURL: auditURL,
-		AuthTokenURL:    tokenURL,
-		ClientID:        envOrDefault("MOSIP_ESIGNET_IDA_CLIENT_ID", auditDefaultClientID),
-		SecretKey:       os.Getenv("MOSIP_ESIGNET_IDA_CLIENT_SECRET"),
-		AppID:           envOrDefault("MOSIP_ESIGNET_IDA_APP_ID", auditDefaultAppID),
-	}, nil
 }

--- a/esignet-service/internal/engine/mosip/config.go
+++ b/esignet-service/internal/engine/mosip/config.go
@@ -39,10 +39,10 @@ type Config struct {
 func LoadConfig() (Config, error) {
 	licenseKey := envOrDefault("MOSIP_ESIGNET_MISP_KEY", "")
 	apiBase := trimTrailingSlash(envOrDefault("MOSIP_API_INTERNAL_HOST", ""))
-	clientSecret := trimTrailingSlash(envOrDefault("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", ""))
+	clientSecret := envOrDefault("MOSIP_IDA_CLIENT_SECRET", "")
 
 	if clientSecret == "" {
-		return Config{}, errors.New("mosip: MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET is required")
+		return Config{}, errors.New("mosip: MOSIP_IDA_CLIENT_SECRET is required")
 	}
 	if licenseKey == "" {
 		return Config{}, errors.New("mosip: MOSIP_ESIGNET_MISP_KEY is required")

--- a/esignet-service/internal/engine/mosip/config_test.go
+++ b/esignet-service/internal/engine/mosip/config_test.go
@@ -17,123 +17,101 @@ func (ts *ConfigTestSuite) TestLoadConfigDefaultsFromAPIBase() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org/")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL", "")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_SEND_OTP_URL", "")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_AUTH_URL", "")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_EXCHANGE_URL", "")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_GET_CERTIFICATES_URL", "")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH_TOKEN_URL", "")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT_MANAGER_URL", "")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_ID", "")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_APP_ID", "")
 	t.Setenv("MOSIP_ESIGNET_DOMAIN_URL", "")
 	t.Setenv("IDA_AUTHENTICATOR_ENV", "")
 
-	cfg := LoadConfig()
+	cfg, err := LoadConfig()
 
+	require.NoError(t, err)
 	require.Equal(t, "misp-key-1", cfg.LicenseKey)
 	require.Equal(t, "http://internal.example.org/mosip-certs/ida-partner.cer", cfg.IDAPartnerCertificateURL)
 	require.Equal(t, "http://internal.example.org/idauthentication/v1/otp/misp-key-1/", cfg.SendOTPBaseURL)
 	require.Equal(t, "http://internal.example.org/idauthentication/v1/kyc-auth/delegated/misp-key-1/", cfg.KYCAuthBaseURL)
 	require.Equal(t, "http://internal.example.org/idauthentication/v1/kyc-exchange/delegated/misp-key-1/", cfg.KYCExchangeBaseURL)
+	require.Equal(t, "http://internal.example.org/idauthentication/v1/internal/getAllCertificates?applicationId=IDA_KYC_EXCHANGE&referenceId= ", cfg.IDACertificateURL)
+	require.Equal(t, "http://internal.example.org/v1/authmanager/authenticate/clientidsecretkey", cfg.AuthTokenURL)
+	require.Equal(t, "http://internal.example.org/v1/auditmanager/audits", cfg.AuditManagerURL)
 	require.Equal(t, "http://internal.example.org", cfg.DomainURI)
 	require.Equal(t, defaultMosipEnv, cfg.Env)
+	require.Equal(t, defaultClientID, cfg.ClientID)
+	require.Equal(t, "shh", cfg.SecretKey)
+	require.Equal(t, defaultAppID, cfg.AppID)
 }
 
 func (ts *ConfigTestSuite) TestLoadConfigExplicitOverridesWin() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL", "http://override/cert")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_SEND_OTP_URL", "http://override/otp")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_AUTH_URL", "http://override/kyc-auth")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_EXCHANGE_URL", "http://override/kyc-exchange")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_GET_CERTIFICATES_URL", "http://override/certificates")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH_TOKEN_URL", "http://override/auth-token")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT_MANAGER_URL", "http://override/audits")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_ID", "client-x")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_APP_ID", "app-x")
 	t.Setenv("MOSIP_ESIGNET_DOMAIN_URL", "http://override/domain")
 	t.Setenv("IDA_AUTHENTICATOR_ENV", "Production")
 
-	cfg := LoadConfig()
+	cfg, err := LoadConfig()
 
+	require.NoError(t, err)
 	require.Equal(t, "http://override/cert", cfg.IDAPartnerCertificateURL)
 	require.Equal(t, "http://override/otp", cfg.SendOTPBaseURL)
 	require.Equal(t, "http://override/kyc-auth", cfg.KYCAuthBaseURL)
 	require.Equal(t, "http://override/kyc-exchange", cfg.KYCExchangeBaseURL)
+	require.Equal(t, "http://override/certificates", cfg.IDACertificateURL)
+	require.Equal(t, "http://override/auth-token", cfg.AuthTokenURL)
+	require.Equal(t, "http://override/audits", cfg.AuditManagerURL)
+	require.Equal(t, "client-x", cfg.ClientID)
+	require.Equal(t, "app-x", cfg.AppID)
 	require.Equal(t, "http://override/domain", cfg.DomainURI)
 	require.Equal(t, "Production", cfg.Env)
 }
 
-func (ts *ConfigTestSuite) TestLoadConfigNoAPIBaseYieldsBareSuffixes() {
+func (ts *ConfigTestSuite) TestLoadConfigFailsWithoutAPIBase() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "")
-	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL", "")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_SEND_OTP_URL", "")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_AUTH_URL", "")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_EXCHANGE_URL", "")
-	t.Setenv("MOSIP_ESIGNET_DOMAIN_URL", "")
-	t.Setenv("IDA_AUTHENTICATOR_ENV", "")
+	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
 
-	cfg := LoadConfig()
-
-	require.Equal(t, "/mosip-certs/ida-partner.cer", cfg.IDAPartnerCertificateURL)
-	require.Equal(t, "/idauthentication/v1/otp//", cfg.SendOTPBaseURL)
-	require.Equal(t, defaultMosipEnv, cfg.Env)
-	require.Empty(t, cfg.DomainURI)
-}
-
-func (ts *ConfigTestSuite) TestLoadAuditConfigDerivesFromAPIBase() {
-	t := ts.T()
-	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org/")
-	t.Setenv("MOSIP_ESIGNET_AUDIT_MANAGER_URL", "")
-	t.Setenv("MOSIP_ESIGNET_AUTH_TOKEN_URL", "")
-	t.Setenv("MOSIP_ESIGNET_IDA_CLIENT_ID", "")
-	t.Setenv("MOSIP_ESIGNET_IDA_CLIENT_SECRET", "shh")
-	t.Setenv("MOSIP_ESIGNET_IDA_APP_ID", "")
-
-	cfg, err := LoadAuditConfig()
-
-	require.NoError(t, err)
-	require.Equal(t, "http://internal.example.org/v1/auditmanager/audits", cfg.AuditManagerURL)
-	require.Equal(t, "http://internal.example.org/v1/authmanager/authenticate/clientidsecretkey", cfg.AuthTokenURL)
-	require.Equal(t, auditDefaultClientID, cfg.ClientID)
-	require.Equal(t, "shh", cfg.SecretKey)
-	require.Equal(t, auditDefaultAppID, cfg.AppID)
-}
-
-func (ts *ConfigTestSuite) TestLoadAuditConfigExplicitOverrides() {
-	t := ts.T()
-	t.Setenv("MOSIP_API_INTERNAL_HOST", "")
-	t.Setenv("MOSIP_ESIGNET_AUDIT_MANAGER_URL", "http://audit/override")
-	t.Setenv("MOSIP_ESIGNET_AUTH_TOKEN_URL", "http://token/override")
-	t.Setenv("MOSIP_ESIGNET_IDA_CLIENT_ID", "client-x")
-	t.Setenv("MOSIP_ESIGNET_IDA_CLIENT_SECRET", "sec")
-	t.Setenv("MOSIP_ESIGNET_IDA_APP_ID", "app-x")
-
-	cfg, err := LoadAuditConfig()
-
-	require.NoError(t, err)
-	require.Equal(t, "http://audit/override", cfg.AuditManagerURL)
-	require.Equal(t, "http://token/override", cfg.AuthTokenURL)
-	require.Equal(t, "client-x", cfg.ClientID)
-	require.Equal(t, "app-x", cfg.AppID)
-}
-
-func (ts *ConfigTestSuite) TestLoadAuditConfigFailsWithoutAnyEndpoint() {
-	t := ts.T()
-	t.Setenv("MOSIP_API_INTERNAL_HOST", "")
-	t.Setenv("MOSIP_ESIGNET_AUDIT_MANAGER_URL", "")
-	t.Setenv("MOSIP_ESIGNET_AUTH_TOKEN_URL", "")
-
-	_, err := LoadAuditConfig()
+	_, err := LoadConfig()
 
 	require.Error(t, err)
 }
 
-func (ts *ConfigTestSuite) TestLoadAuditConfigTokenURLEmptyWithoutAPIBaseOrOverride() {
+func (ts *ConfigTestSuite) TestLoadConfigFailsWithoutMispKey() {
 	t := ts.T()
-	t.Setenv("MOSIP_API_INTERNAL_HOST", "")
-	t.Setenv("MOSIP_ESIGNET_AUDIT_MANAGER_URL", "http://audit/only")
-	t.Setenv("MOSIP_ESIGNET_AUTH_TOKEN_URL", "")
+	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
+	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
 
-	cfg, err := LoadAuditConfig()
+	_, err := LoadConfig()
 
-	require.NoError(t, err)
-	require.Equal(t, "http://audit/only", cfg.AuditManagerURL)
-	require.Empty(t, cfg.AuthTokenURL)
+	require.Error(t, err)
+}
+
+func (ts *ConfigTestSuite) TestLoadConfigFailsWithoutClientSecret() {
+	t := ts.T()
+	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
+	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "")
+
+	_, err := LoadConfig()
+
+	require.Error(t, err)
 }
 
 type ConfigTestSuite struct {

--- a/esignet-service/internal/engine/mosip/config_test.go
+++ b/esignet-service/internal/engine/mosip/config_test.go
@@ -17,7 +17,7 @@ func (ts *ConfigTestSuite) TestLoadConfigDefaultsFromAPIBase() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org/")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
+	t.Setenv("MOSIP_IDA_CLIENT_SECRET", "shh")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL", "")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_SEND_OTP_URL", "")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_AUTH_URL", "")
@@ -52,7 +52,7 @@ func (ts *ConfigTestSuite) TestLoadConfigExplicitOverridesWin() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
+	t.Setenv("MOSIP_IDA_CLIENT_SECRET", "shh")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL", "http://override/cert")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_SEND_OTP_URL", "http://override/otp")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC_AUTH_URL", "http://override/kyc-auth")
@@ -85,7 +85,7 @@ func (ts *ConfigTestSuite) TestLoadConfigFailsWithoutAPIBase() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
+	t.Setenv("MOSIP_IDA_CLIENT_SECRET", "shh")
 
 	_, err := LoadConfig()
 
@@ -96,7 +96,7 @@ func (ts *ConfigTestSuite) TestLoadConfigFailsWithoutMispKey() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "shh")
+	t.Setenv("MOSIP_IDA_CLIENT_SECRET", "shh")
 
 	_, err := LoadConfig()
 
@@ -107,7 +107,7 @@ func (ts *ConfigTestSuite) TestLoadConfigFailsWithoutClientSecret() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-key-1")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "")
+	t.Setenv("MOSIP_IDA_CLIENT_SECRET", "")
 
 	_, err := LoadConfig()
 

--- a/esignet-service/internal/engine/mosip/init.go
+++ b/esignet-service/internal/engine/mosip/init.go
@@ -36,11 +36,17 @@ func Init(appConfig *config.AppConfig, clientSvc *clientmgmt.Service, httpClient
 	if svc == nil || sigSvc == nil {
 		return nil, nil, ErrNilCryptoService
 	}
-	authnProvider, err := NewMosipAuthnProvider(appConfig, clientSvc, httpClient, svc, sigSvc)
+	pluginConfig, err := LoadConfig()
 	if err != nil {
 		return nil, nil, err
 	}
-	auditor, err := NewAuditor(httpClient)
+
+	tokenProvider := newTokenProvider(pluginConfig, httpClient)
+	authnProvider, err := NewMosipAuthnProvider(appConfig, clientSvc, httpClient, svc, sigSvc, pluginConfig, tokenProvider)
+	if err != nil {
+		return nil, nil, err
+	}
+	auditor, err := NewAuditor(httpClient, pluginConfig, tokenProvider)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/esignet-service/internal/engine/mosip/init_test.go
+++ b/esignet-service/internal/engine/mosip/init_test.go
@@ -21,7 +21,7 @@ func (ts *InitTestSuite) TestInitSucceedsWithAuditConfigured() {
 	t := ts.T()
 	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
 	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-1")
-	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "secret")
+	t.Setenv("MOSIP_IDA_CLIENT_SECRET", "secret")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT_MANAGER_URL", "http://audit.example.org/audits")
 	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH_TOKEN_URL", "http://audit.example.org/token")
 

--- a/esignet-service/internal/engine/mosip/init_test.go
+++ b/esignet-service/internal/engine/mosip/init_test.go
@@ -19,9 +19,11 @@ import (
 
 func (ts *InitTestSuite) TestInitSucceedsWithAuditConfigured() {
 	t := ts.T()
-	t.Setenv("MOSIP_ESIGNET_AUDIT_MANAGER_URL", "http://audit.example.org/audits")
-	t.Setenv("MOSIP_ESIGNET_AUTH_TOKEN_URL", "http://audit.example.org/token")
-	t.Setenv("MOSIP_ESIGNET_IDA_CLIENT_SECRET", "secret")
+	t.Setenv("MOSIP_API_INTERNAL_HOST", "http://internal.example.org")
+	t.Setenv("MOSIP_ESIGNET_MISP_KEY", "misp-1")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_CLIENT_SECRET", "secret")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT_MANAGER_URL", "http://audit.example.org/audits")
+	t.Setenv("MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH_TOKEN_URL", "http://audit.example.org/token")
 
 	km, sigSvc := newTestKeyManagerServices(t, false)
 	authnProvider, auditor, err := Init(&config.AppConfig{}, nil, &http.Client{Timeout: 30 * time.Second}, km, sigSvc)

--- a/esignet-service/internal/engine/mosip/model.go
+++ b/esignet-service/internal/engine/mosip/model.go
@@ -192,3 +192,20 @@ type ServiceError struct {
 type AuditResponseWrapper struct {
 	Errors []ServiceError `json:"errors"`
 }
+
+type CertificateResponseWrapper struct {
+	ID           string                      `json:"id,omitempty"`
+	Version      string                      `json:"version,omitempty"`
+	ResponseTime string                      `json:"responsetime,omitempty"` // usually ISO8601 / RFC3339
+	Response     *GetAllCertificatesResponse `json:"response,omitempty"`
+	Errors       []Error                     `json:"errors,omitempty"`
+}
+
+type GetAllCertificatesResponse struct {
+	AllCertificates []KycSigningCertificateData `json:"allCertificates"`
+}
+
+type KycSigningCertificateData struct {
+	KeyId           string `json:"keyId"`
+	CertificateData string `json:"certificateData"` //X509 certificate
+}

--- a/esignet-service/internal/engine/mosip/model.go
+++ b/esignet-service/internal/engine/mosip/model.go
@@ -193,6 +193,7 @@ type AuditResponseWrapper struct {
 	Errors []ServiceError `json:"errors"`
 }
 
+// CertificateResponseWrapper is the getAllCertificates API response envelope.
 type CertificateResponseWrapper struct {
 	ID           string                      `json:"id,omitempty"`
 	Version      string                      `json:"version,omitempty"`
@@ -201,11 +202,14 @@ type CertificateResponseWrapper struct {
 	Errors       []Error                     `json:"errors,omitempty"`
 }
 
+// GetAllCertificatesResponse is the getAllCertificates API success payload.
 type GetAllCertificatesResponse struct {
 	AllCertificates []KycSigningCertificateData `json:"allCertificates"`
 }
 
+// KycSigningCertificateData is a single signing certificate entry returned
+// by the getAllCertificates API.
 type KycSigningCertificateData struct {
-	KeyId           string `json:"keyId"`
-	CertificateData string `json:"certificateData"` //X509 certificate
+	KeyID           string `json:"keyId"`
+	CertificateData string `json:"certificateData"` // X509 certificate
 }

--- a/esignet-service/internal/engine/mosip/utils.go
+++ b/esignet-service/internal/engine/mosip/utils.go
@@ -24,14 +24,14 @@ const authHeaderName = "authorization"
 // tokenProvider fetches and caches an authmanager token in memory. The token
 // is reused across audit calls and refetched after Purge (called on 401/403).
 type tokenProvider struct {
-	cfg    AuditConfig
+	cfg    Config
 	client *http.Client
 
 	mu     sync.RWMutex
 	cached string
 }
 
-func newTokenProvider(cfg AuditConfig, client *http.Client) *tokenProvider {
+func newTokenProvider(cfg Config, client *http.Client) *tokenProvider {
 	return &tokenProvider{cfg: cfg, client: client}
 }
 

--- a/esignet-service/internal/engine/mosip/utils.go
+++ b/esignet-service/internal/engine/mosip/utils.go
@@ -14,6 +14,9 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 
 	applog "github.com/mosip/esignet/internal/log"
 )
@@ -29,6 +32,7 @@ type tokenProvider struct {
 
 	mu     sync.RWMutex
 	cached string
+	expiry time.Time
 }
 
 func newTokenProvider(cfg Config, client *http.Client) *tokenProvider {
@@ -45,13 +49,14 @@ func (t *tokenProvider) GetAuthToken(ctx context.Context) (string, error) {
 		return token, nil
 	}
 
-	token, err := t.fetch(ctx)
+	token, expiry, err := t.fetch(ctx)
 	if err != nil {
 		return "", err
 	}
 
 	t.mu.Lock()
 	t.cached = token
+	t.expiry = expiry
 	t.mu.Unlock()
 	return token, nil
 }
@@ -60,10 +65,25 @@ func (t *tokenProvider) GetAuthToken(ctx context.Context) (string, error) {
 func (t *tokenProvider) Purge() {
 	t.mu.Lock()
 	t.cached = ""
+	t.expiry = time.Time{}
 	t.mu.Unlock()
 }
 
-func (t *tokenProvider) fetch(ctx context.Context) (string, error) {
+// TokenExpiry returns the expiry of the currently cached auth token and
+// whether it's known — i.e. the token parses as a JWT with an exp claim.
+// Callers that cache data fetched using this token (e.g. signing
+// certificates) can use this to avoid caching that data past the point
+// where the token itself needs to be refreshed anyway.
+func (t *tokenProvider) TokenExpiry() (time.Time, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.expiry, !t.expiry.IsZero()
+}
+
+// fetch requests a fresh authmanager token and returns it alongside its
+// expiry, parsed from the token's own exp claim (zero time if the token
+// isn't a JWT or carries no exp claim — callers treat that as "unknown").
+func (t *tokenProvider) fetch(ctx context.Context) (string, time.Time, error) {
 	body, err := json.Marshal(AuditRequestWrapper[ClientIDSecretKeyRequest]{
 		ID:          "ida",
 		RequestTime: GetUTCDateTime(),
@@ -74,30 +94,45 @@ func (t *tokenProvider) fetch(ctx context.Context) (string, error) {
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("marshal auth token request: %w", err)
+		return "", time.Time{}, fmt.Errorf("marshal auth token request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.cfg.AuthTokenURL, bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("create auth token request: %w", err)
+		return "", time.Time{}, fmt.Errorf("create auth token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := t.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("auth token request failed: %w", err)
+		return "", time.Time{}, fmt.Errorf("auth token request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("unexpected auth token status: %d", resp.StatusCode)
+		return "", time.Time{}, fmt.Errorf("unexpected auth token status: %d", resp.StatusCode)
 	}
 
 	token := resp.Header.Get(authHeaderName)
 	if token == "" {
 		applog.GetLogger().Warn(ctx, "audit: authmanager returned empty authorization header")
-		return "", fmt.Errorf("empty authorization header from authmanager")
+		return "", time.Time{}, fmt.Errorf("empty authorization header from authmanager")
 	}
-	return token, nil
+	return token, tokenExpiry(token), nil
+}
+
+// tokenExpiry parses the exp claim from a JWT without verifying its
+// signature — authmanager issues the token, esignet only needs to know when
+// it stops being usable, not to authenticate it.
+func tokenExpiry(token string) time.Time {
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+		return time.Time{}
+	}
+	expiresAt, err := claims.GetExpirationTime()
+	if err != nil || expiresAt == nil {
+		return time.Time{}
+	}
+	return expiresAt.Time
 }

--- a/esignet-service/internal/engine/mosip/utils_test.go
+++ b/esignet-service/internal/engine/mosip/utils_test.go
@@ -12,7 +12,10 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -52,6 +55,40 @@ func (ts *UtilsTestSuite) TestTokenProviderFetchAndCache() {
 	if got := atomic.LoadInt32(&calls); got != 2 {
 		t.Fatalf("auth server calls = %d, want 2 (refetch after purge)", got)
 	}
+}
+
+func (ts *UtilsTestSuite) TestTokenExpiry() {
+	t := ts.T()
+
+	t.Run("valid JWT with exp claim", func(t *testing.T) {
+		exp := time.Now().Add(time.Hour)
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"exp": exp.Unix()})
+		signed, err := token.SignedString([]byte("test-key"))
+		require.NoError(t, err)
+
+		got := tokenExpiry(signed)
+		require.WithinDuration(t, exp, got, time.Second)
+	})
+
+	t.Run("not a JWT", func(t *testing.T) {
+		require.True(t, tokenExpiry("opaque-token").IsZero())
+	})
+
+	t.Run("valid JWT without exp claim", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "someone"})
+		signed, err := token.SignedString([]byte("test-key"))
+		require.NoError(t, err)
+
+		require.True(t, tokenExpiry(signed).IsZero())
+	})
+}
+
+func (ts *UtilsTestSuite) TestTokenProviderRequestCreationError() {
+	t := ts.T()
+	tp := newTokenProvider(Config{AuthTokenURL: "://bad-url", SecretKey: "s"}, http.DefaultClient)
+
+	_, err := tp.GetAuthToken(context.Background())
+	require.ErrorContains(t, err, "create auth token request")
 }
 
 func (ts *UtilsTestSuite) TestTokenProviderEmptyHeader() {

--- a/esignet-service/internal/engine/mosip/utils_test.go
+++ b/esignet-service/internal/engine/mosip/utils_test.go
@@ -26,7 +26,7 @@ func (ts *UtilsTestSuite) TestTokenProviderFetchAndCache() {
 	}))
 	defer srv.Close()
 
-	tp := newTokenProvider(AuditConfig{AuthTokenURL: srv.URL, SecretKey: "s"}, srv.Client())
+	tp := newTokenProvider(Config{AuthTokenURL: srv.URL, SecretKey: "s"}, srv.Client())
 
 	token, err := tp.GetAuthToken(context.Background())
 	if err != nil {
@@ -61,7 +61,7 @@ func (ts *UtilsTestSuite) TestTokenProviderEmptyHeader() {
 	}))
 	defer srv.Close()
 
-	tp := newTokenProvider(AuditConfig{AuthTokenURL: srv.URL, SecretKey: "s"}, srv.Client())
+	tp := newTokenProvider(Config{AuthTokenURL: srv.URL, SecretKey: "s"}, srv.Client())
 	if _, err := tp.GetAuthToken(context.Background()); err == nil {
 		t.Fatal("expected error for empty authorization header")
 	}

--- a/esignet-service/internal/engine/runtime_crypto_provider.go
+++ b/esignet-service/internal/engine/runtime_crypto_provider.go
@@ -290,12 +290,12 @@ func (p *runtimeCryptoProvider) idSystemPublicKeys(ctx context.Context) []provid
 		cert, err := keymanager.ParseCertPEM(certData.Certificate)
 		if err != nil {
 			applog.GetLogger().Warn(ctx, "failed to parse ID system signing certificate",
-				applog.String("keyId", certData.KeyId), applog.Error(err))
+				applog.String("keyId", certData.KeyID), applog.Error(err))
 			continue
 		}
 		keys = append(keys, providers.PublicKeyInfo{
-			KeyID:          certData.KeyId,
-			Algorithm:      signature.AlgorithmForRefID(certData.KeyId),
+			KeyID:          certData.KeyID,
+			Algorithm:      signature.AlgorithmForRefID(certData.KeyID),
 			PublicKey:      cert.PublicKey,
 			Thumbprint:     keymanager.ThumbprintForCert(cert),
 			CertificateDER: cert.Raw,

--- a/esignet-service/internal/engine/runtime_crypto_provider.go
+++ b/esignet-service/internal/engine/runtime_crypto_provider.go
@@ -21,9 +21,11 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/mosip/esignet/internal/config"
+	"github.com/mosip/esignet/internal/engine/shared"
 	"github.com/mosip/esignet/internal/keymanager"
 	"github.com/mosip/esignet/internal/keymanager/cryptomanager"
 	"github.com/mosip/esignet/internal/keymanager/signature"
+	applog "github.com/mosip/esignet/internal/log"
 )
 
 // defaultSymmetricEncryptReferenceID is the reference id Encrypt/Decrypt
@@ -44,6 +46,7 @@ type runtimeCryptoProvider struct {
 	svc             *keymanager.Service
 	sigSvc          *signature.Service
 	cryptoSvc       *cryptomanager.Service
+	authnProvider   shared.ConsolidatedAuthnProvider
 	signReferenceID string
 
 	// jwkCache caches getPublicKey's parsed result — see its doc comment.
@@ -66,7 +69,7 @@ type runtimeCryptoProvider struct {
 // independently usable by any esignet code that already speaks
 // providers.RuntimeCryptoProvider.
 func NewRuntimeCryptoProvider(cfg *config.AppConfig, svc *keymanager.Service, sigSvc *signature.Service,
-	cryptoSvc *cryptomanager.Service) providers.RuntimeCryptoProvider {
+	cryptoSvc *cryptomanager.Service, authnProvider shared.ConsolidatedAuthnProvider) providers.RuntimeCryptoProvider {
 
 	referenceID := cfg.JWT.PreferredKeyID
 	if referenceID == "" {
@@ -78,6 +81,7 @@ func NewRuntimeCryptoProvider(cfg *config.AppConfig, svc *keymanager.Service, si
 		svc:             svc,
 		sigSvc:          sigSvc,
 		cryptoSvc:       cryptoSvc,
+		authnProvider:   authnProvider,
 		signReferenceID: referenceID,
 		jwkCache:        newJWKCache(),
 	}
@@ -256,13 +260,48 @@ func (p *runtimeCryptoProvider) GetPublicKeys(ctx context.Context, filter provid
 	if err != nil {
 		return nil, fmt.Errorf("parse resolved certificate: %w", err)
 	}
-	return []providers.PublicKeyInfo{{
+	keys := []providers.PublicKeyInfo{{
 		KeyID:          refID,
 		Algorithm:      signature.AlgorithmForRefID(refID),
 		PublicKey:      cert.PublicKey,
 		Thumbprint:     keymanager.ThumbprintForCert(cert),
 		CertificateDER: cert.Raw,
-	}}, nil
+	}}
+	return append(keys, p.idSystemPublicKeys(ctx)...), nil
+}
+
+// idSystemPublicKeys fetches the signing certificates of the configured ID
+// system backend (mosip, mock, or sunbird — whichever NewIDSystemProviders
+// selected) and converts them into providers.PublicKeyInfo entries. Fetch
+// failures are logged and skipped rather than propagated, since they'd
+// otherwise take down JWKS/discovery for esignet's own signing key over a
+// dependency that is auxiliary to it.
+func (p *runtimeCryptoProvider) idSystemPublicKeys(ctx context.Context) []providers.PublicKeyInfo {
+	if p.authnProvider == nil {
+		return nil
+	}
+	certs, svcErr := p.authnProvider.GetSigningCertificates(ctx)
+	if svcErr != nil {
+		applog.GetLogger().Warn(ctx, "failed to fetch ID system signing certificates", applog.String("error", svcErr.Code))
+		return nil
+	}
+	keys := make([]providers.PublicKeyInfo, 0, len(certs))
+	for _, certData := range certs {
+		cert, err := keymanager.ParseCertPEM(certData.Certificate)
+		if err != nil {
+			applog.GetLogger().Warn(ctx, "failed to parse ID system signing certificate",
+				applog.String("keyId", certData.KeyId), applog.Error(err))
+			continue
+		}
+		keys = append(keys, providers.PublicKeyInfo{
+			KeyID:          certData.KeyId,
+			Algorithm:      signature.AlgorithmForRefID(certData.KeyId),
+			PublicKey:      cert.PublicKey,
+			Thumbprint:     keymanager.ThumbprintForCert(cert),
+			CertificateDER: cert.Raw,
+		})
+	}
+	return keys
 }
 
 func (p *runtimeCryptoProvider) GetSupportedSigningAlgorithms() []string {

--- a/esignet-service/internal/engine/runtime_crypto_provider.go
+++ b/esignet-service/internal/engine/runtime_crypto_provider.go
@@ -295,7 +295,7 @@ func (p *runtimeCryptoProvider) idSystemPublicKeys(ctx context.Context) []provid
 		}
 		keys = append(keys, providers.PublicKeyInfo{
 			KeyID:          certData.KeyID,
-			Algorithm:      signature.AlgorithmForRefID(certData.KeyID),
+			Algorithm:      signature.AlgorithmForPublicKey(cert.PublicKey),
 			PublicKey:      cert.PublicKey,
 			Thumbprint:     keymanager.ThumbprintForCert(cert),
 			CertificateDER: cert.Raw,

--- a/esignet-service/internal/engine/runtime_crypto_provider_test.go
+++ b/esignet-service/internal/engine/runtime_crypto_provider_test.go
@@ -7,17 +7,99 @@
 package engine
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"math/big"
 	"testing"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/mosip/esignet/internal/config"
+	"github.com/mosip/esignet/internal/engine/shared"
+	"github.com/mosip/esignet/internal/keymanager"
 )
+
+// fakeAuthnProviderForCrypto is a hand-written stub of
+// shared.ConsolidatedAuthnProvider used only to drive
+// runtimeCryptoProvider.idSystemPublicKeys — every method besides
+// GetSigningCertificates is unreachable from that code path.
+type fakeAuthnProviderForCrypto struct {
+	certs  []shared.CertificateData
+	svcErr *common.ServiceError
+}
+
+func (f *fakeAuthnProviderForCrypto) InitiateAuthentication(context.Context, string, any,
+	*providers.AuthnMetadata) (any, *common.ServiceError) {
+	return nil, nil
+}
+
+func (f *fakeAuthnProviderForCrypto) Authenticate(context.Context, map[string]interface{}, map[string]interface{},
+	*providers.AuthnMetadata) (*providers.AuthnResult, *common.ServiceError) {
+	return nil, nil
+}
+
+func (f *fakeAuthnProviderForCrypto) GetEntityReference(context.Context, any) (*providers.EntityReference,
+	*common.ServiceError) {
+	return nil, nil
+}
+
+func (f *fakeAuthnProviderForCrypto) GetAttributes(context.Context, any, *providers.RequestedAttributes,
+	*providers.GetAttributesMetadata) (*providers.AttributesResponse, *common.ServiceError) {
+	return nil, nil
+}
+
+func (f *fakeAuthnProviderForCrypto) InitiateEnrollment(context.Context, string, any,
+	*providers.AuthnMetadata) (any, *common.ServiceError) {
+	return nil, nil
+}
+
+func (f *fakeAuthnProviderForCrypto) Enroll(context.Context, map[string]interface{}, map[string]interface{},
+	*providers.AuthnMetadata) (*providers.AuthnResult, *common.ServiceError) {
+	return nil, nil
+}
+
+func (f *fakeAuthnProviderForCrypto) SendOTP(context.Context, map[string]interface{},
+	*providers.AuthnMetadata) (*shared.SendOTPResult, *common.ServiceError) {
+	return nil, nil
+}
+
+func (f *fakeAuthnProviderForCrypto) GetSigningCertificates(context.Context) ([]shared.CertificateData, *common.ServiceError) {
+	return f.certs, f.svcErr
+}
+
+var _ shared.ConsolidatedAuthnProvider = (*fakeAuthnProviderForCrypto)(nil)
+
+// testCertPEM generates a self-signed RSA certificate PEM for a given
+// CommonName, so idSystemPublicKeys tests exercise genuine
+// keymanager.ParseCertPEM/ThumbprintForCert calls rather than mocked ones.
+func testCertPEM(t *testing.T, cn string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return keymanager.EncodeCertPEM(der)
+}
 
 // testRSAJWKMap builds the map[string]interface{} shape a providers.KeyRef.
 // PublicKeyJWK carries — round-tripped through jose.JSONWebKey's own
@@ -52,7 +134,7 @@ func TestRuntimeCryptoProviderTestSuite(t *testing.T) {
 func (ts *RuntimeCryptoProviderTestSuite) TestNewRuntimeCryptoProvider_DefaultsSignReferenceIDWhenUnset() {
 	cfg := &config.AppConfig{}
 
-	p := NewRuntimeCryptoProvider(cfg, nil, nil, nil).(*runtimeCryptoProvider)
+	p := NewRuntimeCryptoProvider(cfg, nil, nil, nil, nil).(*runtimeCryptoProvider)
 
 	ts.Require().Equal(defaultSignReferenceID, p.signReferenceID)
 }
@@ -61,7 +143,7 @@ func (ts *RuntimeCryptoProviderTestSuite) TestNewRuntimeCryptoProvider_UsesConfi
 	cfg := &config.AppConfig{}
 	cfg.JWT.PreferredKeyID = "RSA_2048"
 
-	p := NewRuntimeCryptoProvider(cfg, nil, nil, nil).(*runtimeCryptoProvider)
+	p := NewRuntimeCryptoProvider(cfg, nil, nil, nil, nil).(*runtimeCryptoProvider)
 
 	ts.Require().Equal("RSA_2048", p.signReferenceID)
 }
@@ -156,6 +238,50 @@ func (ts *RuntimeCryptoProviderTestSuite) TestGetPublicKey_DifferentJWKs_AreNotC
 	rsaB, ok := keyB.Key.(*rsa.PublicKey)
 	ts.Require().True(ok)
 	ts.Assert().False(rsaA.Equal(rsaB), "the two fixtures must carry genuinely different key material")
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_NilAuthnProvider_ReturnsNil() {
+	p := &runtimeCryptoProvider{authnProvider: nil}
+
+	ts.Require().Nil(p.idSystemPublicKeys(context.Background()))
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_ServiceErrorFromProvider_ReturnsNil() {
+	p := &runtimeCryptoProvider{authnProvider: &fakeAuthnProviderForCrypto{
+		svcErr: &common.ServiceError{Code: "certificate_fetch_failed"},
+	}}
+
+	ts.Require().Nil(p.idSystemPublicKeys(context.Background()))
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_ConvertsEachCertificate() {
+	certPEM := testCertPEM(ts.T(), "id-system-key")
+	p := &runtimeCryptoProvider{authnProvider: &fakeAuthnProviderForCrypto{
+		certs: []shared.CertificateData{{KeyId: "id-system-ref", Certificate: certPEM}},
+	}}
+
+	keys := p.idSystemPublicKeys(context.Background())
+
+	ts.Require().Len(keys, 1)
+	ts.Assert().Equal("id-system-ref", keys[0].KeyID)
+	ts.Assert().NotEmpty(keys[0].Thumbprint)
+	ts.Assert().NotNil(keys[0].PublicKey)
+	ts.Assert().NotEmpty(keys[0].CertificateDER)
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_SkipsUnparsableCertificatesButKeepsOthers() {
+	certPEM := testCertPEM(ts.T(), "id-system-key")
+	p := &runtimeCryptoProvider{authnProvider: &fakeAuthnProviderForCrypto{
+		certs: []shared.CertificateData{
+			{KeyId: "bad-ref", Certificate: "not a certificate"},
+			{KeyId: "good-ref", Certificate: certPEM},
+		},
+	}}
+
+	keys := p.idSystemPublicKeys(context.Background())
+
+	ts.Require().Len(keys, 1)
+	ts.Assert().Equal("good-ref", keys[0].KeyID)
 }
 
 func (ts *RuntimeCryptoProviderTestSuite) TestGetPublicKey_NilCache_DisablesCachingWithoutPanic() {

--- a/esignet-service/internal/engine/runtime_crypto_provider_test.go
+++ b/esignet-service/internal/engine/runtime_crypto_provider_test.go
@@ -8,6 +8,8 @@ package engine
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -87,6 +89,30 @@ func testCertPEM(t *testing.T, cn string) string {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("generate RSA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return keymanager.EncodeCertPEM(der)
+}
+
+// testECCertPEM generates a self-signed P-256 certificate PEM for a given
+// CommonName — used to confirm idSystemPublicKeys derives the JWS algorithm
+// from the actual key type rather than any hint in the KeyID string.
+func testECCertPEM(t *testing.T, cn string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate EC key: %v", err)
 	}
 	tmpl := &x509.Certificate{
 		SerialNumber:          big.NewInt(time.Now().UnixNano()),
@@ -269,6 +295,42 @@ func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_ConvertsEachCer
 	ts.Assert().NotEmpty(keys[0].Thumbprint)
 	ts.Assert().NotNil(keys[0].PublicKey)
 	ts.Assert().NotEmpty(keys[0].CertificateDER)
+	ts.Assert().Equal("PS256", keys[0].Algorithm, "an RSA certificate must resolve to PS256")
+}
+
+// TestIdSystemPublicKeys_AlgorithmReflectsActualKeyType_NotKeyIDString
+// guards the fix from computing Algorithm via
+// signature.AlgorithmForPublicKey(cert.PublicKey) instead of
+// signature.AlgorithmForRefID(certData.KeyID): an ID system's KeyID is an
+// arbitrary external string with no relation to esignet's own refID
+// constants, so matching it against those constants could silently report
+// the wrong algorithm for a real key. Here the KeyID happens to collide with
+// keymanager.RefIDECSECP256R1Sign ("EC_SECP256R1_SIGN") even though the
+// certificate is RSA — the resolved algorithm must follow the certificate,
+// not the KeyID.
+func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_AlgorithmReflectsActualKeyType_NotKeyIDString() {
+	rsaCertPEM := testCertPEM(ts.T(), "id-system-key")
+	p := &runtimeCryptoProvider{authnProvider: &fakeAuthnProviderForCrypto{
+		certs: []shared.CertificateData{{KeyID: keymanager.RefIDECSECP256R1Sign, Certificate: rsaCertPEM}},
+	}}
+
+	keys := p.idSystemPublicKeys(context.Background())
+
+	ts.Require().Len(keys, 1)
+	ts.Assert().Equal("PS256", keys[0].Algorithm,
+		"algorithm must be derived from the RSA certificate's key, not misread from the EC_SECP256R1_SIGN-shaped KeyID")
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_ECCertificate_ResolvesES256() {
+	ecCertPEM := testECCertPEM(ts.T(), "id-system-ec-key")
+	p := &runtimeCryptoProvider{authnProvider: &fakeAuthnProviderForCrypto{
+		certs: []shared.CertificateData{{KeyID: "arbitrary-id-system-key-id", Certificate: ecCertPEM}},
+	}}
+
+	keys := p.idSystemPublicKeys(context.Background())
+
+	ts.Require().Len(keys, 1)
+	ts.Assert().Equal("ES256", keys[0].Algorithm)
 }
 
 func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_SkipsUnparsableCertificatesButKeepsOthers() {

--- a/esignet-service/internal/engine/runtime_crypto_provider_test.go
+++ b/esignet-service/internal/engine/runtime_crypto_provider_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -25,6 +26,7 @@ import (
 	"github.com/mosip/esignet/internal/config"
 	"github.com/mosip/esignet/internal/engine/shared"
 	"github.com/mosip/esignet/internal/keymanager"
+	"github.com/mosip/esignet/internal/keymanager/kmtest"
 )
 
 // fakeAuthnProviderForCrypto is a hand-written stub of
@@ -257,7 +259,7 @@ func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_ServiceErrorFro
 func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_ConvertsEachCertificate() {
 	certPEM := testCertPEM(ts.T(), "id-system-key")
 	p := &runtimeCryptoProvider{authnProvider: &fakeAuthnProviderForCrypto{
-		certs: []shared.CertificateData{{KeyId: "id-system-ref", Certificate: certPEM}},
+		certs: []shared.CertificateData{{KeyID: "id-system-ref", Certificate: certPEM}},
 	}}
 
 	keys := p.idSystemPublicKeys(context.Background())
@@ -273,8 +275,8 @@ func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_SkipsUnparsable
 	certPEM := testCertPEM(ts.T(), "id-system-key")
 	p := &runtimeCryptoProvider{authnProvider: &fakeAuthnProviderForCrypto{
 		certs: []shared.CertificateData{
-			{KeyId: "bad-ref", Certificate: "not a certificate"},
-			{KeyId: "good-ref", Certificate: certPEM},
+			{KeyID: "bad-ref", Certificate: "not a certificate"},
+			{KeyID: "good-ref", Certificate: certPEM},
 		},
 	}}
 
@@ -282,6 +284,90 @@ func (ts *RuntimeCryptoProviderTestSuite) TestIdSystemPublicKeys_SkipsUnparsable
 
 	ts.Require().Len(keys, 1)
 	ts.Assert().Equal("good-ref", keys[0].KeyID)
+}
+
+// newTestKeyManagerService builds an in-memory keymanager.Service (backed by
+// kmtest's StateQuerier/FakeKeyStore, no postgres/HSM involved) with ROOT and
+// the OIDC_SERVICE/defaultSignReferenceID EC sign key provisioned — mirrors
+// cmd/esignet/main.go's provisionKeyHierarchy, just scoped to what
+// GetPublicKeys needs.
+func newTestKeyManagerService(t *testing.T) *keymanager.Service {
+	t.Helper()
+	ctx := context.Background()
+	km := keymanager.NewServiceWithQuerier(kmtest.NewStateQuerier(), kmtest.NewFakeKeyStore(), keymanager.Config{
+		AsymmetricKeyLength:  2048,
+		CertCommonName:       "www.mosip.io",
+		CertOrganizationUnit: "thunder-tech-team",
+		CertOrganization:     "IIITB",
+		CertLocation:         "Bangalore",
+		CertState:            "KA",
+		CertCountry:          "IN",
+	})
+
+	_, err := km.GenerateMasterKey(ctx, keymanager.GenerateMasterKeyRequest{
+		ApplicationID: keymanager.AppIDRoot,
+		ObjectType:    keymanager.ObjectTypeCertificate,
+		CommonName:    "MOSIP Root CA",
+	})
+	require.NoError(t, err)
+
+	_, err = km.GenerateMasterKey(ctx, keymanager.GenerateMasterKeyRequest{
+		ApplicationID: config.OIDCServiceAppID,
+		ReferenceID:   defaultSignReferenceID,
+		ObjectType:    keymanager.ObjectTypeCertificate,
+		CommonName:    "test esignet sign key",
+	})
+	require.NoError(t, err)
+
+	return km
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestGetPublicKeys_ReturnsOwnKeyMergedWithIDSystemKeys() {
+	t := ts.T()
+	idCertPEM := testCertPEM(t, "id-system-key")
+	p := &runtimeCryptoProvider{
+		svc:             newTestKeyManagerService(t),
+		signReferenceID: defaultSignReferenceID,
+		authnProvider: &fakeAuthnProviderForCrypto{
+			certs: []shared.CertificateData{{KeyID: "id-system-ref", Certificate: idCertPEM}},
+		},
+	}
+
+	keys, err := p.GetPublicKeys(context.Background(), providers.PublicKeyFilter{})
+
+	ts.Require().NoError(err)
+	ts.Require().Len(keys, 2, "esignet's own key plus the merged ID-system key")
+	ts.Assert().Equal(defaultSignReferenceID, keys[0].KeyID)
+	ts.Assert().NotNil(keys[0].PublicKey)
+	ts.Assert().NotEmpty(keys[0].Thumbprint)
+	ts.Assert().Equal("id-system-ref", keys[1].KeyID)
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestGetPublicKeys_NoIDSystemProvider_ReturnsOnlyOwnKey() {
+	t := ts.T()
+	p := &runtimeCryptoProvider{
+		svc:             newTestKeyManagerService(t),
+		signReferenceID: defaultSignReferenceID,
+	}
+
+	keys, err := p.GetPublicKeys(context.Background(), providers.PublicKeyFilter{})
+
+	ts.Require().NoError(err)
+	ts.Require().Len(keys, 1)
+	ts.Assert().Equal(defaultSignReferenceID, keys[0].KeyID)
+}
+
+func (ts *RuntimeCryptoProviderTestSuite) TestGetPublicKeys_CertificateLookupFailure_WrapsErrKeyNotFound() {
+	// No ROOT/master key provisioned on this Service, so GetCertificate has
+	// nothing to lazily rotate from and returns an error.
+	p := &runtimeCryptoProvider{
+		svc:             keymanager.NewServiceWithQuerier(kmtest.NewStateQuerier(), kmtest.NewFakeKeyStore(), keymanager.Config{}),
+		signReferenceID: defaultSignReferenceID,
+	}
+
+	_, err := p.GetPublicKeys(context.Background(), providers.PublicKeyFilter{})
+
+	ts.Require().ErrorIs(err, providers.ErrKeyNotFound)
 }
 
 func (ts *RuntimeCryptoProviderTestSuite) TestGetPublicKey_NilCache_DisablesCachingWithoutPanic() {

--- a/esignet-service/internal/engine/shared/errors.go
+++ b/esignet-service/internal/engine/shared/errors.go
@@ -39,7 +39,7 @@ var ClientNotFoundError = &common.ServiceError{
 
 // InvalidIndividualIDError is returned when the individual_id in identifiers is missing or invalid.
 var InvalidIndividualIDError = &common.ServiceError{
-	Code: "missing_or_invalid_individual_id",
+	Code: "AUTHN-MGR-1007",
 	Type: common.ClientErrorType,
 	Error: common.I18nMessage{
 		Key:          "missing_or_invalid_individual_id",
@@ -53,7 +53,7 @@ var InvalidIndividualIDError = &common.ServiceError{
 
 // InvalidRequestError is returned when the request is invalid.
 var InvalidRequestError = &common.ServiceError{
-	Code: "invalid_request",
+	Code: "AUTHN-MGR-1008",
 	Type: common.ClientErrorType,
 	Error: common.I18nMessage{
 		Key:          "invalid_request",
@@ -67,7 +67,7 @@ var InvalidRequestError = &common.ServiceError{
 
 // AuthenticationFailedError is returned when the authentication failed.
 var AuthenticationFailedError = &common.ServiceError{
-	Code: "authentication_failed",
+	Code: "AUTHN-MGR-1001",
 	Type: common.ClientErrorType,
 	Error: common.I18nMessage{
 		Key:          "authentication_failed",
@@ -133,6 +133,34 @@ var FileUnmarshallError = &common.ServiceError{
 	ErrorDescription: common.I18nMessage{
 		Key:          "file_unmarshall_error_description",
 		DefaultValue: "The file could not be unmarshalled",
+	},
+}
+
+// CertificateFetchFailed is returned when a failed to fetch certificate from IDA.
+var CertificateFetchFailed = &common.ServiceError{
+	Code: "certificate_fetch_failed",
+	Type: common.ClientErrorType,
+	Error: common.I18nMessage{
+		Key:          "certificate_fetch_failed",
+		DefaultValue: "Certificate fetch failed",
+	},
+	ErrorDescription: common.I18nMessage{
+		Key:          "certificate_fetch_failed_description",
+		DefaultValue: "The certificate could not be fetched",
+	},
+}
+
+// AuthTokenFetchFailed is returned when a failed to fetch auth token from authmanager.
+var AuthTokenFetchFailed = &common.ServiceError{
+	Code: "auth_token_fetch_failed",
+	Type: common.ClientErrorType,
+	Error: common.I18nMessage{
+		Key:          "auth_token_fetch_failed",
+		DefaultValue: "Auth token fetch failed",
+	},
+	ErrorDescription: common.I18nMessage{
+		Key:          "auth_token_fetch_failed_description",
+		DefaultValue: "The auth token could not be fetched",
 	},
 }
 

--- a/esignet-service/internal/engine/shared/interface.go
+++ b/esignet-service/internal/engine/shared/interface.go
@@ -16,6 +16,11 @@ import (
 // ConsolidatedAuthnProvider extends providers.AuthnProviderInterface with sendOTP capability.
 type ConsolidatedAuthnProvider interface {
 	providers.AuthnProviderInterface
+
+	// SendOTP sends an OTP to the user based on the provided identifiers and metadata.
 	SendOTP(_ context.Context, identifiers map[string]interface{},
 		metadata *providers.AuthnMetadata) (*SendOTPResult, *common.ServiceError)
+
+	// GetSigningCertificates retrieves public keys used by the ID system to sign userinfo responses.
+	GetSigningCertificates(ctx context.Context) ([]CertificateData, *common.ServiceError)
 }

--- a/esignet-service/internal/engine/shared/interface_test.go
+++ b/esignet-service/internal/engine/shared/interface_test.go
@@ -58,6 +58,10 @@ func (f *fakeConsolidatedAuthnProvider) SendOTP(_ context.Context, _ map[string]
 	return f.sendOTPResult, nil
 }
 
+func (f *fakeConsolidatedAuthnProvider) GetSigningCertificates(_ context.Context) ([]CertificateData, *common.ServiceError) {
+	return nil, nil
+}
+
 var _ ConsolidatedAuthnProvider = (*fakeConsolidatedAuthnProvider)(nil)
 
 func (ts *InterfaceTestSuite) TestConsolidatedAuthnProviderExtendsAuthnProviderInterface() {

--- a/esignet-service/internal/engine/shared/model.go
+++ b/esignet-service/internal/engine/shared/model.go
@@ -15,6 +15,6 @@ type SendOTPResult struct {
 
 // CertificateData holds Certificates from ID systems
 type CertificateData struct {
-	KeyId       string
+	KeyID       string
 	Certificate string
 }

--- a/esignet-service/internal/engine/shared/model.go
+++ b/esignet-service/internal/engine/shared/model.go
@@ -12,3 +12,9 @@ type SendOTPResult struct {
 	MaskedEmail   string `json:"maskedEmail,omitempty"`
 	MaskedMobile  string `json:"maskedMobile,omitempty"`
 }
+
+// CertificateData holds Certificates from ID systems
+type CertificateData struct {
+	KeyId       string
+	Certificate string
+}

--- a/esignet-service/internal/engine/sunbird/authenticator.go
+++ b/esignet-service/internal/engine/sunbird/authenticator.go
@@ -162,6 +162,10 @@ func (p *sunbirdAuthnProvider) SendOTP(_ context.Context, _ map[string]interface
 	return nil, shared.NotImplementedError
 }
 
+func (p *sunbirdAuthnProvider) GetSigningCertificates(ctx context.Context) ([]shared.CertificateData, *common.ServiceError) {
+	return nil, nil
+}
+
 func (p *sunbirdAuthnProvider) validateKBI(ctx context.Context, individualID string, kbiFields map[string]string) (string, error) {
 
 	filters := make(map[string]sunbirdSearchFilter, len(kbiFields)+1)

--- a/esignet-service/internal/engine/sunbird/authenticator.go
+++ b/esignet-service/internal/engine/sunbird/authenticator.go
@@ -162,7 +162,7 @@ func (p *sunbirdAuthnProvider) SendOTP(_ context.Context, _ map[string]interface
 	return nil, shared.NotImplementedError
 }
 
-func (p *sunbirdAuthnProvider) GetSigningCertificates(ctx context.Context) ([]shared.CertificateData, *common.ServiceError) {
+func (p *sunbirdAuthnProvider) GetSigningCertificates(_ context.Context) ([]shared.CertificateData, *common.ServiceError) {
 	return nil, nil
 }
 

--- a/esignet-service/internal/engine/sunbird/authenticator_test.go
+++ b/esignet-service/internal/engine/sunbird/authenticator_test.go
@@ -354,6 +354,10 @@ func (ts *AuthenticatorTestSuite) TestNoOpMethods() {
 	otpResult, svcErr := p.SendOTP(context.Background(), nil, nil)
 	require.Nil(t, otpResult)
 	require.Same(t, shared.NotImplementedError, svcErr)
+
+	certs, svcErr := p.GetSigningCertificates(context.Background())
+	require.Nil(t, certs)
+	require.Nil(t, svcErr)
 }
 
 func (ts *AuthenticatorTestSuite) TestValidateKBIRequestBuildError() {

--- a/esignet-service/internal/keymanager/signature/header.go
+++ b/esignet-service/internal/keymanager/signature/header.go
@@ -1,6 +1,10 @@
 package signature
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -8,6 +12,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
 
 	"github.com/mosip/esignet/internal/keymanager"
 )
@@ -48,6 +54,28 @@ func algorithmForRefID(refID string) string {
 // a resolved key's JWS algorithm without going through JWSSign/SignRaw.
 func AlgorithmForRefID(refID string) string {
 	return algorithmForRefID(refID)
+}
+
+// AlgorithmForPublicKey maps a public key to its JWS algorithm, using the
+// same RSA/EC/Ed25519 defaults as algorithmForRefID. Callers use this for
+// keys with no refID of ours to resolve (e.g. an external ID system's
+// signing certificate), where cert.SignatureAlgorithm.String() would report
+// Go's x509 algorithm name (e.g. "SHA256-RSA") rather than a JWA identifier.
+// Returns "" for key types with no corresponding JWS algorithm.
+func AlgorithmForPublicKey(pub crypto.PublicKey) string {
+	switch key := pub.(type) {
+	case *rsa.PublicKey:
+		return algPS256
+	case *ecdsa.PublicKey:
+		if key.Curve == btcec.S256() {
+			return algES256K
+		}
+		return algES256
+	case ed25519.PublicKey:
+		return algEdDSA
+	default:
+		return ""
+	}
 }
 
 // jwsHeader is the on-wire JWS protected header shape this port produces —

--- a/esignet-service/internal/keymanager/signature/sign_test.go
+++ b/esignet-service/internal/keymanager/signature/sign_test.go
@@ -2,11 +2,15 @@ package signature_test
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/asn1"
 	"math/big"
+
+	"github.com/btcsuite/btcd/btcec/v2"
 
 	"github.com/mosip/esignet/internal/keymanager/signature"
 )
@@ -106,6 +110,49 @@ func (ts *SignatureTestSuite) TestAlgorithmForRefID_MatchesJavaMapping() {
 	for _, c := range cases {
 		if got := signature.AlgorithmForRefID(c.refID); got != c.want {
 			t.Errorf("algorithmForRefID(%q) = %q, want %q", c.refID, got, c.want)
+		}
+	}
+}
+
+// TestAlgorithmForPublicKey_MatchesKeyType confirms the public-key -> JWS
+// algorithm mapping used for keys with no refID of ours to resolve (e.g. an
+// external ID system's signing certificate): it must inspect the actual key
+// material rather than any string hint, since callers have no refID to go on.
+func (ts *SignatureTestSuite) TestAlgorithmForPublicKey_MatchesKeyType() {
+	t := ts.T()
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	ecP256Key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate P-256 key: %v", err)
+	}
+	ecSecp256k1Key, err := ecdsa.GenerateKey(btcec.S256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate secp256k1 key: %v", err)
+	}
+	edKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate Ed25519 key: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		key  any
+		want string
+	}{
+		{"RSA", &rsaKey.PublicKey, "PS256"},
+		{"EC P-256", &ecP256Key.PublicKey, "ES256"},
+		{"EC secp256k1", &ecSecp256k1Key.PublicKey, "ES256K"},
+		{"Ed25519", edKey, "EdDSA"},
+		{"unsupported key type", "not a key", ""},
+		{"nil", nil, ""},
+	}
+	for _, c := range cases {
+		if got := signature.AlgorithmForPublicKey(c.key); got != c.want {
+			t.Errorf("%s: AlgorithmForPublicKey() = %q, want %q", c.name, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and including ID-system signing certificates in public-key responses.
  * Improved OTP and credential authentication flows with identifier-specific prompts and incomplete-task handling.
  * Added clearer handling for consent denial and authentication service errors.

* **Bug Fixes**
  * Client-side OTP failures now return users to the relevant identifier prompt for retry.
  * Authentication configuration now validates required settings and reports missing values clearly.
  * Improved token refresh and authorization retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->