### PR TITLE
#2283 consent screen according to figma design

### DIFF
--- a/esignet-service/data/flows/flow-esignet.yaml
+++ b/esignet-service/data/flows/flow-esignet.yaml
@@ -1151,11 +1151,17 @@ nodes:
     type: PROMPT
     meta:
       components:
-        - id: timer_consent
-          type: TIMER
-          category: DISPLAY
+        - id: block_consent_timer
+          type: BLOCK
+          category: BLOCK
           resourceType: ELEMENT
-          label: "{{t(consent:timer_label)}} {time}"
+          classes: consent-timer
+          components:
+            - id: timer_consent
+              type: TIMER
+              category: DISPLAY
+              resourceType: ELEMENT
+              label: "{{t(consent:timer_label)}} {time}"
         - id: text_consent_title
           type: TEXT
           label: "{{meta(application.name)}} {{t(consent:title)}}"
@@ -1163,10 +1169,12 @@ nodes:
           category: DISPLAY
           resourceType: ELEMENT
           align: center
+          classes: font-weight-700
         - id: block_consent
           type: BLOCK
           category: BLOCK
           resourceType: ELEMENT
+          classes: consent-block
           components:
             - id: input_consent
               type: CONSENT

--- a/oidc-ui/src/App.css
+++ b/oidc-ui/src/App.css
@@ -280,3 +280,52 @@ input[type="password"]::-ms-clear {
 .thunderid-signin.thunderid-card {
   overflow: visible !important;
 }
+
+.font-weight-700 {
+  font-weight: 700 !important;
+}
+
+/* consent block css */
+.consent-block {
+  line-height: 100% !important;
+  letter-spacing: 0% !important;
+
+  /* for claims title i.e Essential & Voluntary */
+  & .thunderid-typography.thunderid-typography__subtitle2 {
+    font-weight: 700 !important;
+    font-size: 15px !important;
+  }
+
+  /* info icon of claims */
+  & .thunderid-tooltip__container {
+    color: #b9b9b9 !important;
+  }
+
+  /* claims list */
+  & .thunderid-consent-checkbox-list__label-container {
+    & > .thunderid-consent-checkbox-list__bullet,
+    & > .thunderid-consent-checkbox-list__typography {
+      color: #01070dd5 !important;
+    }
+  }
+
+  /* for required of essential claims */
+  & .thunderid-consent-checkbox-list__row > p.thunderid-typography__body2 {
+    color: #707070 !important;
+  }
+}
+
+/* consent timer */
+.consent-timer {
+  margin: -16px -32px 0px !important;
+  background: #fff9f0 !important;
+  padding: 16px !important;
+  border-top-left-radius: var(--thunderid-border-radius-large) !important;
+  border-top-right-radius: var(--thunderid-border-radius-large) !important;
+
+  font-weight: 500 !important;
+  font-size: 14px !important;
+  line-height: 100% !important;
+  letter-spacing: 0% !important;
+  color: #4e4e4e !important;
+}

--- a/oidc-ui/src/App.css
+++ b/oidc-ui/src/App.css
@@ -322,7 +322,6 @@ input[type="password"]::-ms-clear {
   padding: 16px !important;
   border-top-left-radius: var(--thunderid-border-radius-large) !important;
   border-top-right-radius: var(--thunderid-border-radius-large) !important;
-
   font-weight: 500 !important;
   font-size: 14px !important;
   line-height: 100% !important;


### PR DESCRIPTION
After changes, the consent screen look like this.

Specifically added classes in App.css for consent block and consent timer block.

<img width="541" height="802" alt="image" src="https://github.com/user-attachments/assets/443275d7-fe74-4299-a940-662cb0085a3c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the consent screen’s visual layout and styling.
  * Added clearer formatting for consent titles, claim sections, required claims, tooltips, checkboxes, and the countdown timer.
  * Grouped the consent countdown within its own styled section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->