### PR TITLE
updated thunderid reference to thunderid:v1.0.1

### DIFF
--- a/esignet-service/go.mod
+++ b/esignet-service/go.mod
@@ -72,4 +72,4 @@ require (
 	modernc.org/sqlite v1.53.0 // indirect
 )
 
-replace github.com/thunder-id/thunderid => github.com/thunder-id/thunderid/backend v0.0.0-20260822180739-64f1aa911649
+replace github.com/thunder-id/thunderid => github.com/thunder-id/thunderid/backend v0.0.0-20260825062603-12f517c43840

--- a/esignet-service/go.sum
+++ b/esignet-service/go.sum
@@ -124,8 +124,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/thunder-id/thunderid/backend v0.0.0-20260822180739-64f1aa911649 h1:Voo442ITeDfMfpr7byQPeJgmMkUNFV5d45PWlFSLDv0=
-github.com/thunder-id/thunderid/backend v0.0.0-20260822180739-64f1aa911649/go.mod h1:KUUd6FrqXZJPXM8JwCaH8dLMpU5URrfDKYr68Ow2PUo=
+github.com/thunder-id/thunderid/backend v0.0.0-20260825062603-12f517c43840 h1:VrELmxfIW1Ia+s1aF41mmZE16/YOlhkK8wpHv3feaz8=
+github.com/thunder-id/thunderid/backend v0.0.0-20260825062603-12f517c43840/go.mod h1:KUUd6FrqXZJPXM8JwCaH8dLMpU5URrfDKYr68Ow2PUo=
 github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
 github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/esignet-service/make.sh
+++ b/esignet-service/make.sh
@@ -57,7 +57,7 @@ SIGNING_CERT=$KEY_DIR/signing.crt
 : "${DOCKER_IMAGE:=esignet:latest}"
 : "${GOLANGCI_LINT_VERSION:=latest}"
 : "${SQLC_VERSION:=v1.29.0}"
-: "${THUNDER_BRANCH:=1.0.x}"
+: "${THUNDER_BRANCH:=v1.0.1}"
 : "${RACE:=1}"   # set RACE=0 if no C toolchain (go test -race needs gcc on Windows)
 # Local builds default to a static, cgo-free binary, which drops the PKCS11
 # (HSM) keystore backend down to a stub that errors at startup — use


### PR DESCRIPTION
Closes #2463 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the service to use a newer Thunder backend version.
  * Updated the default Thunder release branch to `v1.0.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->