### PR TITLE
[ES-2471] Added get auth code request to postman collection

### DIFF
--- a/postman-collection/Go-eSignet (local).postman_environment.json
+++ b/postman-collection/Go-eSignet (local).postman_environment.json
@@ -56,6 +56,13 @@
 			"enabled": true
 		},
 		{
+			"key": "iam_url",
+			"value": "",
+			"type": "default",
+			"description": "IAM (Keycloak) base URL for Client Management → Get Auth token, which posts to {{iam_url}}/auth/realms/mosip/protocol/openid-connect/token",
+			"enabled": true
+		},
+		{
 			"key": "client_mgmt_token",
 			"value": "",
 			"type": "secret",

--- a/postman-collection/Go-eSignet.postman_collection.json
+++ b/postman-collection/Go-eSignet.postman_collection.json
@@ -11,6 +11,65 @@
       "name": "Client Management",
       "item": [
         {
+          "name": "Get Auth token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('IAM token HTTP 200', () => pm.response.to.have.status(200));",
+                  "const jsonData = pm.response.json();",
+                  "pm.test('access_token present', () => pm.expect(jsonData.access_token).to.be.a('string'));",
+                  "pm.environment.set('client_mgmt_token', jsonData.access_token);"
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "client_secret",
+                  "value": "",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "",
+                  "type": "text"
+                },
+                {
+                  "key": "grant_type",
+                  "value": "client_credentials",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{iam_url}}/auth/realms/mosip/protocol/openid-connect/token",
+              "host": [
+                "{{iam_url}}"
+              ],
+              "path": [
+                "auth",
+                "realms",
+                "mosip",
+                "protocol",
+                "openid-connect",
+                "token"
+              ]
+            },
+            "description": "Fetches an IAM (Keycloak) service-account access token via the `client_credentials` grant and stores it in the `client_mgmt_token` environment variable.\n\nSet `iam_url` in the environment, and fill in `client_id` and `client_secret` in this request's body — they ship blank and are not read from the environment."
+          },
+          "response": []
+        },
+        {
           "name": "Create client",
           "event": [
             {

--- a/postman-collection/README.md
+++ b/postman-collection/README.md
@@ -32,7 +32,7 @@ No external script or manually-generated key is needed: **Create client**'s pre-
 - `additionalConfig`: `require_pushed_authorization_requests: true` and `dpop_bound_access_tokens: true` — required for the FAPI2.0 flow folder.
 - `authContextRefs` defaults to `["mosip:idp:acr:generated-code", "mosip:idp:acr:password", "mosip:idp:acr:biometrics"]` (OTP + password branches). To exercise the Sunbird KBI branch, add `"mosip:idp:acr:knowledge"`.
 
-If scope enforcement is enabled server-side (see `esignet-service`'s `security_config`), set `client_mgmt_token` to a valid Bearer JWT first; otherwise leave it empty.
+If scope enforcement is enabled server-side (see `esignet-service`'s `security_config`), set `client_mgmt_token` to a valid Bearer JWT first; otherwise leave it empty. **Get Auth token** fetches one for you: it posts a `client_credentials` grant to `{{iam_url}}/auth/realms/mosip/protocol/openid-connect/token` and stores the `access_token` in `client_mgmt_token`. Set `iam_url` in the environment and fill in `client_id` / `client_secret` in that request's body — they ship blank.
 
 ### User Mgmt
 
@@ -97,7 +97,8 @@ Both are stored as **collection variables** (not environment) and regenerated on
 | `audience`, `par_audience`, `userinfo_audience` | FAPI2.0 flow | Client-assertion `aud` + DPoP `htu` — see [Audiences](#audiences-editable-from-the-environment) |
 | `scope`, `redirect_uri` | FAPI2.0 flow | OAuth parameters |
 | `relying_party_id` | Client Management | Relying party id for client-mgmt create |
-| `client_mgmt_token` | Client Management | Bearer JWT (only needed if scope enforcement is enabled; leave empty otherwise) |
+| `iam_url` | Client Management (`Get Auth token`) | IAM (Keycloak) base URL; the request appends `/auth/realms/mosip/protocol/openid-connect/token` |
+| `client_mgmt_token` | Client Management | Bearer JWT (only needed if scope enforcement is enabled; leave empty otherwise). Set by **Get Auth token** |
 | `client_id`, `client_private_key`, `client_public_key` | All | Generated automatically by **Create client**; every request signs with these |
 | `individual_id` | FAPI2.0 flow (`Flow execute — enter uin`), User Mgmt | MOSIP UIN; OTP and password branches only. Defaulted (random) by **User Mgmt → Mock → Create User** if empty |
 | `otp` | FAPI2.0 flow (`Flow execute — enter OTP`) | OTP value; OTP branch only |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Postman request for obtaining an authentication token for Client Management.
  - Automatically stores the returned access token for use in subsequent requests.

- **Documentation**
  - Documented the IAM URL configuration and token request workflow.
  - Clarified that client credentials must be provided before requesting a token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->