### PR TITLE
Update coverage script in package.json.

### DIFF
--- a/oidc-ui/README.md
+++ b/oidc-ui/README.md
@@ -79,7 +79,7 @@ Optional polling configuration:
 | `npm run build` | TypeScript check + production build |
 | `npm run preview` | Preview production build locally |
 | `npm run test` | Run all tests with Vitest |
-| `npm run test:coverage` | Run tests with coverage report |
+| `npm run test:ci` | Run tests with coverage report |
 | `npm run typecheck` | TypeScript type checking only |
 | `npm run lint` | Run ESLint |
 

--- a/oidc-ui/package.json
+++ b/oidc-ui/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test:ci": "vitest run --coverage",
     "typecheck": "tsc -b"
   },
   "dependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented test command from `npm run test:coverage` to `npm run test:ci`.

* **Chores**
  * Renamed the test script to `test:ci`; coverage reporting remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->