### PR TITLE
change authnprovider response from individual claims to direct jwt

### DIFF
--- a/esignet-service/go.mod
+++ b/esignet-service/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
-	github.com/thunder-id/thunderid v0.0.0-20260818151849-bceae5bbc1ad
+	github.com/thunder-id/thunderid v0.0.0-20260820032948-5690b9d17986
 	go.mozilla.org/pkcs7 v0.9.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
@@ -72,4 +72,4 @@ require (
 	modernc.org/sqlite v1.53.0 // indirect
 )
 
-replace github.com/thunder-id/thunderid => github.com/thunder-id/thunderid/backend v0.0.0-20260818151849-bceae5bbc1ad
+replace github.com/thunder-id/thunderid => github.com/thunder-id/thunderid/backend v0.0.0-20260820032948-5690b9d17986

--- a/esignet-service/go.sum
+++ b/esignet-service/go.sum
@@ -124,8 +124,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/thunder-id/thunderid/backend v0.0.0-20260818151849-bceae5bbc1ad h1:ECRMilRseQ5bHSrbNazelFt6G2r/hrLAMbjQSMthK+E=
-github.com/thunder-id/thunderid/backend v0.0.0-20260818151849-bceae5bbc1ad/go.mod h1:KUUd6FrqXZJPXM8JwCaH8dLMpU5URrfDKYr68Ow2PUo=
+github.com/thunder-id/thunderid/backend v0.0.0-20260820032948-5690b9d17986 h1:M2/y5kpLj0+STdRMRUsfftFB2e69saCg2sYqOSQhvG8=
+github.com/thunder-id/thunderid/backend v0.0.0-20260820032948-5690b9d17986/go.mod h1:KUUd6FrqXZJPXM8JwCaH8dLMpU5URrfDKYr68Ow2PUo=
 github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
 github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/esignet-service/internal/engine/mock/authenticator.go
+++ b/esignet-service/internal/engine/mock/authenticator.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
@@ -400,20 +399,12 @@ func (p *mockAuthnProvider) callKycExchangeEndpoint(ctx context.Context, request
 		return nil, fmt.Errorf("failed to parse kyc-exchange response: %w", err)
 	}
 
-	// Success path, currently parses the payload and returns the claims
-	// This should instead return signed JWT as is, but this can be done only when
-	// thunderID SDK supports "JWT" key in the Attributes map.
+	// Success path: the signed JWT is passed through as-is, undecoded, under
+	// providers.RawJWTAttributeKey.
 	if wrapper.Response != nil && wrapper.Response.Kyc != "" {
-		claims := jwt.MapClaims{}
-		if _, _, err := jwt.NewParser().ParseUnverified(wrapper.Response.Kyc, claims); err != nil {
-			return nil, fmt.Errorf("failed to parse KYC JWT payload: %w", err)
+		attributes := map[string]*providers.AttributeResponse{
+			providers.RawJWTAttributeKey: {Value: wrapper.Response.Kyc},
 		}
-
-		attributes := make(map[string]*providers.AttributeResponse, len(claims))
-		for k, v := range claims {
-			attributes[k] = &providers.AttributeResponse{Value: v}
-		}
-
 		return &providers.AttributesResponse{Attributes: attributes}, nil
 	}
 

--- a/esignet-service/internal/engine/mock/authenticator_test.go
+++ b/esignet-service/internal/engine/mock/authenticator_test.go
@@ -254,7 +254,7 @@ func (ts *AuthenticatorTestSuite) TestGetAttributes() {
 		require.Same(t, shared.AuthenticationFailedError, svcErr)
 	})
 
-	t.Run("successful kyc exchange maps claims", func(t *testing.T) {
+	t.Run("successful kyc exchange passes through raw jwt", func(t *testing.T) {
 		claims := jwt.MapClaims{"sub": "ind-1", "name": "Jane Doe"}
 		signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-secret"))
 		require.NoError(t, err)
@@ -271,8 +271,8 @@ func (ts *AuthenticatorTestSuite) TestGetAttributes() {
 			&providers.RequestedAttributes{}, getAttributesMetadataWithClientID("client-1"))
 		require.Nil(t, svcErr)
 		require.NotNil(t, attrs)
-		require.Equal(t, "Jane Doe", attrs.Attributes["name"].Value)
-		require.Equal(t, "ind-1", attrs.Attributes["sub"].Value)
+		require.Len(t, attrs.Attributes, 1)
+		require.Equal(t, signed, attrs.Attributes[providers.RawJWTAttributeKey].Value)
 	})
 
 	t.Run("kyc exchange error", func(t *testing.T) {

--- a/esignet-service/internal/engine/mosip/authenticator.go
+++ b/esignet-service/internal/engine/mosip/authenticator.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
-
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
@@ -1046,20 +1044,12 @@ func (p *mosipAuthnProvider) callKycExchangeEndpoint(
 		return nil, fmt.Errorf("failed to parse IdaKycExchangeResponseWrapper: %w", err)
 	}
 
-	// Success path, currently parses the payload and returns the claims
-	// This should instead return signed JWT as is, but this can be done only when
-	// thunderID SDK supports "JWT" key in the Attributes map.
+	// Success path: the signed JWT is passed through as-is, undecoded, under
+	// providers.RawJWTAttributeKey.
 	if wrapper.Response != nil && wrapper.Response.EncryptedKyc != "" {
-		claims := jwt.MapClaims{}
-		if _, _, err := jwt.NewParser().ParseUnverified(wrapper.Response.EncryptedKyc, claims); err != nil {
-			return nil, fmt.Errorf("failed to parse KYC JWT payload: %w", err)
+		attributes := map[string]*providers.AttributeResponse{
+			providers.RawJWTAttributeKey: {Value: wrapper.Response.EncryptedKyc},
 		}
-
-		attributes := make(map[string]*providers.AttributeResponse, len(claims))
-		for k, v := range claims {
-			attributes[k] = &providers.AttributeResponse{Value: v}
-		}
-
 		return &providers.AttributesResponse{Attributes: attributes}, nil
 	}
 

--- a/esignet-service/internal/engine/mosip/authenticator_test.go
+++ b/esignet-service/internal/engine/mosip/authenticator_test.go
@@ -1036,16 +1036,6 @@ func (ts *AuthenticatorTestSuite) TestCallKycExchangeEndpointEmptyEncryptedKycNo
 	require.EqualError(t, err, "no errors in response wrapper")
 }
 
-func (ts *AuthenticatorTestSuite) TestCallKycExchangeEndpointInvalidJWT() {
-	t := ts.T()
-	srv := httptest.NewServer(jsonHandler(http.StatusOK, `{"response":{"encryptedKyc":"not-a-jwt"}}`))
-	defer srv.Close()
-	p := newProvider(nil)
-	p.cfg.KYCExchangeBaseURL = srv.URL
-	_, err := p.callKycExchangeEndpoint(context.Background(), []byte("{}"), "sig", "rp", "cid")
-	require.ErrorContains(t, err, "failed to parse KYC JWT payload")
-}
-
 func (ts *AuthenticatorTestSuite) TestCallKycExchangeEndpointSuccess() {
 	t := ts.T()
 	jwtStr := unsignedJWT(t, map[string]interface{}{"sub": "user-1", "name": "John"})
@@ -1059,8 +1049,8 @@ func (ts *AuthenticatorTestSuite) TestCallKycExchangeEndpointSuccess() {
 
 	resp, callErr := p.callKycExchangeEndpoint(context.Background(), []byte("{}"), "sig", "rp", "cid")
 	require.NoError(t, callErr)
-	require.Equal(t, "user-1", resp.Attributes["sub"].Value)
-	require.Equal(t, "John", resp.Attributes["name"].Value)
+	require.Len(t, resp.Attributes, 1)
+	require.Equal(t, jwtStr, resp.Attributes[providers.RawJWTAttributeKey].Value)
 }
 
 // ---------------------------------------------------------------------------
@@ -1426,8 +1416,7 @@ func (ts *AuthenticatorTestSuite) TestGetAttributesSuccess() {
 
 	resp, svcErr := p.GetAttributes(context.Background(), attributeToken, reqAttrs, getAttributesMetadataFor("client-1"))
 	require.Nil(t, svcErr)
-	require.Equal(t, "user-1", resp.Attributes["sub"].Value)
-	require.Equal(t, "John", resp.Attributes["name"].Value)
+	require.Equal(t, jwtStr, resp.Attributes[providers.RawJWTAttributeKey].Value)
 }
 
 func (ts *AuthenticatorTestSuite) TestGetAttributesDefaultsToSubWhenNoAttributesRequested() {
@@ -1449,7 +1438,7 @@ func (ts *AuthenticatorTestSuite) TestGetAttributesDefaultsToSubWhenNoAttributes
 	attributeToken := strings.Join([]string{"kyctok", "user-1", "txn-1"}, "||")
 	resp, svcErr := p.GetAttributes(context.Background(), attributeToken, &providers.RequestedAttributes{}, getAttributesMetadataFor("client-1"))
 	require.Nil(t, svcErr)
-	require.Equal(t, "user-1", resp.Attributes["sub"].Value)
+	require.Equal(t, jwtStr, resp.Attributes[providers.RawJWTAttributeKey].Value)
 
 	var req IdaKycExchangeRequest
 	require.NoError(t, json.Unmarshal(capturedBody, &req))


### PR DESCRIPTION
Closes #2420 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * KYC exchange responses now preserve and return the complete signed JWT, enabling downstream systems to process the original token directly.
  * Updated identity service integration components to support the latest dependency version.
* **Tests**
  * Updated validation coverage to confirm raw JWT handling for successful KYC exchanges.
  * Refined authentication response tests to reflect the updated token format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->