### PR TITLE
[#2314] Fix Localized client name resolution.

### DIFF
--- a/esignet-service/cmd/esignet/main.go
+++ b/esignet-service/cmd/esignet/main.go
@@ -161,7 +161,7 @@ func main() {
 		thunderidengine.WithConsentProvider(engine.NewConsentProvider(consentmgmt.NewService(pgConn), appCfg)),
 		thunderidengine.WithDesignResolveProvider(engine.NewDesignProvider(appCfg, runtimeStore, appCfg.DesignCacheTTLSecs)),
 		thunderidengine.WithFlowProvider(engine.NewFlowProvider(appCfg, runtimeStore, appCfg.FlowCacheTTLSecs)),
-		thunderidengine.WithI18nProvider(engine.NewI18nProvider(appCfg)),
+		thunderidengine.WithI18nProvider(engine.NewI18nProvider(appCfg, clientSvc)),
 		thunderidengine.WithOUProvider(engine.NewOUProvider(appCfg)),
 		thunderidengine.WithResourceProvider(engine.NewResourceProvider(appCfg)),
 		thunderidengine.WithObservabilityProvider(observabilityProvider),

--- a/esignet-service/internal/engine/actor_provider.go
+++ b/esignet-service/internal/engine/actor_provider.go
@@ -36,7 +36,6 @@ const (
 	// Map keys
 	jwks        = "JWKS"
 	name        = "name"
-	nameLangMap = "nameLangMap"
 	description = "description"
 	logoURL     = "logo_url"
 	app         = "app"
@@ -218,7 +217,8 @@ func (p *actorProvider) GetActor(id string) (*providers.Entity, *common.ServiceE
 		description: client.ClientName,
 	}
 	if len(client.ClientNameLangMap) > 0 {
-		clientAttributes[nameLangMap] = client.ClientNameLangMap
+		// Fixed reference; ResolveTranslations resolves it per-request via namespace=clientID.
+		clientAttributes[name] = "{{t(" + clientNameNamespace + ":name)}}"
 	}
 	data, err := json.Marshal(clientAttributes)
 	if err != nil {

--- a/esignet-service/internal/engine/actor_provider_test.go
+++ b/esignet-service/internal/engine/actor_provider_test.go
@@ -9,6 +9,7 @@ package engine
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -322,6 +323,44 @@ func (ts *ActorProviderTestSuite) TestActorProvider_GetActor() {
 	if _, svcErr := p.GetActor("no-such-client"); svcErr == nil {
 		t.Fatal("expected error for unknown client")
 	}
+}
+
+func (ts *ActorProviderTestSuite) TestActorProvider_GetActor_NameLangMap() {
+	t := ts.T()
+
+	t.Run("no lang map: name stays plain", func(t *testing.T) {
+		p := NewActorProvider(newActorTestService(testClientRow()), &config.AppConfig{})
+		entity, svcErr := p.GetActor("client-001")
+		if svcErr != nil {
+			t.Fatalf("GetActor: %v", svcErr)
+		}
+		var attrs map[string]interface{}
+		if err := json.Unmarshal(entity.SystemAttributes, &attrs); err != nil {
+			t.Fatalf("unmarshal SystemAttributes: %v", err)
+		}
+		if attrs["name"] != "Test App" {
+			t.Errorf("name = %v, want plain \"Test App\"", attrs["name"])
+		}
+	})
+
+	t.Run("lang map present: name becomes an i18n reference", func(t *testing.T) {
+		row := testClientRow()
+		row.Name = `{"@none":"Test App","hin":"टेस्ट ऐप"}`
+		p := NewActorProvider(newActorTestService(row), &config.AppConfig{})
+
+		entity, svcErr := p.GetActor("client-001")
+		if svcErr != nil {
+			t.Fatalf("GetActor: %v", svcErr)
+		}
+		var attrs map[string]interface{}
+		if err := json.Unmarshal(entity.SystemAttributes, &attrs); err != nil {
+			t.Fatalf("unmarshal SystemAttributes: %v", err)
+		}
+		want := "{{t(client:name)}}"
+		if attrs["name"] != want {
+			t.Errorf("name = %v, want %q", attrs["name"], want)
+		}
+	})
 }
 
 func (ts *ActorProviderTestSuite) TestActorProvider_GetActor_ServerError() {

--- a/esignet-service/internal/engine/i18n_provider.go
+++ b/esignet-service/internal/engine/i18n_provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
+	"github.com/mosip/esignet/internal/clientmgmt"
 	"github.com/mosip/esignet/internal/config"
 	"github.com/mosip/esignet/internal/engine/shared"
 	applog "github.com/mosip/esignet/internal/log"
@@ -27,13 +28,19 @@ import (
 // fallbackLanguage is returned by bestMatchLanguage when no confident match is found.
 const fallbackLanguage = "en"
 
+// clientNameNamespace is the fixed namespace a client's localized name is exposed under,
+// matching the static "{{t(client:name)}}" reference GetActor emits.
+const clientNameNamespace = "client"
+
 type i18nProvider struct {
-	cfg *config.AppConfig
+	cfg       *config.AppConfig
+	clientSvc *clientmgmt.Service
 }
 
 // NewI18nProvider returns a file-based i18n provider backed by the configured data directory.
-func NewI18nProvider(cfg *config.AppConfig) providers.I18nProvider {
-	return &i18nProvider{cfg: cfg}
+// clientSvc resolves a client's localized name when a client id is passed as namespace.
+func NewI18nProvider(cfg *config.AppConfig, clientSvc *clientmgmt.Service) providers.I18nProvider {
+	return &i18nProvider{cfg: cfg, clientSvc: clientSvc}
 }
 
 // ListLanguages scans the data/i18n directory and returns all available language codes.
@@ -60,11 +67,11 @@ func (p *i18nProvider) ListLanguages(ctx context.Context) ([]string, *common.Ser
 
 // ResolveTranslations reads and parses the best-matching i18n YAML file for the
 // requested language tag. BCP47 matching is used so that "en-US" resolves to "en",
-// "hi-IN" resolves to "hi", etc.
+// "hi-IN" resolves to "hi", etc. namespace doubles as an optional client id (see injectClientName).
 func (p *i18nProvider) ResolveTranslations(
 	ctx context.Context,
 	requestedLang string,
-	_ string,
+	namespace string,
 ) (*providers.LanguageTranslationsResponse, *common.ServiceError) {
 	available, svcErr := p.ListLanguages(ctx)
 	if svcErr != nil {
@@ -91,6 +98,12 @@ func (p *i18nProvider) ResolveTranslations(
 			applog.Error(err))
 		return nil, shared.FileUnmarshallError
 	}
+	if raw == nil {
+		// Empty/null YAML documents unmarshal to a nil map; writing into it below would panic.
+		raw = make(map[string]map[string]string)
+	}
+
+	p.injectClientName(ctx, raw, namespace, requestedLang)
 
 	total := 0
 	for _, ns := range raw {
@@ -104,25 +117,83 @@ func (p *i18nProvider) ResolveTranslations(
 	}, nil
 }
 
-// bestMatchLanguage returns the closest available language for the requested tag
-// using BCP47 matching. available is reordered with fallbackLanguage first.
+// injectClientName looks up namespace as a client id and, if that client has a localized name,
+// exposes it under clientNameNamespace. A no-op when namespace is empty, clientSvc isn't
+// configured, or the client has no per-language names.
+func (p *i18nProvider) injectClientName(ctx context.Context, raw map[string]map[string]string, namespace, language string) {
+	if namespace == "" || p.clientSvc == nil {
+		return
+	}
+
+	client, err := p.clientSvc.GetClient(ctx, namespace)
+	if err != nil || len(client.ClientNameLangMap) == 0 {
+		return
+	}
+
+	clientName := bestMatchName(client.ClientNameLangMap, language)
+	if clientName == "" {
+		clientName = client.ClientName
+	}
+
+	if raw[clientNameNamespace] == nil {
+		raw[clientNameNamespace] = make(map[string]string)
+	}
+	raw[clientNameNamespace]["name"] = clientName
+}
+
+// bestMatchLanguage returns the closest available language for the requested tag: an exact
+// tag match if available, else the requested tag's
+// own base language if that's supported, else fallbackLanguage.
 func bestMatchLanguage(requested string, available []string) string {
 	if len(available) == 0 {
 		return fallbackLanguage
 	}
 
-	ordered := make([]string, len(available))
-	copy(ordered, available)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		return ordered[i] == fallbackLanguage && ordered[j] != fallbackLanguage
-	})
+	sorted := make([]string, len(available))
+	copy(sorted, available)
+	sort.Strings(sorted)
 
-	tags := make([]language.Tag, len(ordered))
-	for i, l := range ordered {
-		tags[i] = language.Make(l)
+	if match := bestMatchCode(requested, sorted); match != "" {
+		return match
 	}
+	for _, code := range sorted {
+		if code == fallbackLanguage {
+			return fallbackLanguage
+		}
+	}
+	return sorted[0]
+}
 
-	matcher := language.NewMatcher(tags)
-	_, idx, _ := matcher.Match(language.Make(requested))
-	return ordered[idx]
+// bestMatchCode returns the entry in sorted (must already be sorted) that best matches requested:
+// an exact tag match if present, else a base-language match, else "". language.NewMatcher isn't
+// used here since its CLDR scoring can prefer a sibling dialect (e.g. "en-IN") over the plain
+// base tag (e.g. "en") for an unrelated request like "en-GB" — wrong for this use case.
+func bestMatchCode(requested string, sorted []string) string {
+	want := language.Make(requested)
+	wantBase, _ := want.Base()
+
+	baseMatch := ""
+	for _, code := range sorted {
+		tag := language.Make(code)
+		if tag.String() == want.String() {
+			return code
+		}
+		if baseMatch == "" {
+			if base, _ := tag.Base(); base.String() == wantBase.String() {
+				baseMatch = code
+			}
+		}
+	}
+	return baseMatch
+}
+
+// bestMatchName returns the value in names whose key best matches requested (see bestMatchCode),
+// or "" if nothing matches.
+func bestMatchName(names map[string]string, requested string) string {
+	codes := make([]string, 0, len(names))
+	for code := range names {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+	return names[bestMatchCode(requested, codes)]
 }

--- a/esignet-service/internal/engine/i18n_provider_test.go
+++ b/esignet-service/internal/engine/i18n_provider_test.go
@@ -21,7 +21,7 @@ func (ts *I18nProviderTestSuite) TestI18nProvider_ListLanguages() {
 	t := ts.T()
 
 	t.Run("missing directory returns FileNotFoundError", func(t *testing.T) {
-		p := NewI18nProvider(&config.AppConfig{DataDir: t.TempDir()})
+		p := NewI18nProvider(&config.AppConfig{DataDir: t.TempDir()}, nil)
 		langs, svcErr := p.ListLanguages(context.Background())
 		require.NotNil(t, svcErr)
 		require.Nil(t, langs)
@@ -34,7 +34,7 @@ func (ts *I18nProviderTestSuite) TestI18nProvider_ListLanguages() {
 		mustWriteFile(t, filepath.Join(dir, "i18n", "hi.yaml"), "system:\n  hello: Namaste\n")
 		mustWriteFile(t, filepath.Join(dir, "i18n", "not-yaml.txt"), "ignore me")
 
-		p := NewI18nProvider(&config.AppConfig{DataDir: dir})
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, nil)
 		langs, svcErr := p.ListLanguages(context.Background())
 		require.Nil(t, svcErr)
 		require.ElementsMatch(t, []string{"en", "hi"}, langs)
@@ -43,7 +43,7 @@ func (ts *I18nProviderTestSuite) TestI18nProvider_ListLanguages() {
 	t.Run("empty directory falls back to default", func(t *testing.T) {
 		dir := t.TempDir()
 		mustMkdirAll(t, filepath.Join(dir, "i18n"))
-		p := NewI18nProvider(&config.AppConfig{DataDir: dir})
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, nil)
 		langs, svcErr := p.ListLanguages(context.Background())
 		require.Nil(t, svcErr)
 		require.Equal(t, []string{"en"}, langs)
@@ -58,7 +58,7 @@ func (ts *I18nProviderTestSuite) TestI18nProvider_ResolveTranslations() {
 		mustMkdirAll(t, filepath.Join(dir, "i18n"))
 		mustWriteFile(t, filepath.Join(dir, "i18n", "en.yaml"), "system:\n  hello: Hello\n  bye: Bye\n")
 
-		p := NewI18nProvider(&config.AppConfig{DataDir: dir})
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, nil)
 		resp, svcErr := p.ResolveTranslations(context.Background(), "en", "")
 		require.Nil(t, svcErr)
 		require.Equal(t, "en", resp.Language)
@@ -71,14 +71,14 @@ func (ts *I18nProviderTestSuite) TestI18nProvider_ResolveTranslations() {
 		mustMkdirAll(t, filepath.Join(dir, "i18n"))
 		mustWriteFile(t, filepath.Join(dir, "i18n", "en.yaml"), "system:\n  hello: Hello\n")
 
-		p := NewI18nProvider(&config.AppConfig{DataDir: dir})
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, nil)
 		resp, svcErr := p.ResolveTranslations(context.Background(), "en-US", "")
 		require.Nil(t, svcErr)
 		require.Equal(t, "en", resp.Language)
 	})
 
 	t.Run("no available languages returns FileNotFoundError", func(t *testing.T) {
-		p := NewI18nProvider(&config.AppConfig{DataDir: t.TempDir()})
+		p := NewI18nProvider(&config.AppConfig{DataDir: t.TempDir()}, nil)
 		_, svcErr := p.ResolveTranslations(context.Background(), "en", "")
 		require.NotNil(t, svcErr)
 	})
@@ -88,9 +88,90 @@ func (ts *I18nProviderTestSuite) TestI18nProvider_ResolveTranslations() {
 		mustMkdirAll(t, filepath.Join(dir, "i18n"))
 		mustWriteFile(t, filepath.Join(dir, "i18n", "en.yaml"), "not: [valid: yaml")
 
-		p := NewI18nProvider(&config.AppConfig{DataDir: dir})
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, nil)
 		_, svcErr := p.ResolveTranslations(context.Background(), "en", "")
 		require.NotNil(t, svcErr)
+	})
+
+	t.Run("empty translation document: name still injected without panic", func(t *testing.T) {
+		dir := t.TempDir()
+		mustMkdirAll(t, filepath.Join(dir, "i18n"))
+		mustWriteFile(t, filepath.Join(dir, "i18n", "hi.yaml"), "")
+
+		row := testClientRow()
+		row.Name = `{"@none":"Test App","hin":"टेस्ट ऐप"}`
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, newActorTestService(row))
+
+		resp, svcErr := p.ResolveTranslations(context.Background(), "hi", "client-001")
+		require.Nil(t, svcErr)
+		require.Equal(t, "टेस्ट ऐप", resp.Translations["client"]["name"])
+	})
+
+	t.Run("namespace as client id injects name for the best-matching language", func(t *testing.T) {
+		dir := t.TempDir()
+		mustMkdirAll(t, filepath.Join(dir, "i18n"))
+		mustWriteFile(t, filepath.Join(dir, "i18n", "hi.yaml"), "system:\n  hello: Namaste\n")
+
+		row := testClientRow()
+		row.Name = `{"@none":"Test App","hin":"टेस्ट ऐप"}`
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, newActorTestService(row))
+
+		resp, svcErr := p.ResolveTranslations(context.Background(), "hi", "client-001")
+		require.Nil(t, svcErr)
+		require.Equal(t, "टेस्ट ऐप", resp.Translations["client"]["name"])
+	})
+
+	t.Run("namespace as client id falls back to the plain default name", func(t *testing.T) {
+		dir := t.TempDir()
+		mustMkdirAll(t, filepath.Join(dir, "i18n"))
+		mustWriteFile(t, filepath.Join(dir, "i18n", "en.yaml"), "system:\n  hello: Hello\n")
+
+		row := testClientRow()
+		row.Name = `{"@none":"Test App","hin":"टेस्ट ऐप"}`
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, newActorTestService(row))
+
+		resp, svcErr := p.ResolveTranslations(context.Background(), "fr", "client-001")
+		require.Nil(t, svcErr)
+		require.Equal(t, "Test App", resp.Translations["client"]["name"])
+	})
+
+	t.Run("namespace with no client lang map: no name entry", func(t *testing.T) {
+		dir := t.TempDir()
+		mustMkdirAll(t, filepath.Join(dir, "i18n"))
+		mustWriteFile(t, filepath.Join(dir, "i18n", "en.yaml"), "system:\n  hello: Hello\n")
+
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, newActorTestService(testClientRow()))
+
+		resp, svcErr := p.ResolveTranslations(context.Background(), "en", "client-001")
+		require.Nil(t, svcErr)
+		_, ok := resp.Translations["client"]
+		require.False(t, ok)
+	})
+
+	t.Run("namespace with unknown client id: no name entry", func(t *testing.T) {
+		dir := t.TempDir()
+		mustMkdirAll(t, filepath.Join(dir, "i18n"))
+		mustWriteFile(t, filepath.Join(dir, "i18n", "en.yaml"), "system:\n  hello: Hello\n")
+
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, newActorTestService(testClientRow()))
+
+		resp, svcErr := p.ResolveTranslations(context.Background(), "en", "no-such-client")
+		require.Nil(t, svcErr)
+		_, ok := resp.Translations["client"]
+		require.False(t, ok)
+	})
+
+	t.Run("namespace set without a configured clientSvc: no panic, no name entry", func(t *testing.T) {
+		dir := t.TempDir()
+		mustMkdirAll(t, filepath.Join(dir, "i18n"))
+		mustWriteFile(t, filepath.Join(dir, "i18n", "en.yaml"), "system:\n  hello: Hello\n")
+
+		p := NewI18nProvider(&config.AppConfig{DataDir: dir}, nil)
+
+		resp, svcErr := p.ResolveTranslations(context.Background(), "en", "client-001")
+		require.Nil(t, svcErr)
+		_, ok := resp.Translations["client"]
+		require.False(t, ok)
 	})
 }
 
@@ -119,6 +200,44 @@ func (ts *I18nProviderTestSuite) TestBestMatchLanguage() {
 
 	t.Run("no match falls back to first available when english isn't configured", func(t *testing.T) {
 		require.Equal(t, "ar", bestMatchLanguage("zz", []string{"ar", "hi"}))
+	})
+
+	t.Run("exact dialect match preferred over a sibling dialect", func(t *testing.T) {
+		require.Equal(t, "ta-LK", bestMatchLanguage("ta-LK", []string{"ta-IN", "ta-LK"}))
+		require.Equal(t, "ta-IN", bestMatchLanguage("ta-IN", []string{"ta-IN", "ta-LK"}))
+	})
+
+	t.Run("unmatched dialect falls back to its own base language, not a sibling dialect", func(t *testing.T) {
+		// "en" is a genuine match for "en-GB" and must win even though "en-IN" is
+		// also configured and CLDR distance scoring would otherwise favor it.
+		require.Equal(t, "en", bestMatchLanguage("en-GB", []string{"ar", "en", "en-IN", "en-US"}))
+	})
+
+	t.Run("unmatched dialect with no base configured falls back to a sibling dialect", func(t *testing.T) {
+		require.Equal(t, "ta-IN", bestMatchLanguage("ta-SG", []string{"ta-IN", "ta-LK"}))
+	})
+}
+
+func (ts *I18nProviderTestSuite) TestBestMatchName() {
+	t := ts.T()
+
+	t.Run("exact match", func(t *testing.T) {
+		names := map[string]string{"hin": "एक्मे", "eng": "Acme"}
+		require.Equal(t, "एक्मे", bestMatchName(names, "hi"))
+	})
+
+	t.Run("base-language match for a regional tag", func(t *testing.T) {
+		names := map[string]string{"fr": "Acme France"}
+		require.Equal(t, "Acme France", bestMatchName(names, "fr-CA"))
+	})
+
+	t.Run("no match returns empty string", func(t *testing.T) {
+		names := map[string]string{"hin": "एक्मे"}
+		require.Equal(t, "", bestMatchName(names, "fr"))
+	})
+
+	t.Run("empty names returns empty string", func(t *testing.T) {
+		require.Equal(t, "", bestMatchName(map[string]string{}, "en"))
 	})
 }
 

--- a/oidc-ui/package-lock.json
+++ b/oidc-ui/package-lock.json
@@ -12,7 +12,7 @@
         "@marsidev/react-turnstile": "^1.5.3",
         "@mosip/secure-biometric-interface-integrator": "^0.1.0",
         "@tanstack/react-query": "^5.100.9",
-        "@thunderid/react": "^1.0.5",
+        "@thunderid/react": "^1.0.6",
         "axios": "^1.16.0",
         "react": "^19.2.5",
         "react-detect-offline": "^2.4.5",
@@ -1673,12 +1673,12 @@
       }
     },
     "node_modules/@thunderid/browser": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@thunderid/browser/-/browser-1.0.5.tgz",
-      "integrity": "sha512-xpN2FCsAlXdMQ5d6KT+GAikGDdLtyOV+bF1O73+BjNVXfVYnMaimw9sRmEAh59wGNBcxY2mwTrxu1tegxANlBQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@thunderid/browser/-/browser-1.0.6.tgz",
+      "integrity": "sha512-UqGpfIjKwv01BpRe60Q5Vyai802Wh1wvBMYeA5xhAi6EvF1SBqgzmwg+fw+viCrfr26tZs3sdb2HfWT7OyL21Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@thunderid/javascript": "^1.0.5",
+        "@thunderid/javascript": "^1.0.6",
         "base64url": "3.0.1",
         "buffer": "6.0.3",
         "core-js": "3.42.0",
@@ -1700,9 +1700,9 @@
       }
     },
     "node_modules/@thunderid/javascript": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@thunderid/javascript/-/javascript-1.0.5.tgz",
-      "integrity": "sha512-hDBBt2UdJOUp68qI6v2JCN83vbkuioZqAUmtxuLspXf3ggIvqe6g5N5DRFNNV+0SQLH3w8hdvJPok5J4Z7vnoQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@thunderid/javascript/-/javascript-1.0.6.tgz",
+      "integrity": "sha512-fcD28NqitrTDu+gO8XNfK/sEafPmaXKFg7lFSIuKaDg09eiXIcrH0Vqr5XRhc2PacKG0+5B2s5+0vJ4tynHJgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "6.2.3",
@@ -1719,14 +1719,14 @@
       }
     },
     "node_modules/@thunderid/react": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@thunderid/react/-/react-1.0.5.tgz",
-      "integrity": "sha512-Ye3y85uRHMeu5RMjkQ608nmHCtoJmGLvLUVPICBmkVke8SE4a617VThlZfgrhiOpz94285LDWCXr2upcJKzKUg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@thunderid/react/-/react-1.0.6.tgz",
+      "integrity": "sha512-AhOgOBNVLcJkD10HdhYeB1tOu+fKS0uJULPoCAKboOXlePkYpbs3JgRPLvMixdBFVFioijfwoDlocSWRGtWOzg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
         "@floating-ui/react": "0.27.12",
-        "@thunderid/browser": "^1.0.5",
+        "@thunderid/browser": "^1.0.6",
         "dompurify": "3.4.13",
         "tslib": "2.8.1"
       },

--- a/oidc-ui/package.json
+++ b/oidc-ui/package.json
@@ -18,7 +18,7 @@
     "@marsidev/react-turnstile": "^1.5.3",
     "@mosip/secure-biometric-interface-integrator": "^0.1.0",
     "@tanstack/react-query": "^5.100.9",
-    "@thunderid/react": "^1.0.5",
+    "@thunderid/react": "^1.0.6",
     "axios": "^1.16.0",
     "react": "^19.2.5",
     "react-detect-offline": "^2.4.5",

--- a/oidc-ui/src/main.tsx
+++ b/oidc-ui/src/main.tsx
@@ -40,6 +40,7 @@ createRoot(document.getElementById("root")!).render(
       <ThunderIDProvider
         baseUrl={baseUrl}
         applicationId={applicationId}
+        namespace={applicationId}
         preferences={
           initialLanguage ? { i18n: { language: initialLanguage } } : undefined
         }


### PR DESCRIPTION
**Related Issue: ** #2314 

- Attaching local tested reference.
<img width="1919" height="1041" alt="image" src="https://github.com/user-attachments/assets/e4d0571a-d347-42f5-a253-86c344563d04" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized application names to translation responses when available.
  * Improved language selection with exact, base-language, English, and fallback matching.
  * Enabled application-specific translation namespaces in the sign-in experience.

* **Bug Fixes**
  * Ensured application names fall back to default values when translations are unavailable.
  * Prevented translations from appearing for missing or unknown applications.
  * Improved handling of empty translation content and unavailable localization services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->