### PR TITLE
Added env variables overrides

### DIFF
--- a/esignet-service/data/deployment.yaml
+++ b/esignet-service/data/deployment.yaml
@@ -150,8 +150,8 @@ oauth:
     enabled: false  
 
 security_config:
-  issuer_url: ""
-  jwks_url: ""
+  issuer_url: ""  # override via MOSIP_ESIGNET_SECURITY_ISSUER_URL
+  jwks_url: ""    # override via MOSIP_ESIGNET_SECURITY_JWKS_URL
   jwks_cache_ttl: 3000
   scope_mapping:
     - endpoint: "/client-mgmt/oidc-client"

--- a/esignet-service/internal/config/app.go
+++ b/esignet-service/internal/config/app.go
@@ -625,6 +625,21 @@ func ApplyEnvOverrides(cfg *AppConfig) error {
 		}
 		cfg.SupportedEncAlgorithms = algorithms
 	}
+	if v := os.Getenv("MOSIP_ESIGNET_SECURITY_ISSUER_URL"); v != "" {
+		cfg.SecurityConfig.IssuerURL = v
+	}
+	if v := os.Getenv("MOSIP_ESIGNET_SECURITY_JWKS_URL"); v != "" {
+		cfg.SecurityConfig.JwksURL = v
+	}
+	if v := os.Getenv("MOSIP_ESIGNET_CLIENT_CACHE_TTL_SECS"); v != "" {
+		secs, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid MOSIP_ESIGNET_CLIENT_CACHE_TTL_SECS: %w", err)
+		}
+		if secs > 0 {
+			cfg.ClientCacheTTLSecs = secs
+		}
+	}
 	if v := os.Getenv("MOSIP_ESIGNET_RESOURCE_SERVERS_JSON"); v != "" {
 		var resourceServers []ResourceServerConfig
 		if err := json.Unmarshal([]byte(v), &resourceServers); err != nil {

--- a/esignet-service/internal/config/app_test.go
+++ b/esignet-service/internal/config/app_test.go
@@ -747,6 +747,56 @@ func (ts *AppConfigTestSuite) TestApplyEnvOverridesInvalidAccessTokenLifetime() 
 	ts.Require().Error(ApplyEnvOverrides(cfg))
 }
 
+func (ts *AppConfigTestSuite) TestApplyEnvOverridesSecurityConfig() {
+	t := ts.T()
+	cfg := &AppConfig{SecurityConfig: SecurityConfig{IssuerURL: "https://yaml-issuer", JwksURL: "https://yaml-jwks"}}
+	t.Setenv("MOSIP_ESIGNET_SECURITY_ISSUER_URL", "https://issuer.example.com")
+	t.Setenv("MOSIP_ESIGNET_SECURITY_JWKS_URL", "https://issuer.example.com/jwks.json")
+
+	ts.Require().NoError(ApplyEnvOverrides(cfg))
+
+	ts.Require().Equal("https://issuer.example.com", cfg.SecurityConfig.IssuerURL, "env var takes precedence over yaml-set value")
+	ts.Require().Equal("https://issuer.example.com/jwks.json", cfg.SecurityConfig.JwksURL, "env var takes precedence over yaml-set value")
+}
+
+func (ts *AppConfigTestSuite) TestApplyEnvOverridesSecurityConfigNoEnvSetPreservesYAML() {
+	t := ts.T()
+	t.Setenv("MOSIP_ESIGNET_SECURITY_ISSUER_URL", "")
+	t.Setenv("MOSIP_ESIGNET_SECURITY_JWKS_URL", "")
+	cfg := &AppConfig{SecurityConfig: SecurityConfig{IssuerURL: "https://yaml-issuer", JwksURL: "https://yaml-jwks"}}
+
+	ts.Require().NoError(ApplyEnvOverrides(cfg))
+
+	ts.Require().Equal("https://yaml-issuer", cfg.SecurityConfig.IssuerURL, "yaml value preserved when env var unset")
+	ts.Require().Equal("https://yaml-jwks", cfg.SecurityConfig.JwksURL, "yaml value preserved when env var unset")
+}
+
+func (ts *AppConfigTestSuite) TestApplyEnvOverridesClientCacheTTLSecs() {
+	t := ts.T()
+	cfg := &AppConfig{ClientCacheTTLSecs: 42}
+	t.Setenv("MOSIP_ESIGNET_CLIENT_CACHE_TTL_SECS", "99")
+
+	ts.Require().NoError(ApplyEnvOverrides(cfg))
+
+	ts.Require().EqualValues(99, cfg.ClientCacheTTLSecs, "env var takes precedence over yaml-set value")
+}
+
+func (ts *AppConfigTestSuite) TestApplyEnvOverridesClientCacheTTLSecsNonPositiveIgnored() {
+	cfg := &AppConfig{ClientCacheTTLSecs: 42}
+	ts.T().Setenv("MOSIP_ESIGNET_CLIENT_CACHE_TTL_SECS", "0")
+
+	ts.Require().NoError(ApplyEnvOverrides(cfg))
+
+	ts.Require().EqualValues(42, cfg.ClientCacheTTLSecs, "0 or negative override should be ignored")
+}
+
+func (ts *AppConfigTestSuite) TestApplyEnvOverridesInvalidClientCacheTTLSecs() {
+	cfg := &AppConfig{}
+	ts.T().Setenv("MOSIP_ESIGNET_CLIENT_CACHE_TTL_SECS", "abc")
+
+	ts.Require().Error(ApplyEnvOverrides(cfg))
+}
+
 func (ts *AppConfigTestSuite) TestApplyEnvOverridesNoEnvSetLeavesDefaults() {
 	t := ts.T()
 	for _, envVar := range []string{


### PR DESCRIPTION
Closes #2442 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring security issuer and JWKS URLs through environment variables.
  - Added an environment-based override for client cache duration, accepting positive integer values.

- **Bug Fixes**
  - Invalid cache duration values now produce a clear configuration error.
  - Non-positive cache duration values no longer replace the existing setting.

- **Documentation**
  - Documented the environment variables available for overriding security URL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->