### PR TITLE
api-test: sync release-2.0.x with develop-go (backport #2448)

### DIFF
--- a/api-test/.env.example
+++ b/api-test/.env.example
@@ -62,6 +62,14 @@ SUITE_IMAGE_TAG=release-v5.1.42
 
 # Secrets, if you would rather not keep them in data/config/config.local.json
 # KEYCLOAK_CLIENT_SECRET=paste-the-secret-here
+#
+# ADMIN_TOKEN replaces the whole KEYCLOAK_* round-trip above for a target that
+# does not enforce scope — scope middleware in esignet-service only installs
+# when both ISSUER_URL and JWKS_URL are set, so a locally started server never
+# inspects this bearer, and any non-empty value works. Explicit opt-in, not a
+# fallback: leave it unset for a real deployment, where a broken IAM must still
+# fail the run rather than be routed around.
+# ADMIN_TOKEN=local-no-scope
 # INDIVIDUAL_ID=8267411574
 # ID_TYPE selects which identifier kind INDIVIDUAL_ID is (uin|vid|phone|email);
 # the conformance and e2e surfaces use it to pick the matching login-id tab, so

--- a/api-test/.gitignore
+++ b/api-test/.gitignore
@@ -47,3 +47,7 @@ out/
 /consolidate.exe
 /cfg
 /cfg.exe
+
+# Postman: the filled environment carries the Keycloak secret; the example is tracked.
+postman/*.postman_environment.json
+!postman/*.postman_environment.example.json

--- a/api-test/Dockerfile
+++ b/api-test/Dockerfile
@@ -2,7 +2,18 @@
 #
 # api-test harness image — runs the conformance/api/e2e surfaces + consolidate
 # via run-all.sh (see #2209; design: mosip/esignet#2120). Build
-# from api-test/: docker build -t apitest-esignet:latest .
+# from api-test/: docker build --target runtime -t apitest-esignet:latest .
+#
+# --target runtime is required, not optional: this file's LAST stage is
+# `coverage` (below), and a plain `docker build` with no --target builds
+# whatever stage is last — silently producing the multi-GB coverage image
+# (full Go toolchain) under the apitest-esignet:latest tag instead of this
+# slim one. Confirmed live 2026-09-03: an untargeted build came out 1.35GB
+# with `go` on PATH, vs. ~249MB for a correctly `--target runtime` build.
+# CI's build_dockers_apitest job (push-trigger.yml) also builds with no
+# --target, so the Docker Hub-published apitest-esignet image is exposed to
+# the same risk unless that job (or a reusable workflow it calls) already
+# targets `runtime` explicitly.
 #
 # One builder stage compiles everything ahead of time so the runtime image needs
 # no Go toolchain. It spans two Go modules — the stdlib-only parent (conformance,
@@ -40,7 +51,7 @@ RUN mkdir -p /out/bin && \
 WORKDIR /src/api
 RUN go test -c -trimpath -o /out/bin/api.test .
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim AS runtime
 
 ARG SOURCE
 ARG COMMIT_HASH
@@ -65,7 +76,12 @@ COPY --from=builder /out/bin/ ./bin/
 # a mounted config.local.json, both of which override these.
 COPY data ./data
 COPY run-all.sh ./
-RUN chmod +x run-all.sh && mkdir -p out && chown -R apitest:apitest /app
+# A Windows checkout leaves CRLF line endings, which make the shebang line
+# unresolvable — the container then exits with a bare "no such file or
+# directory" naming a script that plainly exists. Normalising here keeps the
+# image buildable from any checkout; a repo-wide .gitattributes would be the
+# permanent fix.
+RUN sed -i 's/\r$//' run-all.sh && chmod +x run-all.sh && mkdir -p out && chown -R apitest:apitest /app
 
 ENV BIN_DIR=/app/bin
 # The prebuilt api.test runs from /app rather than from the module directory it

--- a/api-test/README.md
+++ b/api-test/README.md
@@ -29,8 +29,8 @@ single report.
 | Surface | What it verifies | Needs |
 |---|---|---|
 | **`conformance`** | Formal OpenID Connect compliance. Drives the [OpenID Conformance Suite](https://gitlab.com/openid/conformance-suite), which acts as the OAuth client and grades the result; the harness plays browser-and-user, walking `authorize → /flow/execute → callback`. | A running suite + a plan config ([setup](docs/conformance-suite.md)) |
-| **`api`** | eSignet's REST endpoints directly, one endpoint at a time: client management (`/client-mgmt/client` create/get/update, consent configuration) and the flow entry points (`/flow/meta`, `/flow/execute`, `/oauth2/authorize` validation). Success *and* rejection cases for each. Written in Gherkin, run by [godog](https://github.com/cucumber/godog). | A reachable eSignet; Keycloak admin credentials for the client-management endpoints |
-| **`e2e`** | A complete relying-party journey. The harness registers a throwaway OIDC client, then runs `authorize` (PKCE) → login → `token` (`private_key_jwt`) → `userinfo` and asserts the claims that come back. Covers each authentication factor (OTP, password, biometrics, knowledge-based), positive and negative, plus consent and captcha behaviour. | A reachable eSignet + Keycloak admin credentials + a test identity |
+| **`api`** | eSignet's REST endpoints directly, one endpoint at a time: client management (`/client-mgmt/client` create/get/update, the ACTIVE/INACTIVE status lifecycle, consent and protocol `additionalConfig` validation) and the flow entry points (`/flow/meta`, `/flow/execute`, `/oauth2/authorize` and `/oauth2/introspect` validation). Success *and* rejection cases for each. Written in Gherkin, run by [godog](https://github.com/cucumber/godog). | A reachable eSignet; Keycloak admin credentials or `ADMIN_TOKEN` for a target that does not enforce scope |
+| **`e2e`** | A complete relying-party journey. The harness registers throwaway OIDC clients, then runs `authorize` (PKCE) → login → `token` (`private_key_jwt`) → `userinfo` and asserts the claims that come back. Covers each authentication factor (OTP, password, biometrics, knowledge-based), positive and negative, plus consent, captcha, token introspection (RFC 7662), whether deactivating a client actually stops it (at authorize, at token and at userinfo), and the per-client protocol switches — PKCE, PAR and DPoP — in combination. | A reachable eSignet + Keycloak admin credentials or `ADMIN_TOKEN` + a test identity |
 
 Three identity plugins are supported — **`mock`**, **`sunbird`** and **`mosip`** — selected per run
 by the config file you pass. `mock` needs no identity of your own and is the right starting point.
@@ -103,7 +103,7 @@ api-test/
 
 | Surface | Tests defined in | Selected by |
 |---|---|---|
-| `conformance` | `data/conformance/<plan>.smoke.json` (curated module list) | `run.profile`, `run.modules`, `plans[]` |
+| `conformance` | every module the plan declares (`profile: full`) | `run.profile`, `run.modules`, `plans[]` |
 | `api` | `data/features/**/*.feature` | `api.tags` (Gherkin tags) |
 | `e2e` | `data/scenarios/e2e-scenarios[-<plugin>].json` | `e2e.auth_factors`, `e2e.include`, `e2e.exclude` |
 
@@ -225,9 +225,9 @@ To narrow the `api` surface to particular endpoints, set `api.tags` in the confi
 
 | Tag | Covers |
 |---|---|
-| `@flow-execute` | `/flow/meta`, `/flow/execute` |
+| `@flow-execute` | `/flow/meta`, `/flow/execute`, `/oauth2/introspect` request and client-authentication validation |
 | `@flow-authz-neg` | `/oauth2/authorize` request validation |
-| `@client-mgmt` | client create / get / update, consent configuration |
+| `@client-mgmt` | client create / get / update, consent configuration, protocol `additionalConfig` validation (PKCE, PAR, DPoP) |
 | `@client-mgmt-pms` | client registration via PMS ([MOSIP ID only](docs/mosip-id.md)) |
 
 Leaving `api.tags` empty runs whatever your configured credentials can actually drive; anything
@@ -287,6 +287,7 @@ at `http://host.docker.internal:8080` for one running on your own machine.
 | `CONFIG_FILE` | Which plugin config is mounted (default `data/config/config.mock.json`) |
 | `MOSIP_ESIGNET_BASE_URL` | The deployment under test |
 | `KEYCLOAK_TOKEN_URL`, `KEYCLOAK_CLIENT_SECRET` | Admin credentials |
+| `ADMIN_TOKEN` | Skips the Keycloak round-trip above, for a target that does not enforce scope (no `ISSUER_URL`/`JWKS_URL`) — a locally started `esignet-service`, typically. Explicit opt-in, not a fallback |
 | `INDIVIDUAL_ID`, `FLOW_CLIENT_ID` | Test identity and the pre-registered client for authorize validation |
 | `SURFACES`, `TEST_PROFILE` | Narrow the run without editing a config |
 | `ESIGNET_TLS_VERIFY`, `API_TLS_VERIFY` | Certificate verification for the deployment under test — on unless set `false` |

--- a/api-test/api/engine_test.go
+++ b/api-test/api/engine_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/cucumber/godog"
 )
 
+// adminAuthAvailable reports whether client-mgmt scenarios have a usable admin bearer, so they're gated out on auth rather than failing on it.
+func adminAuthAvailable() bool {
+	return os.Getenv("ADMIN_TOKEN") != "" ||
+		(os.Getenv("KEYCLOAK_TOKEN_URL") != "" &&
+			os.Getenv("KEYCLOAK_CLIENT_ID") != "" &&
+			os.Getenv("KEYCLOAK_CLIENT_SECRET") != "")
+}
+
 // TestFeatures is the godog entry point.
 func TestFeatures(t *testing.T) {
 	base := os.Getenv("MOSIP_ESIGNET_BASE_URL")
@@ -37,8 +45,10 @@ func TestFeatures(t *testing.T) {
 		if os.Getenv("FLOW_CLIENT_ID") != "" {
 			tags += ",@flow-authz-neg"
 		}
-		if os.Getenv("KEYCLOAK_CLIENT_SECRET") != "" {
+		if adminAuthAvailable() {
 			tags += ",@client-mgmt" // godog: comma = OR
+			// @inactive-client deactivates its own client rather than reusing FLOW_CLIENT_ID, so gate on admin auth instead.
+			tags += ",@inactive-client"
 			// The PMS-backed client-mgmt feature is mosipid-only: it needs an onboarded partner and policy.
 			if strings.EqualFold(os.Getenv("MOSIP_ESIGNET_AUTHN_PROVIDER"), "mosip") && os.Getenv("PMS_BASE_URL") != "" {
 				tags += ",@client-mgmt-pms"
@@ -63,13 +73,13 @@ func TestFeatures(t *testing.T) {
 		if plugin == "" {
 			plugin = "mock"
 		}
-		if os.Getenv("KEYCLOAK_CLIENT_SECRET") == "" {
+		if !adminAuthAvailable() {
 			rows = append(rows, Envelope{
 				Surface:        "client-mgmt",
 				Plugin:         plugin,
 				Module:         "client-mgmt (not run)",
 				HarnessOutcome: "ENV_NOT_READY",
-				OutcomeDetail:  "KEYCLOAK_TOKEN_URL/CLIENT_ID/CLIENT_SECRET not set — admin auth unavailable",
+				OutcomeDetail:  "KEYCLOAK_TOKEN_URL/CLIENT_ID/CLIENT_SECRET not set and no ADMIN_TOKEN — admin auth unavailable",
 			})
 		}
 		if os.Getenv("FLOW_CLIENT_ID") == "" {
@@ -81,11 +91,20 @@ func TestFeatures(t *testing.T) {
 				OutcomeDetail:  "FLOW_CLIENT_ID not set — authorize-endpoint negatives need a pre-registered client",
 			})
 		}
+		if !adminAuthAvailable() {
+			rows = append(rows, Envelope{
+				Surface:        "flow-execute",
+				Plugin:         plugin,
+				Module:         "inactive-client (not run)",
+				HarnessOutcome: "ENV_NOT_READY",
+				OutcomeDetail:  "no admin auth — deactivating a client to drive authorize with it needs client-mgmt write access",
+			})
+		}
 		// Either half missing hides this surface: the tag is only added inside the
-		// KEYCLOAK_CLIENT_SECRET branch above, so an empty secret drops it just as
+		// admin-auth branch above, so missing admin auth drops it just as
 		// silently as an unset PMS_BASE_URL would.
 		if strings.EqualFold(plugin, "mosip") &&
-			(os.Getenv("PMS_BASE_URL") == "" || os.Getenv("KEYCLOAK_CLIENT_SECRET") == "") {
+			(os.Getenv("PMS_BASE_URL") == "" || !adminAuthAvailable()) {
 			rows = append(rows, Envelope{
 				Surface:        "client-mgmt",
 				Plugin:         plugin,

--- a/api-test/api/go.mod
+++ b/api-test/api/go.mod
@@ -4,12 +4,12 @@ go 1.24
 
 require (
 	github.com/cucumber/godog v0.15.1
+	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/tidwall/gjson v1.19.0
 )
 
 require (
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
-	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/gofrs/uuid v4.3.1+incompatible // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.4 // indirect

--- a/api-test/api/steps.go
+++ b/api-test/api/steps.go
@@ -32,7 +32,7 @@ type Envelope struct {
 	Plugin           string
 	Module           string
 	Result           string // PASSED | FAILED
-	HarnessOutcome   string // OK | ENV_NOT_READY
+	HarnessOutcome   string // OK | ENV_NOT_READY | KNOWN_ISSUE
 	OutcomeDetail    string
 	DurationMs       int64
 	FailedConditions []Condition
@@ -189,7 +189,12 @@ func (s *state) doClient(ctx context.Context, client *http.Client, label, method
 		req.Header.Set(k, v)
 	}
 	if s.adminToken != "" {
-		req.Header.Set("Authorization", "Bearer "+s.adminToken)
+		// MOSIP kernel services (PMS) want the admin token as an Authorization cookie, not a Bearer header.
+		if pms := s.stash["pms_base"]; pms != "" && strings.HasPrefix(fullURL, pms) {
+			req.AddCookie(&http.Cookie{Name: "Authorization", Value: s.adminToken})
+		} else {
+			req.Header.Set("Authorization", "Bearer "+s.adminToken)
+		}
 	}
 
 	resp, err := client.Do(req)
@@ -251,11 +256,16 @@ func (s *state) record(label, method, u string, reqH http.Header, reqBody string
 
 func iAuthenticateAsAdmin(ctx context.Context) error {
 	s := getState(ctx)
+	// ADMIN_TOKEN is an explicit opt-in for targets that don't enforce scope, not a fallback from failed Keycloak auth — a silent fallback would mask a real auth regression as a green run.
+	if tok := os.Getenv("ADMIN_TOKEN"); tok != "" {
+		s.adminToken = tok
+		return nil
+	}
 	tokenURL := os.Getenv("KEYCLOAK_TOKEN_URL")
 	clientID := os.Getenv("KEYCLOAK_CLIENT_ID")
 	secret := os.Getenv("KEYCLOAK_CLIENT_SECRET")
 	if tokenURL == "" || clientID == "" || secret == "" {
-		return fmt.Errorf("ENV_NOT_READY: KEYCLOAK_TOKEN_URL/CLIENT_ID/CLIENT_SECRET not set for admin auth")
+		return fmt.Errorf("ENV_NOT_READY: KEYCLOAK_TOKEN_URL/CLIENT_ID/CLIENT_SECRET not set for admin auth (or set ADMIN_TOKEN for a target that does not enforce scope)")
 	}
 	form := url.Values{
 		"grant_type":    {"client_credentials"},
@@ -424,6 +434,25 @@ func theJSONPathShouldExist(ctx context.Context, path string) error {
 }
 
 // theJSONPathShouldBeNull asserts an explicit JSON null.
+// theJSONPathShouldBeEmpty passes when a path is absent, null, [], or {} — eSignet and PMS disagree on how "no errors" looks.
+func theJSONPathShouldBeEmpty(ctx context.Context, path string) error {
+	s := getState(ctx)
+	v := gjson.GetBytes(s.lastBody, path)
+	empty := !v.Exists() || v.Type == gjson.Null
+	if v.Exists() && (v.IsArray() || v.IsObject()) {
+		empty = len(v.Array()) == 0 && len(v.Map()) == 0
+	}
+	actual := v.Raw
+	if !v.Exists() {
+		actual = "absent"
+	}
+	s.recordAssertion("JSON "+path, "empty", actual, empty)
+	if !empty {
+		return fmt.Errorf("json path %q is not empty (got %s): %s", path, actual, snippet(s.lastBody))
+	}
+	return nil
+}
+
 func theJSONPathShouldBeNull(ctx context.Context, path string) error {
 	s := getState(ctx)
 	v := gjson.GetBytes(s.lastBody, path)
@@ -515,6 +544,14 @@ func InitScenario(sc *godog.ScenarioContext, coll *Collector) {
 			env.Result = "FAILED"
 			env.HarnessOutcome = "OK"
 			env.FailedConditions = []Condition{{Src: "godog", Result: "FAILURE", Msg: firstLine(scenErr.Error())}}
+			if reason, known := knownIssueReason(scn); known {
+				env.HarnessOutcome = "KNOWN_ISSUE"
+				env.OutcomeDetail = reason
+			} else if reason != "" {
+				// Tagged but unregistered: stays FAILED (HarnessOutcome already
+				// OK), and says why the tag did not take.
+				env.OutcomeDetail = reason
+			}
 		}
 		coll.Add(env)
 		return ctx, nil
@@ -536,6 +573,7 @@ func InitScenario(sc *godog.ScenarioContext, coll *Collector) {
 	sc.Step(`^the JSON value at "([^"]*)" should be "([^"]*)"$`, theJSONValueAtShouldBe)
 	sc.Step(`^the JSON path "([^"]*)" should exist$`, theJSONPathShouldExist)
 	sc.Step(`^the JSON path "([^"]*)" should be null$`, theJSONPathShouldBeNull)
+	sc.Step(`^the JSON path "([^"]*)" should be empty$`, theJSONPathShouldBeEmpty)
 }
 
 // surfaceFromTags maps a scenario's tags to a report surface.
@@ -544,11 +582,43 @@ func surfaceFromTags(scn *godog.Scenario) string {
 		switch strings.TrimPrefix(t.Name, "@") {
 		case "client-mgmt", "client-mgmt-pms":
 			return "client-mgmt"
-		case "flow-execute", "flow-authz-neg":
+		case "flow-execute", "flow-authz-neg", "inactive-client":
 			return "flow-execute"
 		}
 	}
 	return "flow-execute"
+}
+
+// apiKnownIssueReasons names the scenarios tagged @known_issue and why: a
+// scenario runs and asserts the correct (currently failing) behavior same as
+// any other, but a failure is reported as KNOWN_ISSUE instead of FAILED so it
+// doesn't block the run, and goes green on its own once the tracked bug is
+// fixed.
+var apiKnownIssueReasons = map[string]string{
+	"Uploading certificateData that is not a certificate is rejected as an invalid certificate": "esignet-service returns HTTP 500 server_error instead of invalid_certificate for a malformed certificate — tracked as mosip/esignet#2527",
+}
+
+// knownIssueReason reports the reason a failed, @known_issue-tagged scenario is
+// known to fail. The bool is what reclassifies FAILED into KNOWN_ISSUE, so it is
+// true ONLY for a tag backed by an entry in apiKnownIssueReasons.
+//
+// A tag with no entry — a scenario renamed without updating the map, or a tag
+// added without review — returns a diagnostic with false: the scenario stays a
+// normal FAILURE. Reclassifying it would let a typo pull a real regression out
+// of the failure bucket, which is the one thing this mechanism must never do.
+// The diagnostic still reaches the report via the envelope's OutcomeDetail, so
+// the unregistered tag is visible rather than merely ignored.
+func knownIssueReason(scn *godog.Scenario) (string, bool) {
+	for _, t := range scn.Tags {
+		if strings.TrimPrefix(t.Name, "@") == "known_issue" {
+			reason, ok := apiKnownIssueReasons[scn.Name]
+			if !ok {
+				return fmt.Sprintf("scenario tagged @known_issue but apiKnownIssueReasons has no entry for %q — reported as a normal failure", scn.Name), false
+			}
+			return reason, true
+		}
+	}
+	return "", false
 }
 
 func firstLine(s string) string {

--- a/api-test/api/steps_test.go
+++ b/api-test/api/steps_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"strings"
 	"testing"
+
+	"github.com/cucumber/godog"
+	messages "github.com/cucumber/messages/go/v21"
 )
 
 // snippet feeds every step error, and the After hook archives those in the
@@ -51,5 +54,50 @@ func TestSnippetTruncatesAfterRedaction(t *testing.T) {
 	}
 	if len(got) > 400+len("…") {
 		t.Errorf("snippet length = %d, want it capped at 400 runes plus the ellipsis", len(got))
+	}
+}
+
+// A scenario without @known_issue must never be silently reclassified — the
+// tag is what makes a FAILED->KNOWN_ISSUE swap deliberate rather than a bug
+// hiding itself.
+func TestKnownIssueReasonUntaggedScenarioIsNotKnown(t *testing.T) {
+	scn := &godog.Scenario{Name: "some ordinary scenario"}
+	if _, ok := knownIssueReason(scn); ok {
+		t.Error("knownIssueReason: untagged scenario reported as known, want false")
+	}
+}
+
+// The tagged, tracked scenario must resolve to its recorded reason.
+func TestKnownIssueReasonReturnsTheRecordedReason(t *testing.T) {
+	scn := &godog.Scenario{
+		Name: "Uploading certificateData that is not a certificate is rejected as an invalid certificate",
+		Tags: []*messages.PickleTag{{Name: "@known_issue"}},
+	}
+	reason, ok := knownIssueReason(scn)
+	if !ok {
+		t.Fatal("knownIssueReason: tagged scenario reported as not known, want true")
+	}
+	if !strings.Contains(reason, "mosip/esignet#2527") {
+		t.Errorf("reason = %q, want it to name the tracked issue", reason)
+	}
+}
+
+// A scenario tagged @known_issue but missing from apiKnownIssueReasons is a
+// spec mistake — someone added the tag without recording why. It must NOT be
+// reclassified as known: a renamed scenario or an unreviewed tag would then
+// pull a real regression out of the failure bucket, which is exactly what this
+// mechanism exists to prevent. It stays a normal failure, and the returned
+// diagnostic explains why the tag did not take.
+func TestKnownIssueReasonFlagsAMissingEntry(t *testing.T) {
+	scn := &godog.Scenario{
+		Name: "a scenario someone tagged but forgot to record",
+		Tags: []*messages.PickleTag{{Name: "@known_issue"}},
+	}
+	reason, known := knownIssueReason(scn)
+	if known {
+		t.Error("knownIssueReason: unregistered tag reported as known — a typo would hide a regression")
+	}
+	if !strings.Contains(reason, "no entry") {
+		t.Errorf("reason = %q, want it to flag the missing apiKnownIssueReasons entry", reason)
 	}
 }

--- a/api-test/cmd/cfg/main.go
+++ b/api-test/cmd/cfg/main.go
@@ -190,7 +190,10 @@ func printCheck(c *config.Config, path string) {
 	if c.HasSurface(config.SurfaceAPI) {
 		fmt.Printf("\napi\n")
 		fmt.Printf("  tags        %s\n", orDefault(c.API.Tags, "(auto — chosen from configured credentials)"))
-		fmt.Printf("  client-mgmt %s\n", readiness(c.Keycloak.ClientSecret != "", "ENV_NOT_READY: no keycloak.client_secret"))
+		// ADMIN_TOKEN counts as admin auth too, and all three Keycloak fields are required together (matches iAuthenticateAsAdmin).
+		adminAuth := os.Getenv("ADMIN_TOKEN") != "" ||
+			(c.Keycloak.TokenURL != "" && c.Keycloak.ClientID != "" && c.Keycloak.ClientSecret != "")
+		fmt.Printf("  client-mgmt %s\n", readiness(adminAuth, "ENV_NOT_READY: no keycloak.token_url/client_id/client_secret and no ADMIN_TOKEN"))
 		fmt.Printf("  authz-neg   %s\n", readiness(c.API.FlowClientID != "", "ENV_NOT_READY: no api.flow_client_id"))
 	}
 

--- a/api-test/cmd/conformance/main.go
+++ b/api-test/cmd/conformance/main.go
@@ -66,6 +66,13 @@ func main() {
 				logger.Printf("partial report error: %v", werr)
 			} else {
 				logger.Printf("partial report: %s", p)
+				// run-all.sh learns the report path by reading "report: " off
+				// STDOUT, so the log line above is invisible to it. Without this
+				// the partial report is written and then dropped: the surface is
+				// declared to have "produced no report" and consolidate is left
+				// with nothing to fold in — which is exactly the hole the
+				// ENV_NOT_READY rows exist to fill.
+				fmt.Printf("report: %s\n", p)
 			}
 		}
 		os.Exit(2)

--- a/api-test/cmd/e2e/main.go
+++ b/api-test/cmd/e2e/main.go
@@ -114,23 +114,26 @@ func main() {
 	}
 
 	runner := &e2e.Runner{
-		Base:             base,
-		Issuer:           disco.Issuer,
-		AuthEndpoint:     disco.AuthorizationEndpoint,
-		TokenEndpoint:    disco.TokenEndpoint,
-		UserinfoEndpoint: disco.UserinfoEndpoint,
-		JWKSURI:          disco.JWKSURI,
-		AdminToken:       adminTok,
-		Plugin:           es.Provider,
-		Answers:          esignet.BuildAnswers(es),
-		IDType:           es.Identity.IDType,
-		TLSVerify:        tlsVerify,
-		Timeout:          timeout,
-		Logf:             logger.Printf,
-		OTP:              otpProvider,
-		PMSBaseURL:       es.PMS.BaseURL,
-		AuthPartnerID:    es.PMS.AuthPartnerID,
-		PolicyID:         es.PMS.PolicyID,
+		Base:               base,
+		Issuer:             disco.Issuer,
+		AuthEndpoint:       disco.AuthorizationEndpoint,
+		TokenEndpoint:      disco.TokenEndpoint,
+		UserinfoEndpoint:   disco.UserinfoEndpoint,
+		JWKSURI:            disco.JWKSURI,
+		PAREndpoint:        disco.PAREndpoint,
+		IntrospectEndpoint: disco.IntrospectionEndpoint,
+		DPoPAlgs:           disco.DPoPAlgs,
+		AdminToken:         adminTok,
+		Plugin:             es.Provider,
+		Answers:            esignet.BuildAnswers(es),
+		IDType:             es.Identity.IDType,
+		TLSVerify:          tlsVerify,
+		Timeout:            timeout,
+		Logf:               logger.Printf,
+		OTP:                otpProvider,
+		PMSBaseURL:         es.PMS.BaseURL,
+		AuthPartnerID:      es.PMS.AuthPartnerID,
+		PolicyID:           es.PMS.PolicyID,
 	}
 
 	rows := runner.Run(ctx, spec)
@@ -153,6 +156,13 @@ type discovery struct {
 	TokenEndpoint         string `json:"token_endpoint"`
 	UserinfoEndpoint      string `json:"userinfo_endpoint"`
 	JWKSURI               string `json:"jwks_uri"`
+
+	// PAR and DPoP support; both optional, for scenarios that register clients requiring them.
+	PAREndpoint string   `json:"pushed_authorization_request_endpoint"`
+	DPoPAlgs    []string `json:"dpop_signing_alg_values_supported"`
+
+	// IntrospectionEndpoint is RFC 7662 token introspection, optional and needed only by the introspection scenarios.
+	IntrospectionEndpoint string `json:"introspection_endpoint"`
 }
 
 func fetchDiscovery(ctx context.Context, url string, tlsVerify bool) (*discovery, error) {
@@ -175,7 +185,7 @@ func fetchDiscovery(ctx context.Context, url string, tlsVerify bool) (*discovery
 	if d.Issuer == "" {
 		return nil, fmt.Errorf("discovery %s: no issuer", url)
 	}
-	if err := sameOrigin(url, d.Issuer, d.AuthorizationEndpoint, d.TokenEndpoint, d.UserinfoEndpoint, d.JWKSURI); err != nil {
+	if err := sameOrigin(url, d.Issuer, d.AuthorizationEndpoint, d.TokenEndpoint, d.UserinfoEndpoint, d.JWKSURI, d.PAREndpoint, d.IntrospectionEndpoint); err != nil {
 		return nil, fmt.Errorf("discovery %s: %w", url, err)
 	}
 	return &d, nil
@@ -206,9 +216,13 @@ func sameOrigin(ref string, others ...string) error {
 }
 
 func keycloakToken(ctx context.Context, kc config.Keycloak, tlsVerify bool) (string, error) {
+	// Mirrors the ADMIN_TOKEN opt-in in api/steps.go: explicit, not a fallback on Keycloak failure, so a broken IAM can't go green.
+	if tok := os.Getenv("ADMIN_TOKEN"); tok != "" {
+		return tok, nil
+	}
 	tokenURL := kc.TokenURL
 	if tokenURL == "" || kc.ClientID == "" || kc.ClientSecret == "" {
-		return "", fmt.Errorf("keycloak.token_url/client_id/client_secret (KEYCLOAK_*) required")
+		return "", fmt.Errorf("keycloak.token_url/client_id/client_secret (KEYCLOAK_*) required (or set ADMIN_TOKEN for a target that does not enforce scope)")
 	}
 	form := url.Values{"grant_type": {"client_credentials"}, "client_id": {kc.ClientID}, "client_secret": {kc.ClientSecret}}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))

--- a/api-test/data/config/config.example.json
+++ b/api-test/data/config/config.example.json
@@ -126,7 +126,11 @@
     "              separate from conformance.tls_verify, which is false only",
     "              for the suite's self-signed localhost cert. Set false only",
     "              for a deployment with a self-signed cert of its own.",
-    "                                             (env ESIGNET_TLS_VERIFY)"
+    "                                             (env ESIGNET_TLS_VERIFY)",
+    "  credentials.biometric  value submitted as a biometric capture for the",
+    "              bio auth factor. Only mock validates it, and accepts any",
+    "              non-empty value — leave unset elsewhere.",
+    "                                             (env TEST_BIOMETRIC)"
   ],
   "esignet": {
     "base_url": "",
@@ -134,7 +138,7 @@
     "auth_factor": "otp",
     "tls_verify": true,
     "identity": { "individual_id": "", "id_type": "uin" },
-    "credentials": { "username": "", "password": "" },
+    "credentials": { "username": "", "password": "", "biometric": "" },
     "knowledge": { "full_name": "", "dob": "" },
     "otp": { "source": "static", "value": "111111", "ws_url": "", "recipient_email": "" },
     "pms": { "base_url": "", "auth_partner_id": "", "policy_id": "" }
@@ -162,8 +166,10 @@
       "different module sets. Same precedence as documented in plans[] above.",
       "",
       "  modules       explicit allow-list; replaces profile entirely.",
-      "  profile       smoke = data/conformance/<plan name>.smoke.json, full = every",
-      "                module the plan declares.            (env TEST_PROFILE)",
+      "  profile       full (the DEFAULT) = every module the plan declares;",
+      "                smoke = the curated data/conformance/<plan name>.smoke.json.",
+      "                Only oidcc-test-plan ships a smoke list.",
+      "                                                     (env TEST_PROFILE)",
       "  filter        regex over whatever modules/profile produced.",
       "                                                     (env TEST_RUN)",
       "  skip          not run -> Skipped bucket.           (env SKIP_MODULES)",
@@ -185,7 +191,7 @@
       "  ./run-all.sh -c <config> --check"
     ],
     "modules": [],
-    "profile": "smoke",
+    "profile": "full",
     "filter": "",
     "skip": [],
     "known_issues": [],

--- a/api-test/data/config/config.mock.json
+++ b/api-test/data/config/config.mock.json
@@ -6,7 +6,8 @@
     "",
     "Two conformance plans run back to back here, each with its own client/jwks",
     "file (both gitignored — see conformance-suite-private/). The fapi2 entry pins",
-    "profile=full because only data/conformance/oidcc-test-plan.smoke.json exists. api and",
+    "profile=full, which is also the default, so narrowing run.profile to smoke",
+    "cannot send it looking for a curated list that does not ship. api and",
     "e2e still run once, and everything lands in one report. To run only one of",
     "them: ./run-all.sh -c data/config/config.mock.json --check to see the order, then drop the",
     "entry you do not want (or point both at the same config_file if the same",
@@ -57,11 +58,12 @@
     "auth_factor": "otp",
     "identity": {
       "individual_id": "8267411574",
-      "id_type": "phone"
+      "id_type": "uin"
     },
     "credentials": {
       "username": "decl-user-1",
-      "password": "Mosip@123"
+      "password": "Mosip@123",
+      "biometric": "mock-biometric-capture-e2e"
     },
     "otp": {
       "source": "static",

--- a/api-test/data/config/config.mosip.json
+++ b/api-test/data/config/config.mosip.json
@@ -11,9 +11,10 @@
     "",
     "Two conformance plans run back to back, each with its own client/jwks file",
     "(both gitignored — see conformance-suite-private/, and data/conformance/conformance-config.example.json",
-    "for the template). The fapi2 entry pins profile=full because only",
-    "data/conformance/oidcc-test-plan.smoke.json exists; leaving it on run.profile=smoke",
-    "would look for a smoke list it has none of. FAPI also drives two clients, so",
+    "for the template). Runs default to profile=full; the fapi2 entry pins it",
+    "anyway, so that narrowing run.profile to smoke to shorten an oidcc run does",
+    "not send FAPI looking for a curated list that does not ship. FAPI also",
+    "drives two clients, so",
     "its config_file needs client AND client2 filled in — both registered through",
     "PMS, same as the oidcc one.",
     "",
@@ -61,7 +62,7 @@
     "provider": "mosip",
     "auth_factor": "otp",
     "identity": { "individual_id": "", "id_type": "uin" },
-    "credentials": { "username": "", "password": "" },
+    "credentials": { "username": "", "password": "", "biometric": "" },
     "otp": { "source": "dynamic", "ws_url": "", "recipient_email": "" },
     "pms": { "base_url": "", "auth_partner_id": "", "policy_id": "" }
   },
@@ -79,7 +80,7 @@
 
   "run": {
     "surfaces": ["conformance", "api", "e2e"],
-    "profile": "smoke",
+    "profile": "full",
     "debug_show_secrets": false
   }
 }

--- a/api-test/data/config/config.sunbird.json
+++ b/api-test/data/config/config.sunbird.json
@@ -14,8 +14,9 @@
     "Two conformance plans run back to back, each with its own client/jwks file",
     "(both gitignored — see conformance-suite-private/, and data/conformance/conformance-config.example.json",
     "for the template). The fapi2 entry pins profile=full because only",
-    "data/conformance/oidcc-test-plan.smoke.json exists; leaving it on run.profile=smoke",
-    "would look for a smoke list it has none of. FAPI also drives two clients, so",
+    "data/conformance/oidcc-test-plan.smoke.json ships a curated list. Runs",
+    "default to full; the pin only matters if you narrow run.profile to smoke.",
+    "FAPI also drives two clients, so",
     "its config_file needs client AND client2 filled in.",
     "",
     "To run just the oidcc plan: drop the second entry (or point both config_file",
@@ -86,7 +87,7 @@
       "api",
       "e2e"
     ],
-    "profile": "smoke",
+    "profile": "full",
     "debug_show_secrets": false
   }
 }

--- a/api-test/data/features/client-mgmt/additional-config.feature
+++ b/api-test/data/features/client-mgmt/additional-config.feature
@@ -1,0 +1,321 @@
+@client-mgmt
+Feature: Client additionalConfig — protocol switches and allowlist validation
+  additionalConfig is the only place a client turns on the protocol hardening
+  eSignet supports per client: PKCE, pushed authorization requests and
+  DPoP-bound access tokens. This file covers what the endpoint accepts and what
+  it rejects for those keys, plus the allowlist and the remaining typed keys
+  that no other feature file touches.
+
+  Consent-specific keys (consent_expire_in_mins, purpose) live in
+  consent-config.feature; userinfo_response_type has its rejection case in
+  create-client.feature. Everything else in the allowlist is here.
+
+  # The three protocol switches are read back by the engine's actor provider and
+  # become OAuthClient.PKCERequired / RequirePushedAuthorizationRequests /
+  # DPoPBoundAccessTokens. The e2e surface registers clients with exactly these
+  # keys and then drives the flow they enforce; this file is the registration
+  # half of that contract, asserted without needing a login.
+  #
+  # MOSIP API convention throughout: both outcomes are HTTP 200. A rejection
+  # populates "errors" and nulls "response".
+
+  Background:
+    Given I authenticate as admin
+    And a fresh request timestamp
+    And a generated RSA public key as "pubjwk"
+    And a new client id as "cid"
+
+  # ---------------------------------------------------------------- positive --
+
+  # The exact registration shape the e2e surface uses for its "all three on"
+  # combination. If this stops being accepted, every protocol-combination e2e
+  # scenario fails at registration rather than at the behaviour it means to test.
+  Scenario: Create accepts all three protocol switches together
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg protocol",
+          "clientNameLangMap": { "eng": "api addlcfg protocol" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": {
+            "require_pkce": true,
+            "require_pushed_authorization_requests": true,
+            "dpop_bound_access_tokens": true
+          }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+    And the JSON value at "response.status" should be "ACTIVE"
+
+  # ------------------------------------------------------- allowlist rejects --
+
+  # validate.go keys additionalConfig against a fixed allowlist, so a plausible
+  # misspelling of a real switch is rejected outright rather than silently
+  # stored and never enforced — the failure mode that would make a client look
+  # hardened while it keeps accepting unprotected requests.
+  Scenario: Create rejects an additionalConfig key that is not on the allowlist
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg unknown key",
+          "clientNameLangMap": { "eng": "api addlcfg unknown key" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "require_dpop": true }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_additional_config"
+    And the JSON path "response" should be null
+
+  # additionalConfig is bound as a raw JSON message, so a non-object reaches the
+  # validator rather than failing request binding — it must still be rejected.
+  Scenario: Create rejects an additionalConfig that is not a JSON object
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg not object",
+          "clientNameLangMap": { "eng": "api addlcfg not object" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": "require_pkce"
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_additional_config"
+    And the JSON path "response" should be null
+
+  # --------------------------------------------------- protocol switch typing --
+
+  # Each switch is decoded into a bool. A quoted "true" is the realistic mistake
+  # — it looks right in a config file and would otherwise leave the switch off.
+  Scenario Outline: Create rejects a non-boolean <key>
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg bool",
+          "clientNameLangMap": { "eng": "api addlcfg bool" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "<key>": <value> }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_additional_config"
+    And the JSON path "response" should be null
+
+    Examples:
+      | key                                   | value    |
+      | require_pkce                          | "true"   |
+      | require_pushed_authorization_requests | 1        |
+      | dpop_bound_access_tokens              | {}       |
+      | signup_banner_required                | "yes"    |
+      | forgot_pwd_link_required              | ["true"] |
+
+  # ---------------------------------------------------- remaining typed keys --
+
+  # id_token_response_type accepts only JWS or JWE. "JWT" is the near-miss that
+  # would otherwise decide whether the ID token comes back signed or encrypted.
+  Scenario: Create rejects an id_token_response_type outside JWS/JWE
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg idtoken",
+          "clientNameLangMap": { "eng": "api addlcfg idtoken" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "id_token_response_type": "JWT" }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_additional_config"
+    And the JSON path "response" should be null
+
+  # allowed_authorization_scopes downscopes what the client may request. It must
+  # be a list of distinct, non-blank strings: a duplicate or a blank entry would
+  # corrupt the very list that is supposed to narrow the client.
+  Scenario Outline: Create rejects an invalid allowed_authorization_scopes: <case>
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg scopes",
+          "clientNameLangMap": { "eng": "api addlcfg scopes" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "allowed_authorization_scopes": <value> }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_additional_config"
+    And the JSON path "response" should be null
+
+    Examples:
+      | case            | value                |
+      | not an array    | "openid"             |
+      | duplicate entry | ["openid", "openid"] |
+      | blank entry     | ["openid", "   "]    |
+
+  # ------------------------------------------------------------- update path --
+
+  # The merged-update path re-validates additionalConfig, so a switch that could
+  # not be created cannot be edited in afterwards on a client that registered clean.
+  Scenario: Update rejects a non-boolean protocol switch on an existing client
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg update",
+          "clientNameLangMap": { "eng": "api addlcfg update" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "require_pkce": true }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    When I send a "PUT" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api addlcfg update",
+          "clientNameLangMap": { "eng": "api addlcfg update" },
+          "status": "ACTIVE",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "dpop_bound_access_tokens": "true" }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_additional_config"
+    And the JSON path "response" should be null
+
+  # Turning the switches on via update is the supported migration path for a
+  # client that registered before the deployment enabled PAR/DPoP.
+  Scenario: Update accepts turning the protocol switches on
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api addlcfg enable",
+          "clientNameLangMap": { "eng": "api addlcfg enable" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    When I send a "PUT" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api addlcfg enable",
+          "clientNameLangMap": { "eng": "api addlcfg enable" },
+          "status": "ACTIVE",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": {
+            "require_pkce": true,
+            "require_pushed_authorization_requests": true,
+            "dpop_bound_access_tokens": true
+          }
+        }
+      }
+      """
+    # The accepted PUT is the evidence: unlike create, a successful update omits
+    # "errors" rather than nulling it, and GET exposes only clientId and status.
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+    And the JSON value at "response.status" should be "ACTIVE"

--- a/api-test/data/features/client-mgmt/client-pms.feature
+++ b/api-test/data/features/client-mgmt/client-pms.feature
@@ -71,11 +71,16 @@ Feature: POST/PUT {pms}/oauth/client — client management via PMS (mosipid)
     And I save the JSON value at "response.clientId" as "cid"
 
     # PMS update is a PUT to /oauth/client/{client_id} (ClientDetailUpdateRequestV2);
-    # publicKey/authPartnerId/policyId are fixed at create and not sent here
+    # publicKey/authPartnerId/policyId are fixed at create and not sent here.
+    #
+    # The wrapper field is "requesttime", all lowercase — the update endpoint
+    # rejects the camel-case "requestTime" the create endpoint accepts, with
+    # PMS_REQUEST_ERROR_004 "Invalid request time". Same casing as the
+    # "responsetime" this endpoint family sends back. Do not normalise it.
     When I send a "PUT" request to "{{pms_base}}/oauth/client/{{cid}}" with body:
       """
       {
-        "requestTime": "{{now}}",
+        "requesttime": "{{now}}",
         "request": {
           "clientName": "api pms updated",
           "clientNameLangMap": { "eng": "api pms updated" },
@@ -88,17 +93,21 @@ Feature: POST/PUT {pms}/oauth/client — client management via PMS (mosipid)
       }
       """
     Then the response status should be 200
-    And the JSON path "errors" should be null
+    And the JSON path "errors" should be empty
 
     # The GET response exposes only clientId and status, so the new name is not
-    # observable there — the PUT accepting it (errors null) is the update
+    # observable there — the PUT accepting it (errors empty) is the update
     # evidence; this only confirms the client is still retrievable and ACTIVE.
     When I send a "GET" request to "/client-mgmt/client/{{cid}}"
     Then the response status should be 200
     And the JSON value at "response.clientId" should be "{{cid}}"
     And the JSON value at "response.status" should be "ACTIVE"
 
-  Scenario: Deactivate then reactivate a client via PMS update
+  # Deactivation through PMS is TERMINAL: /oauth/client refuses to move a client
+  # back to ACTIVE, answering HTTP 200 with PMS_ESI_008 "Client already
+  # deactivated." eSignet's own client-mgmt has no such guard, so this asymmetry
+  # is a property of the PMS path and is asserted rather than worked around.
+  Scenario: Deactivate a client via PMS update, and reactivation is refused
     When I send a "POST" request to "{{pms_base}}/oauth/client" with body:
       """
       {
@@ -123,7 +132,7 @@ Feature: POST/PUT {pms}/oauth/client — client management via PMS (mosipid)
     When I send a "PUT" request to "{{pms_base}}/oauth/client/{{cid}}" with body:
       """
       {
-        "requestTime": "{{now}}",
+        "requesttime": "{{now}}",
         "request": {
           "clientName": "api pms status",
           "clientNameLangMap": { "eng": "api pms status" },
@@ -140,11 +149,11 @@ Feature: POST/PUT {pms}/oauth/client — client management via PMS (mosipid)
     Then the response status should be 200
     And the JSON value at "response.status" should be "INACTIVE"
 
-    # reactivate
+    # reactivate — refused, and the client stays INACTIVE in eSignet
     When I send a "PUT" request to "{{pms_base}}/oauth/client/{{cid}}" with body:
       """
       {
-        "requestTime": "{{now}}",
+        "requesttime": "{{now}}",
         "request": {
           "clientName": "api pms status",
           "clientNameLangMap": { "eng": "api pms status" },
@@ -157,6 +166,7 @@ Feature: POST/PUT {pms}/oauth/client — client management via PMS (mosipid)
       }
       """
     Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "PMS_ESI_008"
     When I send a "GET" request to "/client-mgmt/client/{{cid}}"
     Then the response status should be 200
-    And the JSON value at "response.status" should be "ACTIVE"
+    And the JSON value at "response.status" should be "INACTIVE"

--- a/api-test/data/features/client-mgmt/client-profiles.feature
+++ b/api-test/data/features/client-mgmt/client-profiles.feature
@@ -1,0 +1,394 @@
+@client-mgmt
+Feature: /client-mgmt/oidc-client and /client-mgmt/oauth-client — the other two client profiles
+  eSignet registers clients under three profiles, each on its own route, and the
+  rest of this directory only ever drives one of them. create-client.feature,
+  update-client.feature and patch-client.feature all post to /client-mgmt/client
+  — the "client" profile — so the oidc-client and oauth-client routes, and the
+  profile-specific rules behind them, went entirely unexercised.
+
+  The three differ only in what they accept, and the difference is not cosmetic:
+
+    route                       clientNameLangMap    additionalConfig
+    /client-mgmt/oidc-client    must be ABSENT       must be ABSENT
+    /client-mgmt/oauth-client   REQUIRED             must be ABSENT
+    /client-mgmt/client         REQUIRED             allowed
+
+  So a body that is valid on one route is a rejection on another, which is what
+  the cross-profile scenarios below assert. Both validators apply the same rules
+  on create and on update, so each rule is checked on POST and on PUT.
+
+  Also here: the non-RSA branches of public-key validation. Every other feature
+  file registers an RSA key, leaving the EC arm — the curve allow-list and the
+  coordinate checks — untested. Those cases are all rejections; see the comment
+  above them for why there is no accepted-EC-key scenario.
+
+  # MOSIP API convention, as everywhere in this directory: both outcomes are
+  # HTTP 200. A rejection populates "errors" and nulls "response".
+
+  Background:
+    Given I authenticate as admin
+    And a fresh request timestamp
+    And a generated RSA public key as "pubjwk"
+    And a new client id as "cid"
+
+  # ------------------------------------------------------- oidc-client --
+
+  # The oidc profile stores clientName bare rather than as a language map, which
+  # is why supplying one is an error rather than being ignored.
+  Scenario: Register and update a client under the oidc profile
+    When I send a "POST" request to "/client-mgmt/oidc-client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api oidc profile",
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    When I send a "PUT" request to "/client-mgmt/oidc-client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api oidc profile updated",
+          "status": "ACTIVE",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+
+  # The same body the "client" profile requires is a rejection here — this is
+  # the clearest statement that the routes are not interchangeable.
+  Scenario: The oidc profile rejects a clientNameLangMap on create and on update
+    When I send a "POST" request to "/client-mgmt/oidc-client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api oidc langmap",
+          "clientNameLangMap": { "eng": "api oidc langmap" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+    # rejected on the update path too — the client id need not exist, the
+    # profile rule is checked before the row is looked up
+    When I send a "PUT" request to "/client-mgmt/oidc-client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api oidc langmap",
+          "clientNameLangMap": { "eng": "api oidc langmap" },
+          "status": "ACTIVE",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+  # additionalConfig carries the protocol switches (PKCE, PAR, DPoP) that
+  # additional-config.feature exercises on the "client" profile. The oidc
+  # profile does not accept them at all.
+  Scenario: The oidc profile rejects an additionalConfig block
+    When I send a "POST" request to "/client-mgmt/oidc-client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api oidc addlcfg",
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "require_pkce": true }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+  # ------------------------------------------------------ oauth-client --
+
+  # oauth sits between the other two: it wants the language map that oidc
+  # forbids, but refuses the additionalConfig that "client" allows.
+  Scenario: Register and update a client under the oauth profile
+    When I send a "POST" request to "/client-mgmt/oauth-client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api oauth profile",
+          "clientNameLangMap": { "eng": "api oauth profile" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    When I send a "PUT" request to "/client-mgmt/oauth-client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api oauth profile updated",
+          "clientNameLangMap": { "eng": "api oauth profile updated" },
+          "status": "ACTIVE",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+
+  # The mirror image of the oidc case above: here the language map is mandatory,
+  # and the body oidc accepts is the one that fails.
+  Scenario: The oauth profile requires a clientNameLangMap on create and on update
+    When I send a "POST" request to "/client-mgmt/oauth-client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api oauth nolangmap",
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+    When I send a "PUT" request to "/client-mgmt/oauth-client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api oauth nolangmap",
+          "status": "ACTIVE",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+  Scenario: The oauth profile rejects an additionalConfig block
+    When I send a "POST" request to "/client-mgmt/oauth-client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api oauth addlcfg",
+          "clientNameLangMap": { "eng": "api oauth addlcfg" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"],
+          "additionalConfig": { "require_pkce": true }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+  # ------------------------------------------- non-RSA public keys --
+
+  # These are all rejections, and deliberately so. A public key is unique across
+  # clients — registering one twice is refused as invalid_public_key — and the
+  # harness can only generate RSA keys, so a committed EC key would be accepted
+  # on a suite's first run against a deployment and rejected as a duplicate on
+  # every run after. Rejections carry no such cost: validation refuses them
+  # before anything is stored, so they are repeatable forever.
+  #
+  # Adding an accepted-EC-key scenario means teaching the harness to generate EC
+  # keys (a new step alongside "a generated RSA public key as"), not committing
+  # a fixture.
+
+  Scenario: A key on an unsupported curve is rejected
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api ec curve",
+          "clientNameLangMap": { "eng": "api ec curve" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {
+            "kty": "EC",
+            "crv": "P-999",
+            "x": "YWuM_9MpH_NOf4OYVaJp3jZr6mUVjPr3XQtR6VZITPY",
+            "y": "q_8GWBcAsLbNIsfnGk61sPNx411JFJ_PZqGlkH6zxu4"
+          },
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_public_key"
+
+  # An EC key is defined by both coordinates; one alone is not a point.
+  Scenario: An EC key missing a coordinate is rejected
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api ec coord",
+          "clientNameLangMap": { "eng": "api ec coord" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "YWuM_9MpH_NOf4OYVaJp3jZr6mUVjPr3XQtR6VZITPY"
+          },
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_public_key"
+
+  # Present but undecodable: the coordinates are checked as base64url, not just
+  # for being non-empty.
+  Scenario: An EC key with an undecodable coordinate is rejected
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api ec b64",
+          "clientNameLangMap": { "eng": "api ec b64" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "not!valid!base64",
+            "y": "q_8GWBcAsLbNIsfnGk61sPNx411JFJ_PZqGlkH6zxu4"
+          },
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_public_key"
+
+  # Only RSA and EC are understood; anything else falls to the default arm
+  # rather than being passed through to the keystore.
+  Scenario: A key of an unsupported type is rejected
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api okp kty",
+          "clientNameLangMap": { "eng": "api okp kty" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": "YWuM_9MpH_NOf4OYVaJp3jZr6mUVjPr3XQtR6VZITPY"
+          },
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_public_key"

--- a/api-test/data/features/client-mgmt/client-status.feature
+++ b/api-test/data/features/client-mgmt/client-status.feature
@@ -1,0 +1,293 @@
+@client-mgmt
+Feature: Client status — the ACTIVE/INACTIVE lifecycle
+  Everything about the status field itself: what sets it, what it accepts, and
+  what leaves it alone. Deactivating and reactivating a client through the whole
+  update payload is covered in update-client.feature, and a single-field status
+  patch in patch-client.feature; this file holds the edges neither reaches.
+
+  Two of them are worth naming up front, because both are easy to get wrong from
+  the caller's side and neither announces itself:
+
+    - create has no status field at all. A status sent in a create request is
+      silently dropped and the client is registered ACTIVE, so a caller who
+      believes they registered a disabled client did not.
+    - update is a full replace and status is mandatory in it. A PUT that only
+      means to rename a client, and leaves status out, is rejected outright
+      rather than preserving the stored value.
+
+  What an INACTIVE client is then still able to DO is a different question, and
+  is asked in flow-execute/inactive-client.feature.
+
+  Background:
+    Given I authenticate as admin
+    And a fresh request timestamp
+    And a generated RSA public key as "pubjwk"
+    And a new client id as "cid"
+
+  # CreateClientRequest carries no status member, so this one is dropped during
+  # decoding — no invalid_input, no echo of what was asked for. Asserted so a
+  # future create that did honour it could not land unnoticed.
+  Scenario: Create ignores a status in the request and always registers ACTIVE
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api status create",
+          "clientNameLangMap": { "eng": "api status create" },
+          "status": "INACTIVE",
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    # and the drop is durable, not just a response-shaping artifact
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+  # normalizeStatus upper-cases before matching, so any casing is the same word.
+  Scenario Outline: Patch accepts <sent> and stores it as INACTIVE
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api status case",
+          "clientNameLangMap": { "eng": "api status case" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": <sent> }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+
+    Examples:
+      | sent       |
+      | "inactive" |
+      | "INACTIVE" |
+      | "InAcTiVe" |
+
+  # The other side of that closed set. Padding is NOT trimmed — " inactive" is
+  # rejected exactly like a misspelling — and neither an empty string nor an
+  # explicit null is read as "leave it alone": naming the field at all commits
+  # the caller to a valid value.
+  Scenario Outline: Patch rejects <case> as a status
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api status bad",
+          "clientNameLangMap": { "eng": "api status bad" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": <sent> }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+    # and the rejected patch changed nothing
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    Examples:
+      | case                | sent        |
+      | leading whitespace  | " inactive" |
+      | trailing whitespace | "inactive " |
+      | the empty string    | ""          |
+      | an explicit null    | null        |
+      | a numeric value     | 0           |
+
+  # A patch names the fields it changes and nothing else. Renaming a client that
+  # someone deliberately took out of service must not quietly put it back.
+  Scenario: Patching another field leaves a deactivated client deactivated
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api status keep",
+          "clientNameLangMap": { "eng": "api status keep" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "INACTIVE" }
+      }
+      """
+    Then the response status should be 200
+
+    # a rename, naming no status at all
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "clientName": "api status renamed" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+
+  # Repeating a deactivation is a no-op, not a conflict: an operator re-running a
+  # deactivation script must not have to care whether it already ran.
+  Scenario: Deactivating an already-inactive client is idempotent
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api status twice",
+          "clientNameLangMap": { "eng": "api status twice" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "INACTIVE" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "INACTIVE" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+
+    # and back, in one step, from a client that has been deactivated twice
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "ACTIVE" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+  # UpdateClientRequest.Status has no omitempty and normalizeStatus("") fails, so
+  # a PUT is not a partial update with a remembered status: leaving it out is an
+  # invalid request, not an instruction to keep the stored value.
+  Scenario: Update rejects a payload that omits status
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api status put",
+          "clientNameLangMap": { "eng": "api status put" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    When I send a "PUT" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api status put renamed",
+          "clientNameLangMap": { "eng": "api status put renamed" },
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+    # the client is untouched by the rejected update
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"

--- a/api-test/data/features/client-mgmt/client-validation.feature
+++ b/api-test/data/features/client-mgmt/client-validation.feature
@@ -1,0 +1,438 @@
+@client-mgmt
+Feature: Client field validation — the rejection paths for each list field
+  create-client.feature and update-client.feature establish that a well-formed
+  client is accepted. This file covers the other direction for the five list
+  fields — redirectUris, userClaims, authContextRefs, grantTypes and
+  clientAuthMethods — where each list is checked for size, for duplicates, and
+  for whether its values are in the allowed set.
+
+  The three write paths do NOT apply the same size rules, which is the reason
+  several scenarios below only make sense on one of them:
+
+    call site   minimum                       maximum
+    create      redirectUris >= 1             none
+    update      every list >= 1               none
+    patch       none                          redirectUris 5, userClaims 30,
+                                              authContextRefs 30, grantTypes 3,
+                                              clientAuthMethods 3
+
+  So the "must not be empty" rules are only reachable through create and update,
+  and the size ceilings are only reachable through PATCH. Neither set can be
+  reached from the other path, which is why the ceilings live in their own
+  scenario at the bottom rather than alongside the create cases.
+
+  Checks run in a fixed order — size, then uniqueness, then allowed values — and
+  each field reports its own error code, so a rejection names the field that
+  caused it rather than a generic failure.
+
+  # MOSIP API convention: both outcomes are HTTP 200. A rejection populates
+  # "errors" and nulls "response".
+
+  Background:
+    Given I authenticate as admin
+    And a fresh request timestamp
+    And a generated RSA public key as "pubjwk"
+    And a new client id as "cid"
+
+  # ------------------------------------------------------ redirect URIs --
+
+  # A redirect URI is where the user is sent back to with a code, so a malformed
+  # or wildcarded one is a security question, not a formatting one: wildcards are
+  # permitted inside a path segment but never in the scheme or host, or an
+  # attacker-controlled host could match.
+  Scenario: Create rejects redirect URI lists that are empty, duplicated or malformed
+    # empty — create requires at least one
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej uri", "clientNameLangMap": { "eng": "api rej uri" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": [],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_redirect_uri"
+
+    # the same URI twice
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej uri", "clientNameLangMap": { "eng": "api rej uri" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb", "https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_redirect_uri"
+
+    # no scheme and no host — not a resolvable callback
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej uri", "clientNameLangMap": { "eng": "api rej uri" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["not-a-uri"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_redirect_uri"
+
+    # wildcard in the host — the case the path-segment allowance must not admit
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej uri", "clientNameLangMap": { "eng": "api rej uri" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://*.example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_redirect_uri"
+
+  # ------------------------------------------------- claims and ACR values --
+
+  # userClaims and authContextRefs are closed sets. An unrecognised entry is
+  # rejected rather than stored and ignored, so a typo surfaces at registration
+  # instead of as a silently missing claim at userinfo time.
+  Scenario: Create rejects unknown claims and unknown or duplicated ACR values
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej claim", "clientNameLangMap": { "eng": "api rej claim" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name", "not_a_real_claim"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_claim"
+
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej acr", "clientNameLangMap": { "eng": "api rej acr" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:not-a-real-acr"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_acr"
+
+    # duplicates are caught before the allowed-value check, so this is the
+    # uniqueness rule and not the allow-list rule being exercised
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej acr", "clientNameLangMap": { "eng": "api rej acr" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code", "mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_acr"
+
+  # ------------------------------------------ grant types and auth methods --
+
+  # Both fields currently admit exactly one value each. They are still lists in
+  # the wire format, so the duplicate case is reachable and worth pinning.
+  Scenario: Create rejects unsupported or duplicated grant types and auth methods
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej grant", "clientNameLangMap": { "eng": "api rej grant" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["client_credentials"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_grant_type"
+
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej grant", "clientNameLangMap": { "eng": "api rej grant" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code", "authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_grant_type"
+
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej auth", "clientNameLangMap": { "eng": "api rej auth" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["client_secret_basic"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_client_auth"
+
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api rej auth", "clientNameLangMap": { "eng": "api rej auth" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt", "private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_client_auth"
+
+  # ------------------------------------------------- update: non-empty lists --
+
+  # Update requires every list to carry at least one entry, where create only
+  # demands it of redirectUris. The client id below is never registered and does
+  # not need to be: update validates the body before it looks the row up, so
+  # these are rejections about the payload, not about the client being missing.
+  Scenario: Update rejects an empty value for each required list
+    When I send a "PUT" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api upd empty", "clientNameLangMap": { "eng": "api upd empty" },
+          "status": "ACTIVE", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": [],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_claim"
+
+    When I send a "PUT" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api upd empty", "clientNameLangMap": { "eng": "api upd empty" },
+          "status": "ACTIVE", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": [],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_acr"
+
+    When I send a "PUT" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api upd empty", "clientNameLangMap": { "eng": "api upd empty" },
+          "status": "ACTIVE", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": [], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_grant_type"
+
+    When I send a "PUT" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientName": "api upd empty", "clientNameLangMap": { "eng": "api upd empty" },
+          "status": "ACTIVE", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": []
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_client_auth"
+
+  # ------------------------------------------------------ patch: ceilings --
+
+  # The size ceilings exist only on the patch path, so this is the only place
+  # they can be exercised at all. Each list below is one item over its limit and
+  # otherwise entirely valid — the entries are repeats of a permitted value, so
+  # the rejection can only be the size rule and not the allow-list or (where it
+  # applies) the uniqueness rule, both of which are checked after it.
+  Scenario: Patch enforces the maximum size of each list
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}", "clientName": "api patch ceiling", "clientNameLangMap": { "eng": "api patch ceiling" },
+          "relyingPartyId": "api-e2e-rp", "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}}, "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"], "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+
+    # six redirect URIs against a ceiling of five
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "redirectUris": [
+            "https://example.org/cb1", "https://example.org/cb2", "https://example.org/cb3",
+            "https://example.org/cb4", "https://example.org/cb5", "https://example.org/cb6"
+          ]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_redirect_uri"
+
+    # thirty-one claims against a ceiling of thirty
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "userClaims": [
+            "name","name","name","name","name","name","name","name","name","name",
+            "name","name","name","name","name","name","name","name","name","name",
+            "name","name","name","name","name","name","name","name","name","name","name"
+          ]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_claim"
+
+    # thirty-one ACR values against a ceiling of thirty
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "authContextRefs": [
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code","mosip:idp:acr:static-code","mosip:idp:acr:static-code",
+            "mosip:idp:acr:static-code"
+          ]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_acr"
+
+    # four grant types against a ceiling of three
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "grantTypes": ["authorization_code","authorization_code","authorization_code","authorization_code"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_grant_type"
+
+    # four auth methods against a ceiling of three
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientAuthMethods": ["private_key_jwt","private_key_jwt","private_key_jwt","private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_client_auth"
+
+    # the client is untouched by the five rejections above
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"

--- a/api-test/data/features/client-mgmt/patch-client.feature
+++ b/api-test/data/features/client-mgmt/patch-client.feature
@@ -1,0 +1,414 @@
+@client-mgmt
+Feature: PATCH /client-mgmt/client/{clientId} — partially update a client
+  PATCH changes only the fields the body names and leaves every other field as
+  it was. That is the whole difference from PUT, which is why this file leads
+  with a patch that sends one field and nothing else.
+
+  How "left as it was" is asserted without reading the fields back: the server
+  merges the patch onto the stored row and then validates the WHOLE merged
+  record, not just the patched part. Every required field — clientName,
+  redirectUris, userClaims, authContextRefs, grantTypes, clientAuthMethods —
+  must still be present and valid for the request to be accepted. So a
+  single-field patch coming back 200 is proof the merge preserved the rest; had
+  it behaved like PUT and replaced the record, the same request would have been
+  rejected for the fields it never mentioned.
+
+  encPublicKey is the one field with three states rather than two — omitted,
+  explicit null, or a JWK object — because null is how a key is removed and
+  omitted is how it is left alone. Those cannot be the same value, so they get
+  their own scenario.
+
+  # MOSIP API convention, as everywhere else in this directory: both outcomes
+  # are HTTP 200. A rejection populates "errors" and nulls "response"; an
+  # unknown client id is errorCode "invalid_client_id", not a 404.
+
+  Background:
+    Given I authenticate as admin
+    And a fresh request timestamp
+    And a generated RSA public key as "pubjwk"
+    And a new client id as "cid"
+
+  # ---------------------------------------------------------------- positive --
+
+  # The headline case. The patch body carries "status" and nothing else — see
+  # the feature preamble for why its acceptance is the evidence that the other
+  # nine fields survived the merge.
+  Scenario: A single-field patch changes that field and preserves the rest
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api patch minimal",
+          "clientNameLangMap": { "eng": "api patch minimal" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name", "email"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "inactive" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+    And the JSON value at "response.status" should be "INACTIVE"
+
+    # and the change is durable, not just echoed back in the patch response
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+
+  # One patch per field, sequentially against the same client. Each request
+  # names exactly one field, so every field's merge branch is exercised on its
+  # own rather than hidden behind a whole-record write.
+  Scenario: Every patchable field is accepted on its own
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api patch fields",
+          "clientNameLangMap": { "eng": "api patch fields" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "clientName": "api patch renamed" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+
+    # clientNameLangMap is stored alongside clientName rather than in its own
+    # column, so patching it alone is the case that would break first if the
+    # merge ever rebuilt the name from the patch instead of the stored row.
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "clientNameLangMap": { "eng": "api patch renamed", "fra": "api patch renomme" } }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "logoUri": "https://example.org/logo2.png" }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "redirectUris": ["https://example.org/cb", "https://example.org/cb2"] }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "userClaims": ["name", "email", "phone_number"] }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "authContextRefs": ["mosip:idp:acr:static-code", "mosip:idp:acr:knowledge"] }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "grantTypes": ["authorization_code"] }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "clientAuthMethods": ["private_key_jwt"] }
+      }
+      """
+    Then the response status should be 200
+
+    # additionalConfig is carried through the merge as raw JSON rather than a
+    # decoded map, so it gets its own patch here to prove the raw path round-trips.
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "additionalConfig": {
+            "require_pkce": true,
+            "dpop_bound_access_tokens": true
+          }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+  # Two fields at once, to show the merge is not limited to a single key and
+  # that field order in the body carries no meaning.
+  Scenario: A patch naming several fields applies all of them
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api patch multi",
+          "clientNameLangMap": { "eng": "api patch multi" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "status": "inactive",
+          "logoUri": "https://example.org/logo-multi.png",
+          "redirectUris": ["https://example.org/cb", "https://example.org/cb-multi"],
+          "userClaims": ["name", "email"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+
+  # encPublicKey distinguishes three states, and only two of them are reachable
+  # from a normal JSON struct decode — hence the dedicated nullable type behind
+  # this field. Setting a key and then clearing it walks both live branches;
+  # every other scenario in this file leaves the field omitted, which is the third.
+  Scenario: encPublicKey can be set to a key and then explicitly cleared with null
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api patch enckey",
+          "clientNameLangMap": { "eng": "api patch enckey" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+
+    # An encryption JWK must additionally carry "alg", so the JWE key-management
+    # algorithm is never left for the server to guess. RSA-OAEP-256 is the
+    # default supported algorithm.
+    #
+    # A fixed modulus rather than {{pubjwk}}: the generated key is stashed as a
+    # whole JWK object and cannot have "alg" spliced into it, and unlike the
+    # signing publicKey an encryption key carries no uniqueness constraint — so
+    # the same literal is safe to reuse across runs and across clients.
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "encPublicKey": {
+            "kty": "RSA",
+            "n": "sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1WlUzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDprecbAYxknTcQkhslANGRUZmdTOQ5qTRsLAt6BTYuyvVRdhS8exSZEy_c4gs_7svlJJQ4H9_NxsiIoLwAEk7-Q3UXERGYw_75IDrGA84-lA_-Ct4eTlXHBIY2EaV7t7LjJaynVJCpkv4LKjTTAumiGUIuQhrNhZLuF_RJLqHpM2kgWFLU7-VTdL1VbC2tejvcI2BlMkEpk1BzBZI0KQB0GaDWFLN-aEAw3vRw",
+            "e": "AQAB",
+            "alg": "RSA-OAEP-256",
+            "use": "enc"
+          }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+
+    # null is a removal, not a malformed key — it must be accepted where the
+    # same body with a "{}" or a partial JWK would be rejected.
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "encPublicKey": null }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.clientId" should be "{{cid}}"
+
+  # ---------------------------------------------------------------- negative --
+
+  # {{cid}}, not a literal: the Background mints a fresh id per scenario and
+  # this one never registers it, so the id is unknown even on a long-lived
+  # deployment.
+  Scenario: Patch a client that does not exist is reported as not found
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "inactive" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_client_id"
+
+  # The envelope is checked before the patch body is decoded, so these two fail
+  # the same way whether or not the client exists.
+  Scenario: Patch without a requestTime is rejected
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "request": { "status": "inactive" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+  # An envelope with no "request" at all is distinct from an empty one: there is
+  # nothing to merge, which the decoder reports rather than treating as a no-op
+  # patch that would rewrite the record with itself.
+  Scenario: Patch with no request object is rejected
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}"
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+  Scenario: Patch with a malformed JSON body is rejected
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      { "requestTime": "{{now}}", "request": { "status": }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+  # Patched values are validated exactly as they are on a create or update — the
+  # merge does not get a weaker rule set. Each case below patches one bad value
+  # onto an otherwise valid client, so the rejection can only come from the
+  # patched field.
+  Scenario: Patched values are validated and bad ones are rejected
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api patch invalid",
+          "clientNameLangMap": { "eng": "api patch invalid" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+
+    # status is a closed set; anything outside ACTIVE/INACTIVE is invalid_input
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "BOGUS" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_input"
+
+    # a URI field gets its own error code, distinct from the generic one above
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "logoUri": "not-a-uri" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_uri"
+
+    # an encryption JWK with no "alg" is rejected as a bad key rather than
+    # silently defaulted — the create path enforces the same rule.
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "encPublicKey": {
+            "kty": "RSA",
+            "n": "sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1WlUzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDprecbAYxknTcQkhslANGRUZmdTOQ5qTRsLAt6BTYuyvVRdhS8exSZEy_c4gs_7svlJJQ4H9_NxsiIoLwAEk7-Q3UXERGYw_75IDrGA84-lA_-Ct4eTlXHBIY2EaV7t7LjJaynVJCpkv4LKjTTAumiGUIuQhrNhZLuF_RJLqHpM2kgWFLU7-VTdL1VbC2tejvcI2BlMkEpk1BzBZI0KQB0GaDWFLN-aEAw3vRw",
+            "e": "AQAB"
+          }
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_public_key"
+
+    # the client is still intact and ACTIVE — a rejected patch writes nothing
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"

--- a/api-test/data/features/flow-execute/inactive-client.feature
+++ b/api-test/data/features/flow-execute/inactive-client.feature
@@ -1,0 +1,131 @@
+@inactive-client
+Feature: GET /oauth2/authorize — a client that has been deactivated
+  Deactivating a client is the operator's kill switch: it is how a relying party
+  that has been retired, compromised or offboarded is taken out of service
+  without deleting its record. client-mgmt/client-status.feature proves the
+  switch can be thrown and that the INACTIVE status is stored and read back.
+  This file asks the question that makes the switch worth anything — whether
+  eSignet then acts on it.
+
+  It is asserted at /oauth2/authorize because that is the first door: a client
+  that cannot get past it cannot reach login, a code, or a token, whatever the
+  later endpoints do. An unknown client id is already refused here
+  (authorize.feature), and a deactivated client is the same claim — this id may
+  not authorize — so the same rejection is expected.
+
+  The token, PAR and introspection endpoints ask the same question further in,
+  but they authenticate the client with a signed private_key_jwt assertion that
+  this surface has no way to produce. Those live in the e2e surface instead, as
+  the "inactive client" scenarios in data/scenarios/e2e-scenarios*.json.
+
+  Requests are made without following redirects so the 302 and its Location are
+  asserted directly, as in authorize.feature. Gated on @inactive-client, which
+  needs admin auth: the scenarios register and deactivate a client of their own
+  rather than driving FLOW_CLIENT_ID, which is shared and must stay usable.
+
+  Background:
+    Given I authenticate as admin
+    And a fresh request timestamp
+    And a generated RSA public key as "pubjwk"
+    And a new client id as "cid"
+
+  # The whole property in one scenario, and it is asserted in both directions:
+  # the same request is made before and after the deactivation, so a rejection
+  # afterwards can only be the status. Without the first call a failure to
+  # authorize could just as well be a malformed request or a bad client.
+  Scenario: A deactivated client can no longer start an authorization
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api inactive authz",
+          "clientNameLangMap": { "eng": "api inactive authz" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    # while ACTIVE: authorize is accepted and hands off to the login UI
+    When I send a "GET" request to "{{authz_endpoint}}?response_type=code&client_id={{cid}}&scope=openid&redirect_uri=https://example.org/cb&state=s1&nonce=n1&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256" without following redirects
+    Then the response status should be 302
+    And the redirect location should contain "{{cid}}"
+
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "INACTIVE" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+
+    # the status eSignet itself now stores for this client — read back so a
+    # failure below cannot be blamed on a write that never landed
+    When I send a "GET" request to "/client-mgmt/client/{{cid}}"
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "INACTIVE"
+
+    # while INACTIVE: the identical request must now be refused, the same way an
+    # unknown client id is (authorize.feature). Reaching the login UI here means
+    # a retired or compromised client can still start authorizations.
+    When I send a "GET" request to "{{authz_endpoint}}?response_type=code&client_id={{cid}}&scope=openid&redirect_uri=https://example.org/cb&state=s1&nonce=n1&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256" without following redirects
+    Then the response status should be 302
+    And the redirect location should contain "/error"
+
+  # The positive control for the scenario above. If reactivation did not restore
+  # authorization, the negative would be proving something about a broken client
+  # rather than about its status.
+  Scenario: Reactivating a client restores its ability to authorize
+    When I send a "POST" request to "/client-mgmt/client" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "clientId": "{{cid}}",
+          "clientName": "api reactivated authz",
+          "clientNameLangMap": { "eng": "api reactivated authz" },
+          "relyingPartyId": "api-e2e-rp",
+          "logoUri": "https://example.org/logo.png",
+          "redirectUris": ["https://example.org/cb"],
+          "publicKey": {{pubjwk}},
+          "userClaims": ["name"],
+          "authContextRefs": ["mosip:idp:acr:static-code"],
+          "grantTypes": ["authorization_code"],
+          "clientAuthMethods": ["private_key_jwt"]
+        }
+      }
+      """
+    Then the response status should be 200
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "INACTIVE" }
+      }
+      """
+    Then the response status should be 200
+    When I send a "PATCH" request to "/client-mgmt/client/{{cid}}" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "status": "ACTIVE" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "response.status" should be "ACTIVE"
+
+    When I send a "GET" request to "{{authz_endpoint}}?response_type=code&client_id={{cid}}&scope=openid&redirect_uri=https://example.org/cb&state=s1&nonce=n1&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256" without following redirects
+    Then the response status should be 302
+    And the redirect location should contain "{{cid}}"

--- a/api-test/data/features/flow-execute/introspect.feature
+++ b/api-test/data/features/flow-execute/introspect.feature
@@ -1,0 +1,62 @@
+@flow-execute
+Feature: POST /oauth2/introspect — request and client-authentication validation
+  The shape of the RFC 7662 introspection endpoint, checked without a token and
+  without a registered client. eSignet authenticates the caller with
+  private_key_jwt and does so before it looks at the submitted token, so every
+  rejection reachable from here is a client-authentication or malformed-request
+  one: 400 invalid_request when the request does not even name a client, 401
+  invalid_client when it names one it cannot prove it is.
+
+  What needs a real token instead — an issued token reported active with its
+  client, subject, scope and DPoP binding, an unissued one reported inactive
+  rather than as an error, and a missing token parameter behind a client
+  assertion that does verify — is covered on the e2e surface, which registers a
+  client and drives a login to obtain one.
+
+  # Bodies are form-encoded, so each scenario sets Content-Type explicitly:
+  # the generic step defaults to application/json.
+
+  Scenario: A request naming no client is rejected as malformed
+    Given I set header "Content-Type" to "application/x-www-form-urlencoded"
+    When I send a "POST" request to "/oauth2/introspect" with body:
+      """
+      token=some-opaque-token
+      """
+    Then the response status should be 400
+    And the JSON value at "error" should be "invalid_request"
+    And the JSON path "error_description" should exist
+
+  Scenario: An empty request is rejected as malformed
+    Given I set header "Content-Type" to "application/x-www-form-urlencoded"
+    When I send a "POST" request to "/oauth2/introspect"
+    Then the response status should be 400
+    And the JSON value at "error" should be "invalid_request"
+
+  # A client id alone is not client authentication: without an assertion there is
+  # nothing to verify against the registered key, so the call must not be trusted.
+  Scenario: A client id with no assertion is refused
+    Given a new client id as "unproven_client_id"
+    And I set header "Content-Type" to "application/x-www-form-urlencoded"
+    When I send a "POST" request to "/oauth2/introspect" with body:
+      """
+      token=some-opaque-token&client_id={{unproven_client_id}}
+      """
+    Then the response status should be 401
+    And the JSON value at "error" should be "invalid_client"
+    And the JSON path "error_description" should exist
+
+  Scenario: An unverifiable client assertion is refused
+    Given a new client id as "unproven_client_id"
+    And I set header "Content-Type" to "application/x-www-form-urlencoded"
+    When I send a "POST" request to "/oauth2/introspect" with body:
+      """
+      token=some-opaque-token&client_id={{unproven_client_id}}&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=not.a.jwt
+      """
+    Then the response status should be 401
+    And the JSON value at "error" should be "invalid_client"
+
+  # RFC 7662 s2.1 defines introspection as a POST; a GET would put the token in
+  # the request URI, where it lands in access logs and referrers.
+  Scenario: The endpoint is not exposed over GET
+    When I send a "GET" request to "/oauth2/introspect"
+    Then the response status should be 405

--- a/api-test/data/features/system-info/system-info.feature
+++ b/api-test/data/features/system-info/system-info.feature
@@ -1,0 +1,161 @@
+@flow-execute
+Feature: /health and /system-info — liveness and the certificate endpoints
+  The last two HTTP surfaces of esignet-service that no other feature file
+  touches: the liveness probe, and the pair of /system-info endpoints that read
+  and replace the service's signing certificates.
+
+  Tagged @flow-execute rather than a tag of its own on purpose — it is the tag
+  the harness always runs. A dedicated @system-info tag would need adding to
+  the default set in engine_test.go before it ever executed.
+
+  /health needs no admin credentials or registered client. Every
+  /system-info/* endpoint DOES require an authenticated admin bearer token —
+  a deployed target 401s "missing Authorization header" otherwise — so each
+  of those scenarios opens with "Given I authenticate as admin" and is
+  ENV_NOT_READY (not a hard failure) when KEYCLOAK_* isn't configured, same
+  as client-mgmt.
+
+  # Unlike client-mgmt, these endpoints answer with errorCode "invalid_request"
+  # (not "invalid_input") and "invalid_certificate". Both still come back as
+  # HTTP 200 with an "errors" array, per the MOSIP convention used throughout.
+
+  # ------------------------------------------------------------------ health --
+
+  # Plain text "ok", not JSON — so status is the only thing to assert. The probe
+  # is what compose and every deployment gate on, so a change that breaks it
+  # strands the whole stack in "starting" with no other symptom.
+  Scenario: The health endpoint reports the service is up
+    When I send a "GET" request to "/health"
+    Then the response status should be 200
+
+  # ------------------------------------------------- certificate — positive --
+
+  # ROOT is the top of the key hierarchy and the one application id whose
+  # referenceId may be blank; every other id requires one. Asking for it returns
+  # the certificate the service provisioned at boot, so this also proves the key
+  # hierarchy came up rather than the server merely accepting connections.
+  Scenario: Read the ROOT certificate
+    Given I authenticate as admin
+    When I send a "GET" request to "/system-info/certificate?applicationId=ROOT"
+    Then the response status should be 200
+    And the JSON path "response.certificate" should exist
+
+  # ------------------------------------------------- certificate — negative --
+
+  Scenario: Reading a certificate without an applicationId is rejected
+    Given I authenticate as admin
+    When I send a "GET" request to "/system-info/certificate"
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_request"
+
+  # The length ceiling is checked before the allow-list, so an over-long id is
+  # rejected for its length even when it would also have failed as not permitted.
+  Scenario: A referenceId beyond the length ceiling is rejected
+    Given I authenticate as admin
+    When I send a "GET" request to "/system-info/certificate?applicationId=ROOT&referenceId=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_request"
+
+  # The allow-list has no silent default: GetCertificate mints a fresh key pair
+  # for any (applicationId, referenceId) pair it has not seen, so an unlisted
+  # encryption-key reference must be refused rather than quietly generating one.
+  # Only the fixed hierarchy tiers (blank, RSA_2048, the three signing refs) are
+  # exempt without configuration.
+  Scenario: A referenceId outside the configured allow-list is refused
+    Given I authenticate as admin
+    When I send a "GET" request to "/system-info/certificate?applicationId=ROOT&referenceId=ANY_ENCRYPTION_KEY"
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_request"
+
+  # ---------------------------------------------- uploadCertificate — negative --
+
+  # The positive upload is deliberately absent: replacing a certificate requires
+  # one signed against the service's own CSR for that alias, which cannot be
+  # committed as a fixture without going stale when the key is regenerated. The
+  # rejection paths below are where the handler's own logic lives; the accepted
+  # path is covered by the package's unit tests.
+
+  Scenario: Uploading a certificate with a malformed body is rejected
+    Given I authenticate as admin
+    When I send a "POST" request to "/system-info/uploadCertificate" with body:
+      """
+      { "requestTime": "{{now}}", "request": { "applicationId": }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_request"
+
+  Scenario: Uploading a certificate without an applicationId is rejected
+    Given I authenticate as admin
+    And a fresh request timestamp
+    When I send a "POST" request to "/system-info/uploadCertificate" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "certificateData": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_request"
+
+  Scenario: Uploading a certificate without certificateData is rejected
+    Given I authenticate as admin
+    And a fresh request timestamp
+    When I send a "POST" request to "/system-info/uploadCertificate" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": { "applicationId": "ROOT" }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_request"
+
+  # KNOWN ISSUE — tracked as mosip/esignet#2527. Real defect in esignet-service,
+  # reported here as KNOWN_ISSUE (not FAILED) rather than muted or weakened to
+  # match the current response, so it stays visible in the report without
+  # blocking the rest of the suite. Revert to plain FAILED (drop @known_issue
+  # below and the apiKnownIssues entry in api/steps.go) only once #2527 is
+  # closed and this scenario goes green on its own — or, if the service team
+  # rules the 500 intentional, invert the assertion to 500 / "server_error" and
+  # record that decision here.
+  #
+  # Expected: HTTP 200 + errorCode "invalid_certificate".
+  # Actual:   HTTP 500 + errorCode "server_error" ("an unexpected error occurred").
+  #
+  # Both required fields are present, so this gets past the handler's own checks
+  # and fails inside the certificate parser. Unparseable client input is then
+  # reported as a server fault, while every other bad-input case in the service
+  # answers HTTP 200 with a specific errorCode.
+  #
+  # Cause: UploadCertificate wraps the parse failure with a bare
+  #   fmt.Errorf("parse uploaded certificate: %w", err)
+  # (keymanager/service.go:823) — an anonymous error with no sentinel.
+  # handleServiceError (keymanager/handler.go:194-204) picks the response by
+  # errors.Is against named sentinels and only maps ErrThumbprintMismatch and
+  # ErrCertificateAlreadyExists to invalid_certificate, so a parse failure
+  # matches no arm and falls into the default branch, which is the 500.
+  #
+  # The endpoint already declares errCodeInvalidCertificate for exactly this
+  # shape of error, and the package already defines ~10 sentinels alongside it,
+  # so the fix is to add one more (e.g. ErrInvalidCertificate), return it here,
+  # and add it to that case — roughly three lines. See #2527 for the full
+  # write-up. That is an esignet-service change, which this branch does not
+  # make for any plugin.
+  @known_issue
+  Scenario: Uploading certificateData that is not a certificate is rejected as an invalid certificate
+    Given I authenticate as admin
+    And a fresh request timestamp
+    When I send a "POST" request to "/system-info/uploadCertificate" with body:
+      """
+      {
+        "requestTime": "{{now}}",
+        "request": {
+          "applicationId": "ROOT",
+          "certificateData": "not-a-certificate"
+        }
+      }
+      """
+    Then the response status should be 200
+    And the JSON value at "errors.0.errorCode" should be "invalid_certificate"

--- a/api-test/data/scenarios/e2e-scenarios-mosip.json
+++ b/api-test/data/scenarios/e2e-scenarios-mosip.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "End-to-end scenarios for MOSIP_ESIGNET_AUTHN_PROVIDER=mosip. Same auth_factor matrix as mock (otp/password/bio), positive + negative. otp uses the real MOSIP send-OTP -> verify chain; the individual id/OTP come from config (INDIVIDUAL_ID/TEST_OTP env), so a positive otp run needs an identity with a working OTP channel in the target environment -- if the configured identity has none, that scenario is expected to FAIL and is kept in place rather than removed, per instruction. password/bio have no credential configured on this deployment; their positive scenarios are likewise kept in place to fail until real credentials exist, and their negative scenarios still assert rejection (structurally, since no valid credential exists to accept). CONSENT/CAPTCHA CASES (appended): the consent cases are ORDER-DEPENDENT and share one registered client per run -- 'stored consent is reused' asserts NO prompt, which only holds because the identical-scope case ran immediately before it and saved a consent record for (client,user). Each other consent case deliberately uses a DISTINCT scope set so its request hash differs and the server re-prompts; reordering them, or narrowing the run with e2e.include so the approve-all case is skipped, will make the reuse case fail. Captcha: an empty token is rejected by the server before the validator-configured check, so that negative is portable to any deployment; a non-empty token is accepted when no MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL is configured (the dev/test default) and validated for real when one is.",
+  "_comment": "End-to-end scenarios for MOSIP_ESIGNET_AUTHN_PROVIDER=mosip. Same auth_factor matrix as mock (otp/password/bio), positive + negative. otp uses the real MOSIP send-OTP -> verify chain; the individual id/OTP come from config (INDIVIDUAL_ID/TEST_OTP env), so a positive otp run needs an identity with a working OTP channel in the target environment -- if the configured identity has none, that scenario is expected to FAIL and is kept in place rather than removed, per instruction. password's positive scenario is requires_credential:password, so it is skipped rather than run when esignet.credentials.password is unset; bio's positive scenario is a tracked known_issue, out of scope until a mock MDS is provisioned for this target. Both negative scenarios still assert rejection (structurally, since no valid credential exists to accept). CONSENT/CAPTCHA CASES (appended): the consent cases are ORDER-DEPENDENT and share one registered client per run -- 'stored consent is reused' asserts NO prompt, which only holds because the identical-scope case ran immediately before it and saved a consent record for (client,user). Each other consent case deliberately uses a DISTINCT scope set so its request hash differs and the server re-prompts; reordering them, or narrowing the run with e2e.include so the approve-all case is skipped, will make the reuse case fail. Captcha: an empty token is rejected by the server before the validator-configured check, so that negative is portable to any deployment; a non-empty token is accepted when no MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL is configured (the dev/test default) and validated for real when one is.",
   "redirect_uri": "https://api-e2e.example.org/callback",
   "user_claims": ["name", "email", "phone_number", "gender", "birthdate"],
   "acr": ["mosip:idp:acr:generated-code", "mosip:idp:acr:password", "mosip:idp:acr:biometrics"],
@@ -20,6 +20,8 @@
     {
       "name": "password positive: login succeeds with configured password",
       "auth_factor": "password",
+      "_comment": "Runs only when esignet.credentials.password is set for this deployment (TEST_PASSWORD); otherwise skipped rather than run against a credential that doesn't exist.",
+      "requires_credential": "password",
       "scopes": ["openid"],
       "expect_present": ["sub"]
     },
@@ -33,6 +35,7 @@
     {
       "name": "bio positive: login succeeds with biometric capture",
       "auth_factor": "bio",
+      "known_issue": "out of scope for this release: no mock MDS (biometric device service) is provisioned on the mosip target, so a real biometric capture cannot be supplied — tracked as mosip/esignet#2528",
       "scopes": ["openid"],
       "expect_present": ["sub"]
     },
@@ -94,6 +97,240 @@
       "scopes": ["openid"],
       "userinfo_claims": { "name": { "essential": true } },
       "consent": { "expect_prompt": "yes", "deny": ["name"] }
+    },
+
+    {
+      "_comment": "PROTOCOL COMBINATIONS. Each client_config registers its own client (clients are pooled by config, so a config appearing twice is registered once) with the additionalConfig switches eSignet enforces at authorize, /oauth2/par, token and userinfo. The positives drive the flow those switches demand, all the way to userinfo; the negatives drive it wrong on purpose and expect rejection. Scenarios with no client_config keep sharing the single unhardened client, which is what the consent cases above depend on. These cases are protocol-level and plugin-independent -- they mirror the block in data/scenarios/e2e-scenarios.json with otp as the auth factor and scopes kept to openid, since claim release is already covered above. MOSIPID CAVEAT: clients here are registered through PMS /oauth/client, not eSignet client-mgmt. The harness sends additionalConfig on that request, but PMS owns whether it forwards the switches to eSignet. If it drops them the positives still pass (an unhardened client accepts a hardened flow), and the negatives are what will show it, by not being rejected. Also requires a deployment whose discovery advertises pushed_authorization_request_endpoint (PAR cases) and dpop_signing_alg_values_supported (DPoP cases).",
+      "name": "protocol positive: require_pkce completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PAR-required client completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: DPoP-bound client completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + PAR completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true, "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + DPoP completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true, "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PAR + DPoP completes to userinfo (proof at PAR binds the code)",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true, "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + PAR + DPoP completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": {
+        "require_pkce": true,
+        "require_pushed_authorization_requests": true,
+        "dpop_bound_access_tokens": true
+      },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+
+    {
+      "_comment": "NEGATIVES. Each reuses a client registered above, so no extra registration happens; only the RP's behaviour changes. expect_error_contains is asserted only on messages the harness itself produces, so these do not depend on a particular server error string.",
+      "name": "protocol negative: require_pkce rejects an authorize with no code_challenge",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true },
+      "flow": { "pkce": "none" },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned error=invalid_request",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: require_pkce rejects the plain challenge method",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true },
+      "flow": { "pkce": "plain" },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned error=invalid_request",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: PAR-required client rejects a direct authorize",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "flow": { "use_par": false },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: DPoP-bound client rejects a token call with no proof",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "flow": { "use_dpop": false },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: a DPoP proof from a different key cannot redeem the code",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true, "dpop_bound_access_tokens": true },
+      "flow": { "dpop_key_mismatch": true },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: a DPoP-bound token is refused at userinfo with the Bearer scheme",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "flow": { "bearer_at_userinfo": true },
+      "expect_login_failure": true,
+      "expect_error_contains": "userinfo request failed",
+      "scopes": ["openid"]
+    },
+    {
+      "_comment": "RFC 7662 token introspection. The cases run after the flow has completed, against tokens it has just proven usable at userinfo, so a failure here belongs to the introspection endpoint rather than to a stale or never-valid token. Each case is one POST to /oauth2/introspect and prefixes its own assertions, so a row says which case failed. {{client_id}}, {{sub}} and {{dpop_jkt}} are substituted with what this run actually obtained. The mismatched-hint case is not a mistake: RFC 7662 s2.1 makes token_type_hint an optimization the server may ignore, so a wrong hint must not stop it finding the token.",
+      "name": "introspection positive: an issued access token is reported active with its client, subject and scope",
+      "auth_factor": "otp",
+      "scopes": ["openid", "profile"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "access token with hint",
+          "token": "access_token",
+          "hint": "access_token",
+          "expect_active": true,
+          "expect_present": ["client_id", "sub", "scope", "iss", "exp", "iat"],
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}", "scope": "openid profile" }
+        },
+        {
+          "name": "access token without a hint",
+          "token": "access_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}" }
+        },
+        {
+          "name": "access token under a mismatched hint",
+          "token": "access_token",
+          "hint": "id_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}" }
+        }
+      ]
+    },
+    {
+      "_comment": "The two axes pointed away from the positive. A token this deployment never issued must come back inactive rather than as an error (RFC 7662 s2.2) and must carry no metadata with it (s4), or introspection becomes an oracle for guessed tokens. A request whose client authentication does not hold up must be refused outright, before the submitted token is looked at.",
+      "name": "introspection negative: unissued tokens and failed client authentication are refused",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "a token this deployment never issued",
+          "token": "unissued",
+          "expect_status": 200,
+          "expect_active": false,
+          "expect_absent": ["sub", "client_id", "scope", "exp", "iat", "iss"]
+        },
+        {
+          "name": "no token parameter",
+          "token": "none",
+          "expect_status": 400,
+          "expect_error": "invalid_request"
+        },
+        {
+          "name": "client id with no assertion",
+          "client_auth": "no_assertion",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        },
+        {
+          "name": "assertion signed with an unregistered key",
+          "client_auth": "wrong_key",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        },
+        {
+          "name": "assertion issued for another audience",
+          "client_auth": "wrong_audience",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        }
+      ]
+    },
+    {
+      "_comment": "A DPoP-bound access token carries its binding as cnf.jkt. Introspection has to report the same thumbprint, otherwise a resource server that consults introspection instead of reading the token would have no way to know a proof of possession is required at all.",
+      "name": "introspection positive: a DPoP-bound access token reports its cnf.jkt binding",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "dpop-bound access token",
+          "token": "access_token",
+          "hint": "access_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "cnf.jkt": "{{dpop_jkt}}" }
+        }
+      ]
+    },
+    {
+      "_comment": "Deactivating a client is the operator's kill switch for a relying party that has been retired, compromised or offboarded. The api surface proves the switch can be thrown and that eSignet stores and returns INACTIVE; these ask whether eSignet then acts on it, at each of the three doors a client passes through once it has been flipped. The stages are separate cases because they fail differently: refusing to start an authorization is a check on a request, while refusing to redeem a code and refusing to spend a token are checks on credentials already issued, and a deployment could plausibly have one without the others. The reactivate case is the control for all of them -- same client, same plumbing, same flow, status restored -- so a negative that fails cannot be blamed on the deactivation machinery itself.",
+      "name": "inactive client negative: a deactivated client cannot start the flow",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "login flow failed: authorize returned eSignet's error page"
+    },
+    {
+      "_comment": "The same question at the pushed-authorization endpoint, which unlike authorize authenticates the client with a signed assertion. A deployment that checks status only on the unauthenticated path would pass the case above and fail this one.",
+      "name": "inactive client negative: a deactivated client cannot push an authorization request",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "par failed"
+    },
+    {
+      "_comment": "Deactivation partway through: the code was issued while the client was still active, and is redeemed after the switch was flipped. Taking a client out of service has to invalidate what it already holds, or an offboarded relying party keeps a working code for as long as the code lives.",
+      "name": "inactive client negative: a code issued before deactivation cannot be redeemed",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "after_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed"
+    },
+    {
+      "_comment": "The control for the three negatives above. The same status writes are made and the client ends up ACTIVE again, so the whole flow must complete. A failure here is the harness's deactivation plumbing or the client itself, not enforcement -- which is exactly what it exists to tell apart.",
+      "name": "inactive client positive: reactivating restores the whole flow",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize", "reactivate": true },
+      "expect_present": ["sub"]
     }
   ]
 }

--- a/api-test/data/scenarios/e2e-scenarios-sunbird.json
+++ b/api-test/data/scenarios/e2e-scenarios-sunbird.json
@@ -69,6 +69,240 @@
       "scopes": ["openid"],
       "userinfo_claims": { "name": { "essential": true } },
       "consent": { "expect_prompt": "yes", "deny": ["name"] }
+    },
+
+    {
+      "_comment": "PROTOCOL COMBINATIONS. Each client_config registers its own client (clients are pooled by config, so a config appearing twice is registered once) with the additionalConfig switches eSignet enforces at authorize, /oauth2/par, token and userinfo. The positives drive the flow those switches demand, all the way to userinfo; the negatives drive it wrong on purpose and expect rejection. Scenarios with no client_config keep sharing the single unhardened client, which is what the consent cases above depend on. These cases are protocol-level and plugin-independent -- they mirror the block in data/scenarios/e2e-scenarios.json with kbi as the auth factor and scopes kept to openid, since claim release is already covered above. Requires a deployment whose discovery advertises pushed_authorization_request_endpoint (PAR cases) and dpop_signing_alg_values_supported (DPoP cases); without them those scenarios fail with an explicit message rather than being skipped.",
+      "name": "protocol positive: require_pkce completes to userinfo",
+      "auth_factor": "kbi",
+      "client_config": { "require_pkce": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PAR-required client completes to userinfo",
+      "auth_factor": "kbi",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: DPoP-bound client completes to userinfo",
+      "auth_factor": "kbi",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + PAR completes to userinfo",
+      "auth_factor": "kbi",
+      "client_config": { "require_pkce": true, "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + DPoP completes to userinfo",
+      "auth_factor": "kbi",
+      "client_config": { "require_pkce": true, "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PAR + DPoP completes to userinfo (proof at PAR binds the code)",
+      "auth_factor": "kbi",
+      "client_config": { "require_pushed_authorization_requests": true, "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + PAR + DPoP completes to userinfo",
+      "auth_factor": "kbi",
+      "client_config": {
+        "require_pkce": true,
+        "require_pushed_authorization_requests": true,
+        "dpop_bound_access_tokens": true
+      },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+
+    {
+      "_comment": "NEGATIVES. Each reuses a client registered above, so no extra registration happens; only the RP's behaviour changes. expect_error_contains is asserted only on messages the harness itself produces, so these do not depend on a particular server error string.",
+      "name": "protocol negative: require_pkce rejects an authorize with no code_challenge",
+      "auth_factor": "kbi",
+      "client_config": { "require_pkce": true },
+      "flow": { "pkce": "none" },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned error=invalid_request",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: require_pkce rejects the plain challenge method",
+      "auth_factor": "kbi",
+      "client_config": { "require_pkce": true },
+      "flow": { "pkce": "plain" },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned error=invalid_request",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: PAR-required client rejects a direct authorize",
+      "auth_factor": "kbi",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "flow": { "use_par": false },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: DPoP-bound client rejects a token call with no proof",
+      "auth_factor": "kbi",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "flow": { "use_dpop": false },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: a DPoP proof from a different key cannot redeem the code",
+      "auth_factor": "kbi",
+      "client_config": { "require_pushed_authorization_requests": true, "dpop_bound_access_tokens": true },
+      "flow": { "dpop_key_mismatch": true },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: a DPoP-bound token is refused at userinfo with the Bearer scheme",
+      "auth_factor": "kbi",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "flow": { "bearer_at_userinfo": true },
+      "expect_login_failure": true,
+      "expect_error_contains": "userinfo request failed",
+      "scopes": ["openid"]
+    },
+    {
+      "_comment": "RFC 7662 token introspection. The cases run after the flow has completed, against tokens it has just proven usable at userinfo, so a failure here belongs to the introspection endpoint rather than to a stale or never-valid token. Each case is one POST to /oauth2/introspect and prefixes its own assertions, so a row says which case failed. {{client_id}}, {{sub}} and {{dpop_jkt}} are substituted with what this run actually obtained. The mismatched-hint case is not a mistake: RFC 7662 s2.1 makes token_type_hint an optimization the server may ignore, so a wrong hint must not stop it finding the token.",
+      "name": "introspection positive: an issued access token is reported active with its client, subject and scope",
+      "auth_factor": "kbi",
+      "scopes": ["openid", "profile"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "access token with hint",
+          "token": "access_token",
+          "hint": "access_token",
+          "expect_active": true,
+          "expect_present": ["client_id", "sub", "scope", "iss", "exp", "iat"],
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}", "scope": "openid profile" }
+        },
+        {
+          "name": "access token without a hint",
+          "token": "access_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}" }
+        },
+        {
+          "name": "access token under a mismatched hint",
+          "token": "access_token",
+          "hint": "id_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}" }
+        }
+      ]
+    },
+    {
+      "_comment": "The two axes pointed away from the positive. A token this deployment never issued must come back inactive rather than as an error (RFC 7662 s2.2) and must carry no metadata with it (s4), or introspection becomes an oracle for guessed tokens. A request whose client authentication does not hold up must be refused outright, before the submitted token is looked at.",
+      "name": "introspection negative: unissued tokens and failed client authentication are refused",
+      "auth_factor": "kbi",
+      "scopes": ["openid"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "a token this deployment never issued",
+          "token": "unissued",
+          "expect_status": 200,
+          "expect_active": false,
+          "expect_absent": ["sub", "client_id", "scope", "exp", "iat", "iss"]
+        },
+        {
+          "name": "no token parameter",
+          "token": "none",
+          "expect_status": 400,
+          "expect_error": "invalid_request"
+        },
+        {
+          "name": "client id with no assertion",
+          "client_auth": "no_assertion",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        },
+        {
+          "name": "assertion signed with an unregistered key",
+          "client_auth": "wrong_key",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        },
+        {
+          "name": "assertion issued for another audience",
+          "client_auth": "wrong_audience",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        }
+      ]
+    },
+    {
+      "_comment": "A DPoP-bound access token carries its binding as cnf.jkt. Introspection has to report the same thumbprint, otherwise a resource server that consults introspection instead of reading the token would have no way to know a proof of possession is required at all.",
+      "name": "introspection positive: a DPoP-bound access token reports its cnf.jkt binding",
+      "auth_factor": "kbi",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "dpop-bound access token",
+          "token": "access_token",
+          "hint": "access_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "cnf.jkt": "{{dpop_jkt}}" }
+        }
+      ]
+    },
+    {
+      "_comment": "Deactivating a client is the operator's kill switch for a relying party that has been retired, compromised or offboarded. The api surface proves the switch can be thrown and that eSignet stores and returns INACTIVE; these ask whether eSignet then acts on it, at each of the three doors a client passes through once it has been flipped. The stages are separate cases because they fail differently: refusing to start an authorization is a check on a request, while refusing to redeem a code and refusing to spend a token are checks on credentials already issued, and a deployment could plausibly have one without the others. The reactivate case is the control for all of them -- same client, same plumbing, same flow, status restored -- so a negative that fails cannot be blamed on the deactivation machinery itself.",
+      "name": "inactive client negative: a deactivated client cannot start the flow",
+      "auth_factor": "kbi",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "login flow failed: authorize returned eSignet's error page"
+    },
+    {
+      "_comment": "The same question at the pushed-authorization endpoint, which unlike authorize authenticates the client with a signed assertion. A deployment that checks status only on the unauthenticated path would pass the case above and fail this one.",
+      "name": "inactive client negative: a deactivated client cannot push an authorization request",
+      "auth_factor": "kbi",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "par failed"
+    },
+    {
+      "_comment": "Deactivation partway through: the code was issued while the client was still active, and is redeemed after the switch was flipped. Taking a client out of service has to invalidate what it already holds, or an offboarded relying party keeps a working code for as long as the code lives.",
+      "name": "inactive client negative: a code issued before deactivation cannot be redeemed",
+      "auth_factor": "kbi",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "after_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed"
+    },
+    {
+      "_comment": "The control for the three negatives above. The same status writes are made and the client ends up ACTIVE again, so the whole flow must complete. A failure here is the harness's deactivation plumbing or the client itself, not enforcement -- which is exactly what it exists to tell apart.",
+      "name": "inactive client positive: reactivating restores the whole flow",
+      "auth_factor": "kbi",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize", "reactivate": true },
+      "expect_present": ["sub"]
     }
   ]
 }

--- a/api-test/data/scenarios/e2e-scenarios.json
+++ b/api-test/data/scenarios/e2e-scenarios.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "End-to-end scenarios for MOSIP_ESIGNET_AUTHN_PROVIDER=mock. Each scenario declares auth_factor (otp|password|bio) and drives the full authorize -> login -> token(private_key_jwt) -> userinfo chain. Positive scenarios expect login to succeed; negative scenarios (expect_login_failure=true) expect it to be rejected. password/bio have no working credential confirmed on this deployment yet -- their positive scenarios are kept in place and will FAIL until real credentials/config exist (per instruction: let it fail, don't omit the testcase). Their negative scenarios still meaningfully assert rejection: for password a deliberately wrong value is submitted; for bio there is no way to submit any credential at all, so rejection is structural (no configured answer) rather than a value mismatch -- also acceptable per instruction. TRIED (2026-07-21) for password ACR: username=decl-user-1 with password='Mosip@123' and, separately, the Postman-documented 'TempPassword123!' -- both submit successfully (flow accepts the inputs, no config error) but the flow loops indefinitely re-requesting username+password (INCOMPLETE) rather than ever completing or returning an explicit rejection, for both passwords. This means neither credential authenticates against this environment's mock-identity-system as currently seeded; the actual valid password (if this user exists here at all) is still unconfirmed. CONSENT/CAPTCHA CASES (appended): the consent cases are ORDER-DEPENDENT and share one registered client per run -- 'stored consent is reused' asserts NO prompt, which only holds because the identical-scope case ran immediately before it and saved a consent record for (client,user). Each other consent case deliberately uses a DISTINCT scope set so its request hash differs and the server re-prompts; reordering them, or narrowing the run with e2e.include so the approve-all case is skipped, will make the reuse case fail. Captcha: an empty token is rejected by the server before the validator-configured check, so that negative is portable to any deployment; a non-empty token is accepted when no MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL is configured (the dev/test default) and validated for real when one is.",
+  "_comment": "End-to-end scenarios for MOSIP_ESIGNET_AUTHN_PROVIDER=mock. Each scenario declares auth_factor (otp|password|bio) and drives the full authorize -> login -> token(private_key_jwt) -> userinfo chain. Positive scenarios expect login to succeed; negative scenarios (expect_login_failure=true) expect it to be rejected. bio is now driven by esignet.credentials.biometric (mock accepts any non-empty value, including one that isn't real biometric data, as a successful capture); its negative case uses omit_credentials to submit no value at all, since mock accepts an empty string too. password has no working credential confirmed on this deployment yet -- its positive scenario is kept in place and will FAIL until real credentials/config exist (per instruction: let it fail, don't omit the testcase). Their negative scenarios still meaningfully assert rejection: for password a deliberately wrong value is submitted; for bio there is no way to submit any credential at all, so rejection is structural (no configured answer) rather than a value mismatch -- also acceptable per instruction. TRIED (2026-07-21) for password ACR: username=decl-user-1 with password='Mosip@123' and, separately, the Postman-documented 'TempPassword123!' -- both submit successfully (flow accepts the inputs, no config error) but the flow loops indefinitely re-requesting username+password (INCOMPLETE) rather than ever completing or returning an explicit rejection, for both passwords. This means neither credential authenticates against this environment's mock-identity-system as currently seeded; the actual valid password (if this user exists here at all) is still unconfirmed. CONSENT/CAPTCHA CASES (appended): the consent cases are ORDER-DEPENDENT and share one registered client per run -- 'stored consent is reused' asserts NO prompt, which only holds because the identical-scope case ran immediately before it and saved a consent record for (client,user). Each other consent case deliberately uses a DISTINCT scope set so its request hash differs and the server re-prompts; reordering them, or narrowing the run with e2e.include so the approve-all case is skipped, will make the reuse case fail. Captcha: an empty token is rejected by the server before the validator-configured check, so that negative is portable to any deployment; a non-empty token is accepted when no MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL is configured (the dev/test default) and validated for real when one is.",
   "redirect_uri": "https://api-e2e.example.org/callback",
   "user_claims": ["name", "email", "phone_number", "gender", "birthdate"],
   "acr": ["mosip:idp:acr:generated-code", "mosip:idp:acr:password", "mosip:idp:acr:biometrics"],
@@ -63,6 +63,7 @@
     {
       "name": "bio positive: login succeeds with biometric capture",
       "auth_factor": "bio",
+      "_comment": "No credentials override: the value comes from esignet.credentials.biometric. Mock accepts any non-empty value as a successful capture.",
       "scopes": ["openid"],
       "expect_present": ["sub"]
     },
@@ -70,6 +71,8 @@
       "name": "bio negative: no biometric capture is rejected",
       "auth_factor": "bio",
       "expect_login_failure": true,
+      "_comment": "omit_credentials, not an empty override: mock treats an empty string as a valid (if odd) capture and accepts it, so the negative must submit no value at all.",
+      "omit_credentials": ["biometric"],
       "scopes": ["openid"]
     },
 
@@ -125,6 +128,243 @@
       "scopes": ["openid"],
       "userinfo_claims": { "name": { "essential": true } },
       "consent": { "expect_prompt": "yes", "deny": ["name"] }
+    },
+
+    {
+      "_comment": "PROTOCOL COMBINATIONS. Each client_config registers its own client (clients are pooled by config, so a config appearing twice is registered once) with the additionalConfig switches eSignet enforces at authorize, /oauth2/par, token and userinfo. The positives below drive the flow those switches demand, all the way to userinfo; the negatives drive it wrong on purpose and expect rejection. Scenarios with no client_config keep sharing the single unhardened client, which is what the consent cases above depend on. These cases are protocol-level and plugin-independent: the same block appears in the sunbird and mosip specs with that plugin's auth_factor. Requires a deployment whose discovery advertises pushed_authorization_request_endpoint (PAR cases) and dpop_signing_alg_values_supported (DPoP cases); without them those scenarios fail with an explicit message rather than being skipped.",
+
+      "name": "protocol positive: require_pkce completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PAR-required client completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: DPoP-bound client completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + PAR completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true, "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PKCE + DPoP completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true, "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "name": "protocol positive: PAR + DPoP completes to userinfo (proof at PAR binds the code)",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true, "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"]
+    },
+    {
+      "_comment": "The full FAPI2-shaped combination, and the one the conformance surface's FAPI2 plan exercises from the other side. Scopes go wider here so the run proves claim release still works with every switch on.",
+      "name": "protocol positive: PKCE + PAR + DPoP completes to userinfo",
+      "auth_factor": "otp",
+      "client_config": {
+        "require_pkce": true,
+        "require_pushed_authorization_requests": true,
+        "dpop_bound_access_tokens": true
+      },
+      "scopes": ["openid", "profile", "email"],
+      "expect_present": ["sub", "name", "email"]
+    },
+
+    {
+      "_comment": "NEGATIVES. Each reuses a client registered above, so no extra registration happens; only the RP's behaviour changes. expect_error_contains is asserted only on messages the harness itself produces, so these do not depend on a particular server error string.",
+      "name": "protocol negative: require_pkce rejects an authorize with no code_challenge",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true },
+      "flow": { "pkce": "none" },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned error=invalid_request",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: require_pkce rejects the plain challenge method",
+      "auth_factor": "otp",
+      "client_config": { "require_pkce": true },
+      "flow": { "pkce": "plain" },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned error=invalid_request",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: PAR-required client rejects a direct authorize",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "flow": { "use_par": false },
+      "expect_login_failure": true,
+      "expect_error_contains": "authorize returned",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: DPoP-bound client rejects a token call with no proof",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "flow": { "use_dpop": false },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed",
+      "scopes": ["openid"]
+    },
+    {
+      "_comment": "The code is bound to the key that proved possession at PAR, so redeeming it with a different key must fail even though that proof is itself valid.",
+      "name": "protocol negative: a DPoP proof from a different key cannot redeem the code",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true, "dpop_bound_access_tokens": true },
+      "flow": { "dpop_key_mismatch": true },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed",
+      "scopes": ["openid"]
+    },
+    {
+      "name": "protocol negative: a DPoP-bound token is refused at userinfo with the Bearer scheme",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "flow": { "bearer_at_userinfo": true },
+      "expect_login_failure": true,
+      "expect_error_contains": "userinfo request failed",
+      "scopes": ["openid"]
+    },
+    {
+      "_comment": "RFC 7662 token introspection. The cases run after the flow has completed, against tokens it has just proven usable at userinfo, so a failure here belongs to the introspection endpoint rather than to a stale or never-valid token. Each case is one POST to /oauth2/introspect and prefixes its own assertions, so a row says which case failed. {{client_id}}, {{sub}} and {{dpop_jkt}} are substituted with what this run actually obtained. The mismatched-hint case is not a mistake: RFC 7662 s2.1 makes token_type_hint an optimization the server may ignore, so a wrong hint must not stop it finding the token.",
+      "name": "introspection positive: an issued access token is reported active with its client, subject and scope",
+      "auth_factor": "otp",
+      "scopes": ["openid", "profile"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "access token with hint",
+          "token": "access_token",
+          "hint": "access_token",
+          "expect_active": true,
+          "expect_present": ["client_id", "sub", "scope", "iss", "exp", "iat"],
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}", "scope": "openid profile" }
+        },
+        {
+          "name": "access token without a hint",
+          "token": "access_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}" }
+        },
+        {
+          "name": "access token under a mismatched hint",
+          "token": "access_token",
+          "hint": "id_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}" }
+        }
+      ]
+    },
+    {
+      "_comment": "The two axes pointed away from the positive. A token this deployment never issued must come back inactive rather than as an error (RFC 7662 s2.2) and must carry no metadata with it (s4), or introspection becomes an oracle for guessed tokens. A request whose client authentication does not hold up must be refused outright, before the submitted token is looked at.",
+      "name": "introspection negative: unissued tokens and failed client authentication are refused",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "a token this deployment never issued",
+          "token": "unissued",
+          "expect_status": 200,
+          "expect_active": false,
+          "expect_absent": ["sub", "client_id", "scope", "exp", "iat", "iss"]
+        },
+        {
+          "name": "no token parameter",
+          "token": "none",
+          "expect_status": 400,
+          "expect_error": "invalid_request"
+        },
+        {
+          "name": "client id with no assertion",
+          "client_auth": "no_assertion",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        },
+        {
+          "name": "assertion signed with an unregistered key",
+          "client_auth": "wrong_key",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        },
+        {
+          "name": "assertion issued for another audience",
+          "client_auth": "wrong_audience",
+          "expect_status": 401,
+          "expect_error": "invalid_client"
+        }
+      ]
+    },
+    {
+      "_comment": "A DPoP-bound access token carries its binding as cnf.jkt. Introspection has to report the same thumbprint, otherwise a resource server that consults introspection instead of reading the token would have no way to know a proof of possession is required at all.",
+      "name": "introspection positive: a DPoP-bound access token reports its cnf.jkt binding",
+      "auth_factor": "otp",
+      "client_config": { "dpop_bound_access_tokens": true },
+      "scopes": ["openid"],
+      "expect_present": ["sub"],
+      "introspect": [
+        {
+          "name": "dpop-bound access token",
+          "token": "access_token",
+          "hint": "access_token",
+          "expect_active": true,
+          "expect_values": { "client_id": "{{client_id}}", "cnf.jkt": "{{dpop_jkt}}" }
+        }
+      ]
+    },
+    {
+      "_comment": "Deactivating a client is the operator's kill switch for a relying party that has been retired, compromised or offboarded. The api surface proves the switch can be thrown and that eSignet stores and returns INACTIVE; these ask whether eSignet then acts on it, at each of the three doors a client passes through once it has been flipped. The stages are separate cases because they fail differently: refusing to start an authorization is a check on a request, while refusing to redeem a code and refusing to spend a token are checks on credentials already issued, and a deployment could plausibly have one without the others. The reactivate case is the control for all of them -- same client, same plumbing, same flow, status restored -- so a negative that fails cannot be blamed on the deactivation machinery itself.",
+      "name": "inactive client negative: a deactivated client cannot start the flow",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "login flow failed: authorize returned eSignet's error page"
+    },
+    {
+      "_comment": "The same question at the pushed-authorization endpoint, which unlike authorize authenticates the client with a signed assertion. A deployment that checks status only on the unauthenticated path would pass the case above and fail this one.",
+      "name": "inactive client negative: a deactivated client cannot push an authorization request",
+      "auth_factor": "otp",
+      "client_config": { "require_pushed_authorization_requests": true },
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "par failed"
+    },
+    {
+      "_comment": "Deactivation partway through: the code was issued while the client was still active, and is redeemed after the switch was flipped. Taking a client out of service has to invalidate what it already holds, or an offboarded relying party keeps a working code for as long as the code lives.",
+      "name": "inactive client negative: a code issued before deactivation cannot be redeemed",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "after_authorize" },
+      "expect_login_failure": true,
+      "expect_error_contains": "token exchange failed"
+    },
+    {
+      "_comment": "The control for the three negatives above. The same status writes are made and the client ends up ACTIVE again, so the whole flow must complete. A failure here is the harness's deactivation plumbing or the client itself, not enforcement -- which is exactly what it exists to tell apart.",
+      "name": "inactive client positive: reactivating restores the whole flow",
+      "auth_factor": "otp",
+      "scopes": ["openid"],
+      "client_lifecycle": { "deactivate": "before_authorize", "reactivate": true },
+      "expect_present": ["sub"]
     }
   ]
 }

--- a/api-test/docker-compose.yml
+++ b/api-test/docker-compose.yml
@@ -94,6 +94,12 @@ services:
       - MOSIP_ESIGNET_BASE_URL
       - KEYCLOAK_TOKEN_URL
       - KEYCLOAK_CLIENT_SECRET
+      # Stands in for the whole Keycloak round-trip above, for a target that does
+      # not enforce scope (no ISSUER_URL/JWKS_URL — a locally started
+      # esignet-service, typically). Explicit opt-in, not a fallback: a real
+      # deployment must still supply KEYCLOAK_* and cannot go green on a broken
+      # IAM just because this happens to be set.
+      - ADMIN_TOKEN
       - INDIVIDUAL_ID
       - ID_TYPE
       - FLOW_CLIENT_ID

--- a/api-test/docs/configuration.md
+++ b/api-test/docs/configuration.md
@@ -3,7 +3,8 @@
 Every field the harness reads, where it belongs, and how to override it. For the layering model and
 the handful of values a first run needs, see the [README](../README.md#configuration).
 
-**Contents:** [Layering](#layering) · [Config blocks](#config-blocks) · [Selecting what runs](#selecting-what-runs) ·
+**Contents:** [Layering](#layering) · [Config blocks](#config-blocks) · [Common vs per-plugin](#common-vs-per-plugin) ·
+[Selecting what runs](#selecting-what-runs) ·
 [Environment overrides](#environment-overrides) · [TLS verification](#tls-verification)
 
 ---
@@ -53,6 +54,7 @@ what "passing" means.
 | `identity.individual_id` | The test identity. Required for every provider except `mock`. |
 | `identity.id_type` | `uin` \| `vid` \| `phone` \| `email` — selects the matching login-id tab |
 | `credentials.username` / `.password` | For the password factor |
+| `credentials.biometric` | For the bio factor. Only `mock` validates it, and accepts any non-empty value |
 | `knowledge.full_name` / `.dob` | For the knowledge-based factor |
 | `otp.*` | Static or dynamic OTP retrieval — see [MOSIP ID](mosip-id.md#dynamic-otp-retrieval) |
 | `pms.*` | MOSIP-ID-only partner binding — see [MOSIP ID](mosip-id.md#partner-registration-via-pms) |
@@ -65,6 +67,39 @@ missing `conformance.base_url`.
 
 ---
 
+## Common vs per-plugin
+
+Almost everything on this page is the same whichever plugin the deployment runs. Passing
+`-c data/config/config.<plugin>.json` sets `esignet.provider`, and that single field changes a
+short, enumerable list of things — worth knowing before you template a deployment, because it is
+exactly the part one shared config block cannot carry.
+
+**Identical for every plugin:** the target (`esignet.base_url`, `esignet.tls_verify`), the admin
+grant (`keycloak.token_url` / `client_id` / `client_secret`, or `ADMIN_TOKEN`), all of `run`, all of
+`conformance` and `plans[]`, and `api.tags` / `api.flow_client_id` / `api.tls_verify`. Template that
+once and vary only the table below.
+
+| | `mock` | `mosip` | `sunbird` |
+|---|---|---|---|
+| Default `auth_factor` | `otp` | `otp` | `kbi` — defaulted from the provider |
+| `identity.individual_id` | **not needed**: the tracked config ships a synthetic seed identity | **required** for `conformance` and `e2e` | **required** for `conformance` and `e2e` |
+| `otp.source` | `static` | **`dynamic`** — and `otp.ws_url` is then required | `static`, unused at `kbi` |
+| `credentials.username` / `.password` | ship in the tracked config | yours; unset skips the one `requires_credential` scenario rather than failing it | — its spec has no password scenarios |
+| `credentials.biometric` | the only plugin that validates it, and any non-empty value passes | leave unset — bio is a tracked known issue | — |
+| `knowledge.full_name` / `.dob` | — | — | **required** |
+| `pms.*` | — | **required** — see [MOSIP ID](mosip-id.md#partner-registration-via-pms) | — |
+| e2e client registration | eSignet `/client-mgmt/client` | **PMS** `/oauth/client` | eSignet `/client-mgmt/client` |
+| Default `e2e.spec` | `data/scenarios/e2e-scenarios.json` | `…-mosip.json` | `…-sunbird.json` |
+| Factors its spec covers | `otp`, `password`, `bio` | `otp`, `password`, `bio` | `kbi` only |
+| `@client-mgmt-pms` in `api` | not selected | selected once `pms.base_url` **and** admin auth are both present | not selected |
+| Prerequisites the harness cannot create | none beyond eSignet + Keycloak | an onboarded auth partner, a published policy, an identity with a live OTP channel, reachable mock-SMTP | a seeded registry with the KBI flow enabled |
+
+Two asymmetries that have caught people out: the config field is `pms.policy_id` but its
+environment override is **`AUTH_POLICY_ID`**; and `provider` is **never auto-detected** — pointing a
+`mock` config at a `mosip` deployment is a silently wrong run, not an error.
+
+---
+
 ## Selecting what runs
 
 All of it lives in the config; `--check` shows the resolved result before anything executes.
@@ -74,8 +109,8 @@ All of it lives in the config; `--check` shows the resolved result before anythi
 | Which plugin | The config file you pass to `-c` |
 | Which surfaces | `run.surfaces` (`conformance`, `api`, `e2e`), or `-s` for one run |
 | Which auth factor (conformance) | `esignet.auth_factor` |
-| Which conformance modules | `run.profile` (`smoke`/`full`) → `run.filter` (regex) → `run.modules` (exact list, overrides the profile) |
-| Which endpoints (`api`) | `api.tags` — `@client-mgmt`, `@client-mgmt-pms`, `@flow-execute`, `@flow-authz-neg` (comma = OR) |
+| Which conformance modules | `run.profile` (`full` by default, or `smoke`) → `run.filter` (regex) → `run.modules` (exact list, overrides the profile) |
+| Which endpoints (`api`) | `api.tags` — `@client-mgmt`, `@client-mgmt-pms`, `@flow-execute`, `@flow-authz-neg`, `@inactive-client` (comma = OR) |
 | Which e2e scenarios | `e2e.auth_factors`, plus `e2e.include` / `e2e.exclude` (regex on scenario name) |
 
 `run.skip` moves modules to a **Skipped** bucket and `run.known_issues` to a **Known** bucket with a
@@ -113,7 +148,7 @@ override**, so a container needing to change those must mount the config file it
 | `AUTH_FACTOR` | `esignet.auth_factor` | | `KEYCLOAK_CLIENT_SECRET` | `keycloak.client_secret` |
 | `ESIGNET_TLS_VERIFY` | `esignet.tls_verify` | | | |
 | `INDIVIDUAL_ID` / `ID_TYPE` | `esignet.identity.*` | | `GODOG_TAGS` | `api.tags` |
-| `TEST_USERNAME` / `TEST_PASSWORD` | `esignet.credentials.*` | | `FLOW_CLIENT_ID` | `api.flow_client_id` |
+| `TEST_USERNAME` / `TEST_PASSWORD` / `TEST_BIOMETRIC` | `esignet.credentials.*` | | `FLOW_CLIENT_ID` | `api.flow_client_id` |
 | `KBI_FULL_NAME` / `KBI_DOB` | `esignet.knowledge.*` | | `API_TLS_VERIFY` | `api.tls_verify` |
 | `OTP_SOURCE` / `TEST_OTP` | `esignet.otp.*` | | `E2E_SPEC` | `e2e.spec` |
 | `OTP_WS_URL` / `OTP_RECIPIENT_EMAIL` | `esignet.otp.*` | | `E2E_AUTH_FACTORS` | `e2e.auth_factors` |
@@ -143,6 +178,7 @@ These are not config overrides — they point the harness at files, or turn on o
 | `SUITE_WAIT_SECONDS` | How long `run-all.sh` polls the suite's readiness endpoint (default 90; 0 disables) |
 | `ESIGNET_DEBUG` | Stream each `/flow/execute` request and response to stderr |
 | `WSOTP_DEBUG` | Print the first few raw OTP WebSocket frames |
+| `ADMIN_TOKEN` | Supplies the admin bearer directly, skipping the Keycloak client-credentials call in `api`'s `@client-mgmt` steps and in `e2e`'s pre-registration. Only meaningful against a target that does not enforce scope — `esignet-service` installs no scope middleware unless both `ISSUER_URL` and `JWKS_URL` are set, so such a target never inspects the value. Explicit opt-in, not a fallback: `keycloak.*` is still required whenever this is unset |
 
 ### Plan-config path variables
 

--- a/api-test/docs/conformance-suite.md
+++ b/api-test/docs/conformance-suite.md
@@ -245,9 +245,11 @@ once, and every plan's modules land in the same report under a section of its ow
 ```
 
 - `profile`, `modules`, `filter`, `skip` and `known_issues` are per plan and fall back to `run.*`.
-- `profile: "smoke"` reads `data/conformance/<plan name>.smoke.json`. Only
-  `oidcc-test-plan.smoke.json` ships, so any other plan needs `"profile": "full"` — otherwise it
-  looks for a curated list that is not there and becomes one errored `(plan setup)` row.
+- **`profile` defaults to `full`** — every module the plan declares. Narrowing is deliberate,
+  because a partial run still reports as "conformance". `profile: "smoke"` reads
+  `data/conformance/<plan name>.smoke.json`, and only `oidcc-test-plan.smoke.json` ships: point any
+  other plan at `smoke` and it looks for a curated list that is not there, becoming one errored
+  `(plan setup)` row. The shipped configs pin the FAPI plan to `full` for exactly that reason.
 - Plan names must be unique: they key the report sections and the profile files.
 - A plan the suite refuses to create becomes one errored row and the next plan still runs, so a
   broken FAPI variant does not throw away the oidcc results.

--- a/api-test/docs/e2e-scenarios.md
+++ b/api-test/docs/e2e-scenarios.md
@@ -1,8 +1,9 @@
 # e2e scenario model
 
-The `e2e` surface reads a scenario file, registers one throwaway OIDC client, then drives each
-scenario through the full relying-party journey — `authorize` (PKCE) → login → `token`
-(`private_key_jwt`) → `userinfo` — and asserts the outcome.
+The `e2e` surface reads a scenario file, registers a throwaway OIDC client for each distinct client
+configuration the scenarios ask for, then drives each scenario through the full relying-party
+journey — optional `/oauth2/par` → `authorize` (PKCE) → login → `token` (`private_key_jwt`, with a
+DPoP proof when the client is bound) → `userinfo` — and asserts the outcome.
 
 One scenario file ships per plugin:
 
@@ -15,6 +16,7 @@ One scenario file ships per plugin:
 Selected by `e2e.spec`, or overridden for one run with `-spec`.
 
 **Contents:** [File shape](#file-shape) · [Scenario fields](#scenario-fields) · [Filtering](#filtering) ·
+[Protocol combinations](#protocol-combinations) · [Introspection](#introspection-coverage) ·
 [Consent](#consent-coverage) · [Captcha](#captcha-coverage)
 
 ---
@@ -48,19 +50,29 @@ one authentication factor against it.
 |---|---|
 | `name` | Shown in the report; also what `include`/`exclude` match against |
 | `auth_factor` | **Required.** `otp` \| `password` \| `bio` \| `kbi` — selects the ACR at the login step |
-| `credentials` | Overrides the base identity answers for this scenario only. Keys: `username`, `password`, `otp`, `fullName`, `dob`, `captchaToken` |
-| `expect_login_failure` | Negative case: **passes when login is correctly rejected**, fails if a bad credential is wrongly accepted. Omitted means positive — login must succeed |
+| `credentials` | Overrides the base identity answers for this scenario only. Keys: `username`, `password`, `biometric`, `otp`, `fullName`, `dob`, `captchaToken` |
+| `omit_credentials` | Removes these keys (after `credentials` overrides are applied) from this scenario's answers, so no value at all is submitted. Not the same as overriding to `""` — a target that accepts any non-empty value would accept an empty string too |
+| `expect_login_failure` | Negative case: **passes when the flow is correctly rejected**, fails if a bad credential or an unhardened request is wrongly accepted. Rejection anywhere in the chain counts, not only at login. Omitted means positive — the flow must complete |
+| `expect_error_contains` | On a negative case, additionally requires the rejection message to contain this substring, so the case cannot pass on an unrelated failure. Ignored without `expect_login_failure` |
+| `client_config` | The `additionalConfig` protocol switches the scenario's client is registered with — see [Protocol combinations](#protocol-combinations) |
+| `flow` | Overrides what the relying party actually sends, independently of what the client requires — see [Protocol combinations](#protocol-combinations) |
 | `scopes` | Scopes requested at `authorize` |
 | `userinfo_claims` | Per-claim request object, e.g. `{"name": {"essential": true}}` |
 | `expect_present` / `expect_absent` | Claims that must / must not come back from `userinfo` |
 | `expect_values` | Exact claim values that must match |
+| `introspect` | Introspection cases to run once the flow has completed — see [Introspection](#introspection-coverage) |
 | `consent` | How to answer the consent step and what to assert — see below |
-| `known_issue` | A reason string for an already-tracked environment gap. A **claim-assertion** failure then lands in the **Known** bucket with that reason instead of Failed, leaving the exit code alone; the failing check is still shown. It does not cover login failures, and a scenario that starts passing is still reported as passed |
+| `client_lifecycle` | Deactivates the scenario's client partway through the flow — see [Client status](#client-status-coverage) |
+| `known_issue` | A reason string for an already-tracked environment gap. A **claim-assertion** failure or a **login** failure then lands in the **Known** bucket with that reason instead of Failed, leaving the exit code alone; the failing check is still shown. A scenario that starts passing is still reported as passed |
+| `requires_credential` | Names an answer key (e.g. `password`) that must be non-empty, after `credentials` overrides are merged in, for the scenario to run at all. Left unconfigured on this deployment, the scenario is reported **SKIPPED** instead of attempting a login with no credential to use |
 
-> **Scenarios for unavailable factors are kept and reported failed, deliberately.** An ACR with no
-> working credential on the target (`bio`, say, or `password` where the user is not seeded) stays in
-> the file and is reported **FAILED** with a clear reason rather than quietly omitted. It goes green
-> once real credentials exist, and stays visible until then.
+> **Scenarios for unavailable factors are kept and reported failed, deliberately** — unless marked
+> otherwise. An ACR with no working credential on the target (`bio`, say, or `password` where the
+> user is not seeded) stays in the file and is reported **FAILED** with a clear reason rather than
+> quietly omitted, and goes green once real credentials exist. The two deliberate exceptions are
+> `known_issue`, for a gap that is out of scope for now (kept visible in the Known bucket rather than
+> Failed), and `requires_credential`, for a factor that legitimately varies by deployment (kept out of
+> the Failed count as SKIPPED rather than failing every run that hasn't seeded it).
 
 ---
 
@@ -77,11 +89,140 @@ one authentication factor against it.
 
 A filter matching zero scenarios is an **error**, not an empty run.
 
-> **The consent scenarios are order-dependent.** One client is registered per run and every scenario
-> shares it, so each successful login stores a consent record. The consent-reuse case asserts "no
-> prompt" precisely because the identical-request case ran immediately before it. Narrowing a run
-> with `include` so an earlier case is skipped can therefore break it. A build-time test enforces
-> these invariants on the shipped files.
+> **The consent scenarios are order-dependent.** Scenarios that name no `client_config` all share
+> one registered client, so each successful login stores a consent record. The consent-reuse case
+> asserts "no prompt" precisely because the identical-request case ran immediately before it.
+> Narrowing a run with `include` so an earlier case is skipped can therefore break it. A build-time
+> test enforces these invariants on the shipped files.
+
+---
+
+## Protocol combinations
+
+eSignet exposes three protocol switches in a client's `additionalConfig`, enforced by the engine at
+`authorize`, `/oauth2/par`, `token` and `userinfo` respectively:
+
+| Switch | What the client then requires |
+|---|---|
+| `require_pkce` | A `code_challenge` on the authorization request, and `S256` — the `plain` method is refused |
+| `require_pushed_authorization_requests` | The request pushed to `/oauth2/par` first; a direct `authorize` is refused |
+| `dpop_bound_access_tokens` | A DPoP proof (RFC 9449) at `token`, and the resulting token presented with the `DPoP` scheme plus a fresh proof at `userinfo` |
+
+A scenario declares the client it wants; the harness registers **one client per distinct
+`client_config`**, on first use, and reuses it for every later scenario asking for the same one. A
+scenario with no `client_config` gets the plain unhardened client — the same one it always got.
+
+```jsonc
+{ "name": "protocol positive: PKCE + PAR + DPoP completes to userinfo",
+  "auth_factor": "otp",
+  "client_config": {
+    "require_pkce": true,
+    "require_pushed_authorization_requests": true,
+    "dpop_bound_access_tokens": true
+  },
+  "scopes": ["openid"], "expect_present": ["sub"] }
+```
+
+By default the relying party does whatever the client requires: it pushes when PAR is required,
+proves possession when the client is DPoP-bound, and always sends `S256` PKCE. That is all a
+**positive** combination case needs.
+
+A **negative** case is written by making the RP disagree with the client, through `flow`:
+
+| `flow` field | Effect |
+|---|---|
+| `use_par` | Force the push on or off, against what the client requires |
+| `use_dpop` | Force proofs on or off |
+| `pkce` | `S256` (default), `plain`, or `none` |
+| `dpop_key_mismatch` | Redeem the code with a proof from a *different* key than the one bound at PAR |
+| `bearer_at_userinfo` | Present a DPoP-bound token with the `Bearer` scheme |
+
+```jsonc
+{ "name": "protocol negative: DPoP-bound client rejects a token call with no proof",
+  "auth_factor": "otp",
+  "client_config": { "dpop_bound_access_tokens": true },
+  "flow": { "use_dpop": false },
+  "expect_login_failure": true,
+  "expect_error_contains": "token exchange failed",
+  "scopes": ["openid"] }
+```
+
+Alongside the claim checks, these scenarios add protocol assertions to the report: the PAR
+`request_uri` is in the RFC 9126 URN namespace, `token_type` comes back as `DPoP`, and the access
+token's `cnf.jkt` is the thumbprint of the key that proved possession.
+
+**What they need from the deployment.** PAR cases need discovery to advertise
+`pushed_authorization_request_endpoint`; DPoP cases read `dpop_signing_alg_values_supported` and
+sign with `PS256` or `RS256`, whichever it lists. A deployment advertising neither still runs every
+other scenario — the affected ones fail with an explicit message rather than being skipped.
+
+> **mosipid caveat.** With the `mosip` plugin, clients are registered through PMS `/oauth/client`,
+> not eSignet client-mgmt. The harness sends `additionalConfig` on that request, but whether PMS
+> forwards the switches to eSignet is PMS's call. If it drops them, the positives still pass (an
+> unhardened client happily accepts a hardened flow) and the **negatives** are what expose it, by
+> not being rejected.
+
+Registration-side validation of these same keys — allowlisting, type checking, the update path — is
+covered by the `api` surface in `additional-config.feature`, where no login is needed.
+
+---
+
+## Introspection coverage
+
+`/oauth2/introspect` (RFC 7662) answers *is this token still good, and what is it for*. It takes the
+token as a form parameter, authenticates the caller with `private_key_jwt` exactly like `token`, and
+returns `active` either way: a token it never issued is reported **inactive rather than as an
+error**, and that answer carries no other metadata — otherwise introspection becomes an oracle for
+guessed tokens (RFC 7662 §2.2, §4).
+
+Reaching it needs a token the deployment actually issued, so the scenarios add `introspect` to a
+flow that has already completed through `userinfo`. Each entry is one POST, and prefixes its own
+assertions with its `name`, so a row says *which* case failed:
+
+```json
+{ "name": "introspection positive: an issued access token is reported active …",
+  "auth_factor": "otp",
+  "scopes": ["openid", "profile"],
+  "expect_present": ["sub"],
+  "introspect": [
+    { "name": "access token with hint",
+      "token": "access_token", "hint": "access_token",
+      "expect_active": true,
+      "expect_present": ["client_id", "sub", "scope", "iss", "exp", "iat"],
+      "expect_values": { "client_id": "{{client_id}}", "sub": "{{sub}}" } }
+  ]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `name` | Labels the case in the report; defaults to `<token>/<client_auth>` |
+| `token` | What is submitted: `access_token` (default) \| `id_token` \| `unissued` (a value this deployment never minted) \| `none` (the parameter is left out) |
+| `hint` | `token_type_hint`. Omitted when empty — RFC 7662 §2.1 makes it an optimization the server may ignore, so a *mismatched* hint must still resolve the token |
+| `client_auth` | `private_key_jwt` (default) \| `no_assertion` (a `client_id` alone) \| `wrong_key` (an assertion signed with a key the client never registered) \| `wrong_audience` (a correctly signed assertion made out to somebody else) |
+| `expect_status` | HTTP status the call must answer with. Defaults to `200` |
+| `expect_active` | Asserts the `active` member. Left unset, nothing is asserted about it — which is what an error case wants, since a 400/401 body has none |
+| `expect_present` / `expect_absent` | Response members that must / must not be there |
+| `expect_values` | Exact member values. Dotted paths work (`cnf.jkt`), and an array member matches when any element does (RFC 7662 lets `aud` be either) |
+| `expect_error` | The OAuth `error` member a rejection must carry |
+
+Four values are substituted from what the run obtained, since a spec file cannot know them ahead of
+time: `{{client_id}}`, `{{issuer}}`, `{{sub}}` (the `id_token` subject) and `{{dpop_jkt}}` (the
+thumbprint a DPoP-bound access token is bound to). One check is added rather than declared: an
+`active` token whose `exp` is already in the past fails, because a resource server would otherwise
+accept a token the authorization server considers dead.
+
+The negatives are written by pointing one axis away from the positive — an unissued token behind
+good client authentication, or a good token behind an assertion that does not verify. Client
+authentication is checked **first**, so `wrong_key` and `wrong_audience` are refused before the
+token is ever looked at.
+
+**What it needs from the deployment.** Discovery must advertise `introspection_endpoint`; without it
+the introspection scenarios fail with an explicit message and everything else still runs.
+
+Endpoint-shape validation that needs no token — a request naming no client, a `client_id` with no
+assertion, an unverifiable assertion, and the endpoint not being exposed over `GET` — is covered by
+the `api` surface in `introspect.feature`, where no login is needed.
 
 ---
 
@@ -117,6 +258,73 @@ The `consent` block on an e2e scenario:
 
 Consent-record **expiry** re-prompting is not covered: it needs control over the deployment's
 consent validity period, which the harness does not have.
+
+---
+
+## Client status coverage
+
+A client's status is the operator's kill switch: `INACTIVE` is how a relying party that has been
+retired, compromised or offboarded is taken out of service without deleting its record. That the
+switch can be *thrown* is the api surface's business (`client-mgmt/client-status.feature`); whether
+eSignet then *acts* on it is this surface's, because it takes a real client through real endpoints.
+
+```jsonc
+"client_lifecycle": {
+  "deactivate": "before_authorize",  // before_authorize | after_authorize | after_token
+  "reactivate": false                // set back to ACTIVE right after, before the flow continues
+}
+```
+
+The stage names the door the client is standing at when the switch is flipped, and each asks a
+different question:
+
+| Stage | Question | Rejection expected at |
+|---|---|---|
+| `before_authorize` | May a deactivated client start an authorization at all? | `authorize`, or `par` for a PAR-required client |
+| `after_authorize` | May a code issued while the client was active still be redeemed? | `token` |
+| `after_token` | Does anything still consult client status once a token is issued? | nothing — see below |
+
+They are separate scenarios rather than one switch because they fail differently — the first is a
+check on a request, the second a check on a credential already issued — and a deployment could
+plausibly have one without the other. Pair each with `expect_error_contains` naming the specific
+call that must be the one to refuse: `"par failed"` and `"token exchange failed"` can only be
+raised by that call itself, so their presence already proves rejection happened at that door and
+nowhere earlier.
+
+> **`after_token` ships with no scenario, on purpose.** The two stages above are enforceable because
+> both `authorize` and `token` authenticate the *client* — deactivation is visible to them. `userinfo`
+> authenticates only the bearer token and never looks at the client, so there is no point in that
+> request at which an `INACTIVE` status could be noticed. Expecting a rejection there asserts
+> something OAuth does not promise: an issued access token stays valid until it expires or is
+> explicitly revoked (RFC 7009), and deactivating its client is neither. A scenario asserting
+> otherwise was removed for that reason — it was reporting a spec-conformant response as a defect.
+> The stage remains available for a deployment that has *chosen* to enforce status at userinfo and
+> wants to prove it, which is a local policy claim rather than a protocol one.
+
+`before_authorize` has no such call of its own — the whole `authorize → flow/execute → callback`
+journey is one opaque `driver.Run`, and *any* failure inside it — a bad OTP, an unavailable
+authentication factor, a transport error — surfaces as the same generic `"login flow failed: ..."`.
+Asserting on that prefix alone proves nothing: a client wrongly let past authorize can still fail
+the login for an unrelated reason and the scenario passes anyway, crediting enforcement that never
+happened. Assert on `"login flow failed: authorize returned eSignet's error page"` instead — the
+driver only produces that text when eSignet bounced the authorize hop to its own `/error` route
+before login was ever reached (see `AuthorizeErrorCode` in `internal/esignet/driver.go`), so its
+presence is what actually proves the rejection happened here and not somewhere downstream.
+
+`reactivate` is the **positive control**: the same status writes run, the client ends up `ACTIVE`
+again, and the flow must complete. A negative is only meaningful next to it — without the control,
+a rejection could be the deactivation plumbing or the client itself rather than enforcement.
+
+Two mechanics are worth knowing:
+
+- **The client is dedicated, never pooled.** A scenario carrying `client_lifecycle` registers a
+  client of its own. Deactivating a shared client would break every later scenario using that
+  config, and would do so silently — they would simply stop being able to log in, for a reason none
+  of them names.
+- **Each status write is read back** from `GET /client-mgmt/client/{id}` and asserted, for every
+  plugin including `mosip` (whose clients are registered through PMS, but whose eSignet record is
+  what the engine actually resolves). A patch response that echoed `INACTIVE` over a record that
+  stayed `ACTIVE` would otherwise leave every assertion below it testing an active client.
 
 ---
 

--- a/api-test/docs/troubleshooting.md
+++ b/api-test/docs/troubleshooting.md
@@ -55,6 +55,7 @@ Its detail line names the setting to supply.
 | `create plan HTTP 400 … server_metadata` | Remove `server_metadata` from that plan's `variant` — the plan sets it itself |
 | One errored `(plan setup)` row | The suite refused to create that plan: an unreadable `config_file`, a rejected variant, or `profile: "smoke"` with no curated list for that plan. Remaining plans still run |
 | Module stuck, then `timeout … WAITING` | The login did not complete, or the implicit submit never fired — check the flow trace in the report |
+| `The user was authenticated on the initial visit to login page`, or a module waiting for `error=access_denied` | A few modules need driving that is not the happy path, and the harness carries a per-module table for them (`moduleBehaviors` in `internal/conformance/run.go`): `user-rejects-authentication` denies consent and follows the resulting error redirect back to the client, and `par-ensure-reused-request-uri…` stops at the login page on its first visit so the same `request_uri` can be driven a second time. A new module needing either has to be added there |
 | `ESIGNET_BASE_URL_MISMATCH` | `esignet.base_url` disagrees with the authorize URL the suite discovered. Either correct it or leave it empty for a conformance-only run |
 | Image pull fails for `server` / `httpd` | The pinned suite tag was pruned. Pick a current one from the [releases page](https://gitlab.com/openid/conformance-suite/-/releases) and set `SUITE_IMAGE_TAG` |
 
@@ -78,7 +79,9 @@ Full setup: [Conformance suite setup](conformance-suite.md).
 | Symptom | Likely cause |
 |---|---|
 | `no configured answer for flow input(s): …` | The flow asked for an input with no configured value. Expected for factors you have not credentialed; add them under `esignet.credentials` / `.knowledge`, or the scenario's `credentials` |
-| Login loops `INCOMPLETE`, then fails | The submitted credential is not authenticating — the user is not seeded, or the password is wrong. This is distinct from a clean rejection |
+| `flow step rejected: FET-… (…)` | The deployment refused the submitted credential and left the flow `INCOMPLETE`. The driver reports the code rather than re-submitting the same step, which on the OTP path would spend a real attempt per retry and can trip a max-attempts lockout. Usually an unseeded user or a wrong password — distinct from a clean, asserted rejection |
+| `authorize returned eSignet's error page: …` | eSignet refused the authorize request and sent the browser to its own `/error` route instead of redirecting to the client. The named `errorCode` is the server's reason — a required `code_challenge`, a PAR-only client approached directly, an unregistered `redirect_uri` |
+| `unexpected alg "…" (want RS256 or PS256)` | A signed `userinfo` or ID token was issued under an algorithm the harness does not verify. Both RSA families are accepted; anything else is a target-side registration question |
 | A negative case fails | Read it the right way round: `expect_login_failure` cases **pass when login is rejected**. A failure means a bad credential was wrongly *accepted* |
 | A filter runs nothing | A filter matching zero scenarios is an error, not an empty run — a green "0 of 0" is indistinguishable from a real pass |
 | The consent-reuse case fails after narrowing a run | Those cases are order-dependent; see [e2e scenario model](e2e-scenarios.md#filtering) |

--- a/api-test/internal/config/config.go
+++ b/api-test/internal/config/config.go
@@ -143,6 +143,9 @@ type Identity struct {
 type Credentials struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
+	// Biometric is the value submitted as a biometric capture. Only mock
+	// validates it, and accepts any non-empty value as a successful capture.
+	Biometric string `json:"biometric"`
 }
 
 type Knowledge struct {
@@ -193,8 +196,12 @@ type E2E struct {
 type Run struct {
 	// Surfaces selects which test surfaces this run executes: any of
 	// conformance, api, e2e. Defaults to all three.
-	Surfaces            []string     `json:"surfaces"`
-	Modules             []string     `json:"modules"`
+	Surfaces []string `json:"surfaces"`
+	Modules  []string `json:"modules"`
+	// Profile selects how many conformance modules run: full (every module the
+	// plan declares) or smoke (the curated list in
+	// data/conformance/<plan>.smoke.json). Defaults to full — narrowing the run
+	// is a deliberate act, because a partial run still reports as "conformance".
 	Profile             string       `json:"profile"`
 	Filter              string       `json:"filter"`
 	Skip                []string     `json:"skip"`         // modules to not run at all -> Skipped bucket
@@ -403,8 +410,10 @@ func (c *Config) ValidateSurface(name string) error {
 		}
 		// Unlike api, e2e cannot degrade: it registers a throwaway OIDC client
 		// before it can drive anything, and that needs the admin grant.
-		if c.Keycloak.TokenURL == "" || c.Keycloak.ClientID == "" || c.Keycloak.ClientSecret == "" {
-			return fmt.Errorf("keycloak.token_url/client_id/client_secret (KEYCLOAK_*) are required for the e2e surface — it registers a test client before running")
+		// ADMIN_TOKEN also satisfies this; checked here too so a missing setting fails with a clear message instead of a 401 mid-run.
+		if os.Getenv("ADMIN_TOKEN") == "" &&
+			(c.Keycloak.TokenURL == "" || c.Keycloak.ClientID == "" || c.Keycloak.ClientSecret == "") {
+			return fmt.Errorf("keycloak.token_url/client_id/client_secret (KEYCLOAK_*) are required for the e2e surface — it registers a test client before running (or set ADMIN_TOKEN for a target that does not enforce scope)")
 		}
 		if c.E2E.Spec == "" {
 			return fmt.Errorf("e2e.spec (E2E_SPEC) is required for the e2e surface — no default known for provider %q", c.Esignet.Provider)
@@ -462,6 +471,7 @@ func (c *Config) applyEnv() (int, error) {
 	envStr(&c.Esignet.Identity.IDType, "ID_TYPE", &n)
 	envStr(&c.Esignet.Credentials.Username, "TEST_USERNAME", &n)
 	envStr(&c.Esignet.Credentials.Password, "TEST_PASSWORD", &n)
+	envStr(&c.Esignet.Credentials.Biometric, "TEST_BIOMETRIC", &n)
 	envStr(&c.Esignet.Knowledge.FullName, "KBI_FULL_NAME", &n)
 	envStr(&c.Esignet.Knowledge.DOB, "KBI_DOB", &n)
 	envStr(&c.Esignet.OTP.Source, "OTP_SOURCE", &n)
@@ -631,8 +641,13 @@ func (c *Config) defaults() {
 	if c.Esignet.OTP.Value == "" {
 		c.Esignet.OTP.Value = "111111"
 	}
+	// full, not smoke: a run that silently grades a curated subset and reports
+	// it as "conformance" overstates what was checked. Only oidcc-test-plan
+	// ships a smoke list, so smoke was never a usable default for the FAPI plan
+	// anyway — every shipped config already had to override it back to full.
+	// Narrow deliberately with run.profile or plans[].profile.
 	if c.Run.Profile == "" {
-		c.Run.Profile = "smoke"
+		c.Run.Profile = "full"
 	}
 	if c.Run.PollIntervalSeconds == 0 {
 		c.Run.PollIntervalSeconds = 2
@@ -765,6 +780,7 @@ func (c *Config) Redacted() string {
 	// The username is a login identifier on every plugin but mock, and the wire trace already masks it.
 	clone.Esignet.Credentials.Username = mask(clone.Esignet.Credentials.Username)
 	clone.Esignet.Credentials.Password = mask(clone.Esignet.Credentials.Password)
+	clone.Esignet.Credentials.Biometric = mask(clone.Esignet.Credentials.Biometric)
 	// Authenticator + personal data: reports are archived as CI artifacts.
 	clone.Esignet.OTP.Value = mask(clone.Esignet.OTP.Value)
 	clone.Esignet.OTP.RecipientEmail = mask(clone.Esignet.OTP.RecipientEmail)

--- a/api-test/internal/config/config_test.go
+++ b/api-test/internal/config/config_test.go
@@ -694,3 +694,46 @@ func TestLoadAcceptsAPIBlock(t *testing.T) {
 		t.Errorf("api block not applied: flow_client_id=%q tls_verify=%v", c.API.FlowClientID, c.API.TLSVerify)
 	}
 }
+
+// A conformance run that is not told otherwise must grade every module the plan
+// declares. The default was smoke, which quietly reported a curated subset as
+// "conformance" — and which only oidcc-test-plan even had a list for.
+func TestProfileDefaultsToFull(t *testing.T) {
+	cfg := writeLayers(t,
+		`{"conformance":{"base_url":"https://suite.example"},
+		  "plan":{"config_file":$PLAN},
+		  "esignet":{"provider":"mosip","auth_factor":"otp",
+		             "identity":{"individual_id":"x","id_type":"uin"}},
+		  "run":{"surfaces":["conformance"]}}`, "")
+
+	c, err := load(t, cfg)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.Run.Profile != "full" {
+		t.Errorf("run.profile = %q, want full", c.Run.Profile)
+	}
+	// A plan that names no profile of its own inherits it, so the default has to
+	// reach the selection the conformance surface actually runs from.
+	if got := c.Selection(c.Plans[0]).Profile; got != "full" {
+		t.Errorf("selection profile = %q, want full", got)
+	}
+}
+
+// Narrowing stays available: an explicit smoke must still win over the default.
+func TestProfileSmokeStillOverrides(t *testing.T) {
+	cfg := writeLayers(t,
+		`{"conformance":{"base_url":"https://suite.example"},
+		  "plan":{"config_file":$PLAN},
+		  "esignet":{"provider":"mosip","auth_factor":"otp",
+		             "identity":{"individual_id":"x","id_type":"uin"}},
+		  "run":{"surfaces":["conformance"],"profile":"smoke"}}`, "")
+
+	c, err := load(t, cfg)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.Run.Profile != "smoke" {
+		t.Errorf("run.profile = %q, want smoke", c.Run.Profile)
+	}
+}

--- a/api-test/internal/conformance/run.go
+++ b/api-test/internal/conformance/run.go
@@ -20,14 +20,56 @@ import (
 	"github.com/mosip/esignet/api-test/internal/wsotp"
 )
 
-// unsupportedModuleHints flag modules the harness can't drive in v1 (they need
-// browser-fragment / QR / logout / reject handling). Matched as substrings.
+// unsupportedModuleHints flag modules the harness can't drive in v1 (browser-fragment / QR / logout / reject handling), matched as substrings.
 var unsupportedModuleHints = map[string]string{
 	"logout":       "logout",
 	"rp-initiated": "logout",
 	"qr":           "qr",
 	"backchannel":  "backchannel",
 	"ciba":         "ciba",
+}
+
+// moduleBehavior describes the non-default driving a module needs; the zero value is the ordinary happy path.
+type moduleBehavior struct {
+	// consent answers the consent step; the zero value approves everything.
+	consent esignet.ConsentPolicy
+	// followRejection posts the flow's errorAssertion so the RP receives the error redirect instead of the flow being reported as merely failed.
+	followRejection bool
+	// loadOnlyVisits is how many leading browser visits load the login page without authenticating.
+	loadOnlyVisits int
+	// maxVisits is how many times the same browser URL may be driven; 0 means 1.
+	maxVisits int
+}
+
+// moduleBehaviors maps a module-name substring to the behaviour it needs, matched the same way as unsupportedModuleHints.
+var moduleBehaviors = map[string]moduleBehavior{
+	// The suite requires "the tester MUST press 'cancel' ... or deny consent"; denying every element ends the flow in the ERROR redirect it wants.
+	"user-rejects-authentication": {
+		consent:         esignet.ConsentPolicy{DenyAll: true},
+		followRejection: true,
+	},
+	// The first visit must reach the login page and stop, or the suite aborts with "authenticated on the initial visit"; the second visit completes the login.
+	"par-ensure-reused-request-uri-prior-to-auth-completion-succeeds": {
+		loadOnlyVisits: 1,
+		maxVisits:      2,
+	},
+}
+
+// behaviorFor returns the behaviour configured for a module, or the zero value.
+func behaviorFor(module string) moduleBehavior {
+	for hint, b := range moduleBehaviors {
+		if strings.Contains(module, hint) {
+			return b
+		}
+	}
+	return moduleBehavior{}
+}
+
+func (b moduleBehavior) visitBudget() int {
+	if b.maxVisits < 1 {
+		return 1
+	}
+	return b.maxVisits
 }
 
 type Orchestrator struct {
@@ -45,8 +87,7 @@ func New(cfg *config.Config, logf func(string, ...any)) *Orchestrator {
 	}
 }
 
-// RunResult bundles the per-module results. Suite plumbing calls (available,
-// create-plan, polls, deliver) are not reported — use the harness logs.
+// RunResult bundles the per-module results; suite plumbing calls (available, create-plan, polls, deliver) are not reported — use the harness logs.
 type RunResult struct {
 	Modules []result.ModuleResult
 }
@@ -58,23 +99,24 @@ func (o *Orchestrator) Run(ctx context.Context) (*RunResult, error) {
 	// Preflight: suite reachable.
 	if err := o.client.Available(ctx); err != nil {
 		o.client.TakeCalls()
-		return out, fmt.Errorf("ENV_NOT_READY: %w", err)
+		return out, o.envNotReady(out, err)
 	}
 	o.logf("suite is available")
 	o.client.TakeCalls() // discard the availability call
 
 	answers := esignet.BuildAnswers(o.cfg.Esignet)
-	// Preferred actions: the auth-factor (ACR) choice AND the login-ID-type
-	// choice (uin/vid/phone), since eSignet asks for both in the OTP flow.
+	// Preferred actions: the auth-factor (ACR) choice AND the login-ID-type choice, since eSignet asks for both in the OTP flow.
 	preferred := append(esignet.AuthFactorTokens(o.cfg.Esignet.AuthFactor), esignet.IDTypeTokens(o.cfg.Esignet.Identity.IDType)...)
 	// esignet.tls_verify, not conformance.tls_verify: this driver talks to the real deployment.
 	driver := esignet.New(answers, preferred, o.cfg.Esignet.TLSVerify, time.Duration(o.cfg.Run.TimeoutSeconds)*time.Second)
+	// Also passed separately: the id-type is matched against an action's nextNode, the only thing distinguishing login-id tabs that submit under the same ref.
+	driver.UseIDType(esignet.IDTypeTokens(o.cfg.Esignet.Identity.IDType))
 
 	// Dynamic OTP: connect the mock-SMTP listener once and share it across all modules.
 	if o.cfg.Esignet.OTP.Source == "dynamic" {
 		lst := wsotp.NewListener(o.cfg.Esignet.OTP.WSURL, o.cfg.Esignet.TLSVerify)
 		if err := lst.Start(ctx); err != nil {
-			return out, fmt.Errorf("ENV_NOT_READY: %w", err)
+			return out, o.envNotReady(out, err)
 		}
 		defer lst.Close()
 		timeout := time.Duration(o.cfg.Run.TimeoutSeconds) * time.Second
@@ -128,8 +170,7 @@ func (o *Orchestrator) runPlan(ctx context.Context, p config.Plan, driver *esign
 	}
 	o.logf("selected %d module(s) for profile=%q filter=%q", len(selected), sel.Profile, sel.Filter)
 
-	// known_issues and skip modules are separated out before execution: they are
-	// not run, they just get a report row in the Known / Skipped bucket.
+	// known_issues and skip modules are separated out before execution: not run, just a report row in the Known / Skipped bucket.
 	known := knownMap(sel.KnownIssues)
 	skip := nameSet(sel.Skip)
 
@@ -158,6 +199,37 @@ func (o *Orchestrator) runPlan(ctx context.Context, p config.Plan, driver *esign
 	return false, nil
 }
 
+// envNotReady records a surface-wide precondition failure as one report row per
+// configured plan and returns the error to abort on.
+//
+// Returning the bare error is not enough: cmd/conformance only writes a partial
+// report when the run produced at least one module, so a precondition that fails
+// before any plan is created (an unreachable suite, most often) left the surface
+// with no report at all — and run-all.sh could then say only that it "crashed
+// before writing one", with the actual cause visible nowhere but the container
+// log. Every other surface degrades to a visible ENV_NOT_READY row; this one now
+// does too.
+func (o *Orchestrator) envNotReady(out *RunResult, err error) error {
+	names := o.cfg.PlanNames()
+	// A config with no plans cannot reach here today (ValidateSurface rejects it),
+	// but a row with no plan name still beats silently reporting nothing.
+	if len(names) == 0 {
+		names = []string{""}
+	}
+	for _, name := range names {
+		out.Modules = append(out.Modules, result.ModuleResult{
+			Surface:        result.SurfaceConformance,
+			Plugin:         o.cfg.Esignet.Provider,
+			Plan:           name,
+			Module:         "(surface not run)",
+			HarnessOutcome: result.OutcomeEnvNotReady,
+			OutcomeDetail:  err.Error(),
+			Status:         "NOT_RUN",
+		})
+	}
+	return fmt.Errorf("ENV_NOT_READY: %w", err)
+}
+
 // planErrorResult is the report row for a plan that never got as far as running a module.
 func planErrorResult(planName, provider string, err error) result.ModuleResult {
 	return result.ModuleResult{
@@ -171,8 +243,7 @@ func planErrorResult(planName, provider string, err error) result.ModuleResult {
 	}
 }
 
-// gatedResult builds a not-run report row for a module excluded by config
-// (known_issues -> Known bucket, skip -> Skipped bucket).
+// gatedResult builds a not-run report row for a module excluded by config (known_issues -> Known bucket, skip -> Skipped bucket).
 func gatedResult(plan, provider string, m Module, outcome, detail string) result.ModuleResult {
 	return result.ModuleResult{
 		Surface:        result.SurfaceConformance,
@@ -245,12 +316,21 @@ func (o *Orchestrator) runModule(ctx context.Context, plan *PlanResponse, m Modu
 
 	deadline := time.Now().Add(time.Duration(o.cfg.Run.TimeoutSeconds) * time.Second)
 	poll := time.Duration(o.cfg.Run.PollIntervalSeconds) * time.Second
-	// A zero interval would turn the wait below into a hot loop that hammers the
-	// suite for the whole timeout window (wsotp.WaitOTP applies the same floor).
+	// A zero interval would turn the wait below into a hot loop hammering the suite for the whole timeout window (wsotp.WaitOTP applies the same floor).
 	if poll <= 0 {
 		poll = time.Second
 	}
-	handled := map[string]bool{}
+	// One Driver is shared across every module, so both switches are restored before returning, or a stray DenyAll would deny consent for later modules.
+	behavior := behaviorFor(m.TestModule)
+	driver.SetConsentPolicy(behavior.consent)
+	driver.SetFollowRejection(behavior.followRejection)
+	defer func() {
+		driver.SetConsentPolicy(esignet.ConsentPolicy{})
+		driver.SetFollowRejection(false)
+	}()
+
+	visits := map[string]int{}
+	visitCount := 0
 
 	for {
 		info, err := o.client.GetInfo(ctx, test.ID)
@@ -269,11 +349,12 @@ func (o *Orchestrator) runModule(ctx context.Context, plan *PlanResponse, m Modu
 			res.HarnessError = err.Error()
 			break
 		}
-		pending := pendingURLs(runner.Browser, handled)
+		pending := pendingURLs(runner.Browser, visits, behavior.visitBudget())
 		if len(pending) > 0 {
 			for _, u := range pending {
-				o.driveOne(ctx, driver, u, &res)
-				handled[u] = true
+				o.driveOne(ctx, driver, u, &res, visitCount < behavior.loadOnlyVisits)
+				visits[u]++
+				visitCount++
 				if res.HarnessError != "" {
 					break
 				}
@@ -296,8 +377,7 @@ func (o *Orchestrator) runModule(ctx context.Context, plan *PlanResponse, m Modu
 
 	// Final verdict: re-fetch in case the loop exited before reaching a terminal status.
 	if info, err := o.client.GetInfo(ctx, test.ID); err == nil {
-		// Only overwrite with a populated field: a transient/partial payload
-		// would otherwise blank an already-captured verdict into a report dash.
+		// Only overwrite with a populated field, or a transient/partial payload would blank an already-captured verdict into a report dash.
 		if info.Status != "" {
 			res.Status = info.Status
 		}
@@ -307,25 +387,38 @@ func (o *Orchestrator) runModule(ctx context.Context, plan *PlanResponse, m Modu
 	} else if res.HarnessError == "" {
 		res.HarnessError = fmt.Sprintf("final GetInfo: %v", err)
 	}
-	// Full condition log (best effort): rendered UI-style in the report, and
-	// distilled into the FAILURE/WARNING summary.
+	// Full condition log (best effort): rendered UI-style in the report, and distilled into the FAILURE/WARNING summary.
 	if raw, err := o.client.GetRawLog(ctx, test.ID); err == nil {
 		res.LogItems = buildLogItems(raw)
 		res.FailedConditions = failedFromItems(res.LogItems)
 	}
 
-	// The report shows only eSignet-thunder traffic; discard the suite plumbing
-	// calls (create_test, polls, info, log, deliver) captured on the client.
+	// The report shows only eSignet-thunder traffic; discard suite plumbing calls (create_test, polls, info, log, deliver) captured on the client.
 	o.client.TakeCalls()
 	res.Calls = result.CollapseCalls(res.Calls)
 	return res
 }
 
 // driveOne drives a single authorize URL through eSignet and hands the code back to the suite.
-func (o *Orchestrator) driveOne(ctx context.Context, driver *esignet.Driver, authorizeURL string, res *result.ModuleResult) {
+func (o *Orchestrator) driveOne(ctx context.Context, driver *esignet.Driver, authorizeURL string,
+	res *result.ModuleResult, loadOnly bool) {
 	base, err := o.esignetBase(authorizeURL)
 	if err != nil {
 		res.HarnessError = err.Error()
+		return
+	}
+
+	// A load-only visit stops at the login page on purpose, so there is no assertion and no redirect to deliver — the suite drives the next visit.
+	if loadOnly {
+		flow := driver.RunToLogin(ctx, base, authorizeURL)
+		res.FlowTrace.AuthorizeStatus = flow.AuthorizeStatus
+		res.FlowTrace.Steps = append(res.FlowTrace.Steps, flow.Steps...)
+		res.Calls = append(res.Calls, flow.Calls...)
+		if flow.Error != "" {
+			res.HarnessError = "eSignet flow: " + flow.Error
+		} else if !flow.LoginReached {
+			res.HarnessError = "eSignet flow: login page not reached on the load-only visit"
+		}
 		return
 	}
 
@@ -430,8 +523,7 @@ type smokeFile struct {
 	Modules      []string `json:"modules"`
 }
 
-// loadSmokeProfile reads the smoke module list for one plan. The file is keyed
-// by plan name, so a multi-plan run needs one per plan that uses profile=smoke.
+// loadSmokeProfile reads the smoke module list for one plan; the file is keyed by plan name, so a multi-plan run needs one per plan using profile=smoke.
 func loadSmokeProfile(planName string) ([]string, error) {
 	path := filepath.Join("data", "conformance", planName+".smoke.json")
 	data, err := os.ReadFile(path)
@@ -449,10 +541,7 @@ func loadSmokeProfile(planName string) ([]string, error) {
 }
 
 func unsupportedReason(module string, variant map[string]any) string {
-	// form_post is not a module name: the suite runs the ordinary modules and
-	// carries the mode in the plan variant, so a name-substring hint would never
-	// fire. The harness reads the code from the redirect query, which a form-post
-	// response body does not have.
+	// form_post is not a module name; it carries in the plan variant, and the harness reads the code from the redirect query, which a form-post body lacks.
 	if mode, ok := variant["response_mode"].(string); ok && strings.EqualFold(mode, "form_post") {
 		return "form_post"
 	}
@@ -465,30 +554,32 @@ func unsupportedReason(module string, variant map[string]any) string {
 	return ""
 }
 
-func pendingURLs(b Browser, handled map[string]bool) []string {
+// pendingURLs returns the browser URLs still to be driven, capped per-URL by budget; a budget above the default of 1 lets a URL be redriven, which par-ensure-reused-request-uri needs since its first visit deliberately does not authenticate.
+func pendingURLs(b Browser, visits map[string]int, budget int) []string {
+	if budget < 1 {
+		budget = 1
+	}
 	visited := map[string]bool{}
 	for _, v := range b.Visited {
 		visited[v] = true
 	}
 	var out []string
 	for _, u := range b.URLs {
-		if !visited[u] && !handled[u] {
+		if !visited[u] && visits[u] < budget {
 			out = append(out, u)
 		}
 	}
 	return out
 }
 
-// primaryLogKeys are the log-entry fields rendered as columns (or dropped as
-// internal noise); everything else becomes an expandable detail row.
+// primaryLogKeys are the log-entry fields rendered as columns (or dropped as internal noise); everything else becomes an expandable detail row.
 var primaryLogKeys = map[string]bool{
 	"time": true, "src": true, "msg": true, "result": true, "requirements": true,
 	"_id": true, "testId": true, "testOwner": true, "seq": true,
 	"blockId": true, "startBlock": true, // internal block markers
 }
 
-// detailOrder ranks the common HTTP detail fields so the report shows them in
-// the same order as the suite UI (status, headers, body) rather than alphabetically.
+// detailOrder ranks the common HTTP detail fields so the report shows them in suite-UI order (status, headers, body) rather than alphabetically.
 var detailOrder = map[string]int{
 	"http": 0, "request_method": 1, "request_url": 2, "request_headers": 3, "request_body": 4,
 	"response_status_code": 5, "response_status_text": 6, "response_headers": 7, "response_body": 8,
@@ -549,8 +640,7 @@ func prettyValue(v any) string {
 	}
 }
 
-// prettyJSONString parses a JSON string, redacts private JWK material, and
-// re-indents it. Returns ok=false when s is not a JSON object/array.
+// prettyJSONString parses a JSON string, redacts private JWK material, and re-indents it; returns ok=false when s is not a JSON object/array.
 func prettyJSONString(s string) (string, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" || (s[0] != '{' && s[0] != '[') || !json.Valid([]byte(s)) {
@@ -585,8 +675,7 @@ func failedFromItems(items []result.LogItem) []result.Condition {
 	return out
 }
 
-// logKind derives the badge label: the condition result if present, else the
-// HTTP direction (REQUEST/RESPONSE), else INFO.
+// logKind derives the badge label: the condition result if present, else the HTTP direction (REQUEST/RESPONSE), else INFO.
 func logKind(e map[string]any) string {
 	if r := strings.ToUpper(asString(e["result"])); r != "" {
 		return r

--- a/api-test/internal/conformance/run_test.go
+++ b/api-test/internal/conformance/run_test.go
@@ -1,10 +1,12 @@
 package conformance
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/mosip/esignet/api-test/internal/config"
+	"github.com/mosip/esignet/api-test/internal/result"
 )
 
 func newTestOrchestrator(base string) *Orchestrator {
@@ -39,8 +41,7 @@ func TestEsignetBase(t *testing.T) {
 			want:       "https://esignet.example/v1/esignet",
 		},
 		{
-			// The regression: a prefix test accepted this and then returned the
-			// SHORT value, silently driving the flow at https://esignet.example/v1.
+			// The regression: a prefix test accepted this and returned the SHORT value, silently driving the flow at https://esignet.example/v1.
 			name:       "configured base shorter than derived is rejected",
 			configured: "https://esignet.example/v1",
 			wantErr:    true,
@@ -86,8 +87,7 @@ func TestEsignetBaseRejectsNonAuthorizeURL(t *testing.T) {
 	}
 }
 
-// form_post is not a module name: the suite runs the ordinary modules and puts
-// the mode in the plan variant, so only the variant can reveal it.
+// form_post is not a module name: the suite puts the mode in the plan variant, so only the variant can reveal it.
 func TestUnsupportedReasonReadsTheResponseModeVariant(t *testing.T) {
 	if got := unsupportedReason("oidcc-server", map[string]any{"response_mode": "form_post"}); got != "form_post" {
 		t.Errorf("unsupportedReason(form_post variant) = %q, want form_post", got)
@@ -101,5 +101,107 @@ func TestUnsupportedReasonReadsTheResponseModeVariant(t *testing.T) {
 	// The name-substring hints still apply.
 	if got := unsupportedReason("oidcc-rp-initiated-logout", nil); got != "logout" {
 		t.Errorf("unsupportedReason(logout module) = %q, want logout", got)
+	}
+}
+
+// The visit budget defaults to 1: a URL already driven, or one the suite has marked visited, is not returned again.
+func TestPendingURLsDefaultBudgetDrivesEachURLOnce(t *testing.T) {
+	b := Browser{URLs: []string{"https://a/authorize", "https://b/authorize"}}
+	visits := map[string]int{}
+
+	got := pendingURLs(b, visits, 1)
+	if len(got) != 2 {
+		t.Fatalf("first pass = %v, want both URLs", got)
+	}
+	for _, u := range got {
+		visits[u]++
+	}
+	if got := pendingURLs(b, visits, 1); got != nil {
+		t.Errorf("second pass = %v, want none (budget of 1 already spent)", got)
+	}
+
+	// A URL the suite reports as visited is never offered, budget notwithstanding.
+	b2 := Browser{URLs: []string{"https://a/authorize"}, Visited: []string{"https://a/authorize"}}
+	if got := pendingURLs(b2, map[string]int{}, 1); got != nil {
+		t.Errorf("suite-visited URL = %v, want none", got)
+	}
+}
+
+// A budget above 1 is what par-ensure-reused-request-uri needs: the same authorize URL has to be drivable a second time, since the first visit doesn't authenticate.
+func TestPendingURLsBudgetAllowsASecondVisit(t *testing.T) {
+	b := Browser{URLs: []string{"https://a/authorize"}}
+	visits := map[string]int{"https://a/authorize": 1}
+
+	if got := pendingURLs(b, visits, 2); len(got) != 1 {
+		t.Errorf("budget 2 after 1 visit = %v, want the URL again", got)
+	}
+	visits["https://a/authorize"]++
+	if got := pendingURLs(b, visits, 2); got != nil {
+		t.Errorf("budget 2 after 2 visits = %v, want none", got)
+	}
+}
+
+// Only the two modules that need special driving get it; everything else must keep the zero value, or a stray DenyAll would deny consent across the run.
+func TestBehaviorForLeavesOtherModulesOnTheDefault(t *testing.T) {
+	// moduleBehavior holds a ConsentPolicy (a slice), so it is not comparable with ==; check the fields that change driving instead.
+	if b := behaviorFor("fapi2-security-profile-final-happy-flow"); b.consent.DenyAll ||
+		len(b.consent.Deny) != 0 || b.followRejection || b.loadOnlyVisits != 0 || b.visitBudget() != 1 {
+		t.Errorf("happy-flow behaviour = %+v, want the default driving", b)
+	}
+	if b := behaviorFor("fapi2-security-profile-final-user-rejects-authentication"); !b.consent.DenyAll || !b.followRejection {
+		t.Errorf("user-rejects behaviour = %+v, want DenyAll + followRejection", b)
+	}
+	reuse := behaviorFor("fapi2-security-profile-final-par-ensure-reused-request-uri-prior-to-auth-completion-succeeds")
+	if reuse.loadOnlyVisits != 1 || reuse.visitBudget() != 2 {
+		t.Errorf("par-reuse behaviour = %+v, want 1 load-only visit and a budget of 2", reuse)
+	}
+	if got := (moduleBehavior{}).visitBudget(); got != 1 {
+		t.Errorf("default visitBudget() = %d, want 1", got)
+	}
+}
+
+// An unreachable suite must still reach the report. Before this, the surface returned
+// an error carrying zero modules, cmd/conformance wrote nothing, and run-all.sh could
+// only report that the surface "crashed before writing one".
+func TestEnvNotReadyProducesOneRowPerPlan(t *testing.T) {
+	o := newTestOrchestrator("https://esignet.example/v1/esignet")
+	o.cfg.Esignet.Provider = "mosip"
+	o.cfg.Plans = []config.Plan{{Name: "oidcc-test-plan"}, {Name: "fapi2-security-profile-final-test-plan"}}
+
+	out := &RunResult{}
+	err := o.envNotReady(out, errors.New("suite /api/runner/available: connection refused"))
+
+	if err == nil || !strings.Contains(err.Error(), "ENV_NOT_READY") {
+		t.Fatalf("err = %v, want one wrapping ENV_NOT_READY", err)
+	}
+	if len(out.Modules) != 2 {
+		t.Fatalf("got %d rows, want one per plan", len(out.Modules))
+	}
+	for i, want := range []string{"oidcc-test-plan", "fapi2-security-profile-final-test-plan"} {
+		got := out.Modules[i]
+		if got.Plan != want {
+			t.Errorf("row %d Plan = %q, want %q", i, got.Plan, want)
+		}
+		if got.HarnessOutcome != result.OutcomeEnvNotReady {
+			t.Errorf("row %d HarnessOutcome = %q, want %q", i, got.HarnessOutcome, result.OutcomeEnvNotReady)
+		}
+		// The row must carry the cause: the operator reads the report, not the container log.
+		if !strings.Contains(got.OutcomeDetail, "connection refused") {
+			t.Errorf("row %d OutcomeDetail = %q, want the underlying error", i, got.OutcomeDetail)
+		}
+		// ENV_NOT_READY is a not-run row, never a failure — it must not land in the Failed bucket.
+		if got.Result == "FAILED" {
+			t.Errorf("row %d Result = FAILED, want an unset result", i)
+		}
+	}
+}
+
+// A plan-less config cannot reach envNotReady today, but it must not silently report nothing if it ever does.
+func TestEnvNotReadyWithNoPlansStillReportsARow(t *testing.T) {
+	o := newTestOrchestrator("https://esignet.example/v1/esignet")
+	out := &RunResult{}
+	_ = o.envNotReady(out, errors.New("boom"))
+	if len(out.Modules) != 1 {
+		t.Fatalf("got %d rows, want 1", len(out.Modules))
 	}
 }

--- a/api-test/internal/e2e/crypto.go
+++ b/api-test/internal/e2e/crypto.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"math/big"
 	"net/http"
@@ -38,13 +39,21 @@ func publicJWK(priv *rsa.PrivateKey, kid string) map[string]any {
 	}
 }
 
-// signRS256 builds and signs a compact JWS (JWT) with the given claims.
-func signRS256(priv *rsa.PrivateKey, kid string, claims map[string]any) (string, error) {
-	header := map[string]any{"alg": "RS256", "typ": "JWT"}
-	if kid != "" {
-		header["kid"] = kid
+// signJWS builds and signs a compact JWS with an explicit header. The caller
+// owns every header member except "alg", which is set from alg so the header
+// and the signature scheme can never disagree.
+//
+// Both supported algs sign with the same RSA key and differ only in padding:
+// RS256 is PKCS#1 v1.5, PS256 is RSA-PSS. Which one a deployment accepts for a
+// DPoP proof comes from its dpop_signing_alg_values_supported, so the harness
+// has to be able to produce either.
+func signJWS(priv *rsa.PrivateKey, alg string, header, claims map[string]any) (string, error) {
+	hdr := maps.Clone(header)
+	if hdr == nil {
+		hdr = map[string]any{}
 	}
-	h, err := json.Marshal(header)
+	hdr["alg"] = alg
+	h, err := json.Marshal(hdr)
 	if err != nil {
 		return "", err
 	}
@@ -54,12 +63,35 @@ func signRS256(priv *rsa.PrivateKey, kid string, claims map[string]any) (string,
 	}
 	signingInput := b64(h) + "." + b64(p)
 	sum := sha256.Sum256([]byte(signingInput))
-	sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, sum[:])
+	var sig []byte
+	switch alg {
+	case "RS256":
+		sig, err = rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, sum[:])
+	case "PS256":
+		// RFC 7518 fixes the PS256 salt length at the hash length.
+		sig, err = rsa.SignPSS(rand.Reader, priv, crypto.SHA256, sum[:],
+			&rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256})
+	default:
+		return "", fmt.Errorf("unsupported signing alg %q (want RS256 or PS256)", alg)
+	}
 	if err != nil {
 		return "", err
 	}
 	return signingInput + "." + b64(sig), nil
 }
+
+// signRS256 builds and signs a compact JWS (JWT) with the given claims.
+func signRS256(priv *rsa.PrivateKey, kid string, claims map[string]any) (string, error) {
+	header := map[string]any{"typ": "JWT"}
+	if kid != "" {
+		header["kid"] = kid
+	}
+	return signJWS(priv, "RS256", header, claims)
+}
+
+// clientAssertionTypeJWTBearer is the RFC 7523 client_assertion_type every
+// private_key_jwt call carries — token, PAR and introspection alike.
+const clientAssertionTypeJWTBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 // clientAssertion builds the private_key_jwt client assertion for the token call.
 func clientAssertion(priv *rsa.PrivateKey, kid, clientID, aud string) (string, error) {
@@ -111,7 +143,10 @@ type jwksKey struct {
 	E   string `json:"e"`
 }
 
-// verifyJWS verifies a compact RS256 JWS against the keys at jwksURL, matching by kid when present.
+// verifyJWS verifies a compact JWS against the keys at jwksURL, matching by kid
+// when present. Both RSA signature families are accepted, mirroring signJWS:
+// eSignet's discovery advertises whichever it signs with, and a deployment
+// publishing PS256 only (RSA-PSS) is as valid as one on RS256 (PKCS#1 v1.5).
 func verifyJWS(ctx context.Context, token, jwksURL string, tlsVerify bool) error {
 	parts := strings.Split(strings.TrimSpace(token), ".")
 	if len(parts) != 3 {
@@ -127,8 +162,8 @@ func verifyJWS(ctx context.Context, token, jwksURL string, tlsVerify bool) error
 		Alg string `json:"alg"`
 	}
 	_ = json.Unmarshal(hb, &hdr)
-	if hdr.Alg != "RS256" {
-		return fmt.Errorf("unexpected alg %q (want RS256)", hdr.Alg)
+	if hdr.Alg != "RS256" && hdr.Alg != "PS256" {
+		return fmt.Errorf("unexpected alg %q (want RS256 or PS256)", hdr.Alg)
 	}
 
 	keys, err := fetchJWKS(ctx, jwksURL, tlsVerify)
@@ -152,7 +187,20 @@ func verifyJWS(ctx context.Context, token, jwksURL string, tlsVerify bool) error
 		if err != nil {
 			continue
 		}
-		if rsa.VerifyPKCS1v15(pub, crypto.SHA256, sum[:], sig) == nil {
+		// The header alg picked above decides the scheme; a key that does not
+		// verify falls through to the next one exactly as before.
+		var verr error
+		if hdr.Alg == "PS256" {
+			// Same salt policy signJWS signs under: RFC 7518 fixes the PS256
+			// salt at the hash length, so auto-detecting it here would accept a
+			// signature the spec does not allow — the opposite of what a
+			// harness looking for target-side deviations should do.
+			verr = rsa.VerifyPSS(pub, crypto.SHA256, sum[:], sig,
+				&rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256})
+		} else {
+			verr = rsa.VerifyPKCS1v15(pub, crypto.SHA256, sum[:], sig)
+		}
+		if verr == nil {
 			return nil
 		}
 	}

--- a/api-test/internal/e2e/dpop.go
+++ b/api-test/internal/e2e/dpop.go
@@ -1,0 +1,154 @@
+package e2e
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DPoP (RFC 9449) sender-constrained access tokens; the DPoP key is deliberately NOT the client's registration key, so a wrong-key proof is a meaningful negative.
+
+// defaultDPoPAlg is used when discovery advertises no dpop_signing_alg_values_supported; it is in the shipped deployment.yaml allow-list.
+const defaultDPoPAlg = "RS256"
+
+// dpopAlgs are the algs this harness can produce, in preference order; both sign with the same RSA key, so picking between them costs nothing.
+var dpopAlgs = []string{"PS256", "RS256"}
+
+// chooseDPoPAlg picks the first alg the harness can produce that the
+// deployment also advertises. An empty supported list means discovery simply
+// doesn't publish dpop_signing_alg_values_supported, so defaultDPoPAlg (in
+// every shipped deployment.yaml allow-list) is assumed. A non-empty list with
+// no PS256/RS256 match is a real harness capability gap, not that case:
+// falling back to defaultDPoPAlg there would send a proof the server
+// correctly rejects, and the scenario would report that rejection as a
+// deployment failure instead of naming the actual limit.
+func chooseDPoPAlg(supported []string) (string, error) {
+	if len(supported) == 0 {
+		return defaultDPoPAlg, nil
+	}
+	for _, want := range dpopAlgs {
+		for _, got := range supported {
+			if strings.EqualFold(want, got) {
+				return want, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("dpop_signing_alg_values_supported %v has no algorithm this harness can produce (%v)", supported, dpopAlgs)
+}
+
+// dpopSigner mints the DPoP proofs for one scenario's flow, shared across PAR, token and userinfo so the shared jkt is the binding the server enforces.
+type dpopSigner struct {
+	priv *rsa.PrivateKey
+	alg  string
+	jwk  map[string]any // exactly the RFC 7638 members, so it also serves as the proof header's jwk
+	jkt  string         // base64url(SHA-256(canonical jwk)) — the cnf.jkt the token carries
+
+	// nonce is the most recent DPoP-Nonce the server issued; the next proof replays it.
+	nonce string
+}
+
+// newDPoPSigner generates a fresh proof key and precomputes its thumbprint.
+func newDPoPSigner(alg string) (*dpopSigner, error) {
+	priv, err := generateRSA()
+	if err != nil {
+		return nil, fmt.Errorf("dpop keygen: %w", err)
+	}
+	// Only kty/n/e: the thumbprint is defined over exactly these members.
+	jwk := map[string]any{
+		"kty": "RSA",
+		"n":   b64(priv.PublicKey.N.Bytes()),
+		"e":   b64(big.NewInt(int64(priv.PublicKey.E)).Bytes()),
+	}
+	jkt, err := jwkThumbprint(jwk)
+	if err != nil {
+		return nil, err
+	}
+	return &dpopSigner{priv: priv, alg: alg, jwk: jwk, jkt: jkt}, nil
+}
+
+// jwkThumbprint computes the RFC 7638 SHA-256 thumbprint of an RSA JWK: required members only, lexicographically ordered, no whitespace.
+func jwkThumbprint(jwk map[string]any) (string, error) {
+	kty, _ := jwk["kty"].(string)
+	n, _ := jwk["n"].(string)
+	e, _ := jwk["e"].(string)
+	if kty != "RSA" || n == "" || e == "" {
+		return "", fmt.Errorf("thumbprint: not an RSA JWK with n and e")
+	}
+	// Assembled by hand rather than marshalled from a map, since a generic encoder guarantees neither member order nor absent whitespace.
+	eb, err := json.Marshal(e)
+	if err != nil {
+		return "", err
+	}
+	kb, err := json.Marshal(kty)
+	if err != nil {
+		return "", err
+	}
+	nb, err := json.Marshal(n)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(`{"e":` + string(eb) + `,"kty":` + string(kb) + `,"n":` + string(nb) + `}`))
+	return b64(sum[:]), nil
+}
+
+// proof returns a DPoP proof JWT for one request; accessToken is passed only at resource endpoints, adding the ath claim that ties the proof to that token.
+func (d *dpopSigner) proof(method, uri, accessToken string) (string, error) {
+	jti := make([]byte, 16)
+	if _, err := rand.Read(jti); err != nil {
+		return "", fmt.Errorf("dpop jti: %w", err)
+	}
+	claims := map[string]any{
+		"jti": b64(jti),
+		"htm": strings.ToUpper(method),
+		"htu": htu(uri),
+		"iat": time.Now().Unix(),
+	}
+	if accessToken != "" {
+		sum := sha256.Sum256([]byte(accessToken))
+		claims["ath"] = b64(sum[:])
+	}
+	if d.nonce != "" {
+		claims["nonce"] = d.nonce
+	}
+	return signJWS(d.priv, d.alg, map[string]any{"typ": "dpop+jwt", "jwk": d.jwk}, claims)
+}
+
+// htu strips the query and fragment, which RFC 9449 excludes from the htu claim.
+func htu(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	u.RawFragment = ""
+	return u.String()
+}
+
+// dpopNonceFrom records a server-issued DPoP nonce and reports whether it is new.
+func (d *dpopSigner) dpopNonceFrom(h http.Header) bool {
+	n := strings.TrimSpace(h.Get("DPoP-Nonce"))
+	if n == "" || n == d.nonce {
+		return false
+	}
+	d.nonce = n
+	return true
+}
+
+// isDPoPNonceError reports whether a response body is the use_dpop_nonce error asking the client to retry with the DPoP-Nonce header's value.
+func isDPoPNonceError(body []byte) bool {
+	var e struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &e) != nil {
+		return false
+	}
+	return e.Error == "use_dpop_nonce"
+}

--- a/api-test/internal/e2e/e2e.go
+++ b/api-test/internal/e2e/e2e.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -20,8 +21,7 @@ import (
 	"github.com/mosip/esignet/api-test/internal/result"
 )
 
-// Spec is the E2E test definition (loaded from JSON): how to register the test
-// client and the list of scenarios to run against it.
+// Spec is the E2E test definition (loaded from JSON): how to register the test client and the list of scenarios to run against it.
 type Spec struct {
 	RedirectURI string     `json:"redirect_uri"`
 	UserClaims  []string   `json:"user_claims"` // claims registered on the client
@@ -111,11 +111,32 @@ type Scenario struct {
 	// Credentials overrides the plugin's base identity answers for just this scenario.
 	Credentials map[string]string `json:"credentials"`
 
-	// ExpectLoginFailure marks a negative auth case: the login is expected to be rejected.
+	// OmitCredentials removes these keys (after Credentials overrides are
+	// merged in) from just this scenario's answers, so a negative case can
+	// submit no value at all rather than an empty one — the two are not
+	// equivalent when the target accepts any non-empty value as valid.
+	OmitCredentials []string `json:"omit_credentials"`
+
+	// ExpectLoginFailure marks a negative case: the flow is expected to be rejected anywhere in the chain, not only at login.
 	ExpectLoginFailure bool `json:"expect_login_failure"`
+
+	// ExpectErrorContains additionally requires the rejection to mention this substring; only meaningful with expect_login_failure.
+	ExpectErrorContains string `json:"expect_error_contains"`
 
 	// Consent controls how the consent step is answered and what is asserted about it.
 	Consent *ConsentSpec `json:"consent"`
+
+	// ClientConfig is the additionalConfig the scenario's client is registered with; scenarios asking for the same config share one client.
+	ClientConfig *ClientConfig `json:"client_config"`
+
+	// Flow overrides what the relying party actually sends; omitted, the RP does whatever the client config demands.
+	Flow *FlowSpec `json:"flow"`
+
+	// ClientLifecycle deactivates (and optionally reactivates) the scenario's own client partway through the flow.
+	ClientLifecycle *ClientLifecycle `json:"client_lifecycle"`
+
+	// Introspect submits the tokens the flow obtained to /oauth2/introspect after completion; only meaningful when the flow is expected to succeed.
+	Introspect []IntrospectCase `json:"introspect"`
 
 	Scopes         []string          `json:"scopes"`
 	UserinfoClaims map[string]any    `json:"userinfo_claims"` // OIDC "claims".userinfo request object
@@ -124,12 +145,17 @@ type Scenario struct {
 	ExpectAbsent   []string          `json:"expect_absent"`
 	// KnownIssue marks the scenario as a tracked environment gap, reported in the Known bucket.
 	KnownIssue string `json:"known_issue"`
+
+	// RequiresCredential names a key (as merged into this scenario's answers,
+	// e.g. "password") that must be non-empty for the scenario to run at all.
+	// Left unconfigured on this deployment, the scenario is reported in the
+	// Skipped bucket instead of attempting a login that has no credential to use.
+	RequiresCredential string `json:"requires_credential"`
 }
 
 // ConsentSpec is a scenario's consent behaviour and expectations.
 type ConsentSpec struct {
-	// Deny withholds approval from these element names (case-insensitive). A name
-	// the prompt never offers fails the scenario rather than passing vacuously.
+	// Deny withholds approval from these element names (case-insensitive); a name the prompt never offers fails the scenario.
 	Deny []string `json:"deny"`
 	// DenyAll withholds approval from every element offered.
 	DenyAll bool `json:"deny_all"`
@@ -152,8 +178,7 @@ type consentObservation struct {
 	denied   []string
 }
 
-// assertConsent turns the scenario's consent expectations into report assertions.
-// Returns nil when the scenario asserts nothing about consent.
+// assertConsent turns the scenario's consent expectations into report assertions, or nil when the scenario asserts nothing.
 func assertConsent(sc Scenario, obs consentObservation) []result.Assertion {
 	if sc.Consent == nil {
 		return nil
@@ -205,14 +230,20 @@ type Runner struct {
 	TokenEndpoint    string
 	UserinfoEndpoint string
 	JWKSURI          string
-	AdminToken       string
-	Plugin           string
-	Answers          map[string]string // base identity answers; Scenario.Credentials overrides per case
-	IDType           string            // uin | vid | phone | email — login-id-type preference, combined with each scenario's AuthFactor
-	TLSVerify        bool
-	Timeout          time.Duration
-	Logf             func(string, ...any)
-	OTP              esignet.OTPProvider // dynamic OTP source; nil for static OTP
+	// PAREndpoint is discovery's pushed_authorization_request_endpoint; empty blocks the PAR scenarios only.
+	PAREndpoint string
+	// IntrospectEndpoint is discovery's introspection_endpoint (RFC 7662); empty blocks the introspection scenarios only.
+	IntrospectEndpoint string
+	// DPoPAlgs is discovery's dpop_signing_alg_values_supported, narrowed to one alg the harness can produce.
+	DPoPAlgs   []string
+	AdminToken string
+	Plugin     string
+	Answers    map[string]string // base identity answers; Scenario.Credentials overrides per case
+	IDType     string            // uin | vid | phone | email — login-id-type preference, combined with each scenario's AuthFactor
+	TLSVerify  bool
+	Timeout    time.Duration
+	Logf       func(string, ...any)
+	OTP        esignet.OTPProvider // dynamic OTP source; nil for static OTP
 
 	// PMS registration (mosip plugin only).
 	PMSBaseURL    string
@@ -230,15 +261,30 @@ func (r *Runner) httpClient() *http.Client {
 	return r.client
 }
 
+// requireHTTPS rejects a base URL that would send AdminToken in cleartext, since the client's redirect policy does not strip it on a scheme downgrade.
+func requireHTTPS(label, raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("%s must be an absolute https URL, got %q", label, raw)
+	}
+	return nil
+}
+
 // do performs an HTTP call and records it (Authorization redacted) into calls.
 func (r *Runner) do(ctx context.Context, calls *[]result.HTTPCall, label, method, u string, headers map[string]string, body string) (int, []byte, error) {
+	status, rb, _, err := r.doWithHeaders(ctx, calls, label, method, u, headers, body)
+	return status, rb, err
+}
+
+// doWithHeaders is do, additionally returning the response headers, which DPoP needs to read a server-issued DPoP-Nonce.
+func (r *Runner) doWithHeaders(ctx context.Context, calls *[]result.HTTPCall, label, method, u string, headers map[string]string, body string) (int, []byte, http.Header, error) {
 	var rdr io.Reader
 	if body != "" {
 		rdr = bytes.NewBufferString(body)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, u, rdr)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
@@ -247,7 +293,7 @@ func (r *Runner) do(ctx context.Context, calls *[]result.HTTPCall, label, method
 	rec := result.HTTPCall{Seq: len(*calls) + 1, At: time.Now().UnixNano(), Label: label, Method: method, URL: u, ReqBody: body, ReqHeaders: redactHeaders(req.Header)}
 	if err != nil {
 		*calls = append(*calls, rec)
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 	rb, _ := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
@@ -255,13 +301,23 @@ func (r *Runner) do(ctx context.Context, calls *[]result.HTTPCall, label, method
 	rec.RespHeaders = httpx.CloneHeader(resp.Header)
 	rec.RespBody = string(rb)
 	*calls = append(*calls, rec)
-	return resp.StatusCode, rb, nil
+	return resp.StatusCode, rb, resp.Header, nil
 }
+
+// sensitiveHeaders carry credentials that must never reach the archived report; Cookie is included because the PMS admin token travels there.
+var sensitiveHeaders = []string{"Authorization", "Proxy-Authorization", "Cookie", "Set-Cookie"}
 
 func redactHeaders(h http.Header) map[string][]string {
 	out := map[string][]string{}
 	for k, v := range h {
-		if strings.EqualFold(k, "Authorization") {
+		redacted := false
+		for _, s := range sensitiveHeaders {
+			if strings.EqualFold(k, s) {
+				redacted = true
+				break
+			}
+		}
+		if redacted {
 			out[k] = []string{"***redacted***"}
 			continue
 		}
@@ -270,8 +326,7 @@ func redactHeaders(h http.Header) map[string][]string {
 	return out
 }
 
-// Run registers a throwaway client, executes every scenario against it, and
-// returns one ModuleResult per scenario (Surface=e2e).
+// Run registers a throwaway client, executes every scenario against it, and returns one ModuleResult per scenario (Surface=e2e).
 func (r *Runner) Run(ctx context.Context, spec Spec) []result.ModuleResult {
 	logf := r.Logf
 	if logf == nil {
@@ -280,41 +335,97 @@ func (r *Runner) Run(ctx context.Context, spec Spec) []result.ModuleResult {
 	var out []result.ModuleResult
 	r.acr = spec.Acr
 
-	// 1. Register a throwaway client with a fresh key we control.
-	priv, err := generateRSA()
-	if err != nil {
-		return []result.ModuleResult{r.errRow("e2e client keygen", fmt.Errorf("keygen: %w", err))}
+	if r.AdminToken != "" {
+		// An https URL is worthless cover for the token if the client doesn't
+		// actually validate the certificate on the other end of it.
+		if !r.TLSVerify {
+			return r.registrationFailureRows(spec, nil,
+				errors.New("TLS verification must be enabled when ADMIN_TOKEN is set"))
+		}
+		if err := requireHTTPS("esignet base URL", r.Base); err != nil {
+			return r.registrationFailureRows(spec, nil, err)
+		}
+		if r.PMSBaseURL != "" {
+			if err := requireHTTPS("PMS base URL", r.PMSBaseURL); err != nil {
+				return r.registrationFailureRows(spec, nil, err)
+			}
+		}
 	}
-	kid := "e2e-" + strconv.FormatInt(time.Now().Unix(), 10)
-	// requestedID is the harness-chosen id used when registering against eSignet client-mgmt.
-	requestedID := "api-e2e-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
+	// Register the clients the scenarios ask for; scenarios sharing a client config share a client, registered on first use.
+	pool := &clientPool{runner: r, spec: spec}
 	var setupCalls []result.HTTPCall
-	clientID, err := r.createClient(ctx, &setupCalls, priv, kid, requestedID, spec)
-	if err != nil {
+	if _, err := pool.get(ctx, &setupCalls, ClientConfig{}); err != nil {
 		// Keep every scenario visible in the report rather than collapsing to a single error row.
 		logf("e2e: client registration failed (%v) — reporting %d scenario(s) as blocked", err, len(spec.Scenarios))
 		return r.registrationFailureRows(spec, setupCalls, err)
 	}
-	logf("e2e: registered client %s", clientID)
 
-	// 2. Run each scenario against the registered client.
+	// Run each scenario against the client its config calls for.
 	for _, sc := range spec.Scenarios {
 		start := time.Now()
 		row := result.ModuleResult{Surface: result.SurfaceE2E, Plugin: r.Plugin, Module: sc.Name, HarnessOutcome: result.OutcomeOK}
 
-		if sc.AuthFactor == "" {
+		if msg := scenarioConfigError(sc); msg != "" {
 			row.Result = "FAILED"
-			row.FailedConditions = []result.Condition{{Src: "e2e", Result: "FAILURE", Msg: "scenario config error: auth_factor is required (otp|password|bio|kbi)"}}
-			logf("e2e: %-55s -> FAILED (no auth_factor configured)", sc.Name)
+			row.FailedConditions = []result.Condition{{Src: "e2e", Result: "FAILURE", Msg: "scenario config error: " + msg}}
+			logf("e2e: %-55s -> FAILED (%s)", sc.Name, msg)
+			out = append(out, row)
+			continue
+		}
+
+		cfg := ClientConfig{}
+		if sc.ClientConfig != nil {
+			cfg = *sc.ClientConfig
+		}
+		// A scenario that changes its client's status gets one of its own — see clientPool.dedicated.
+		get := pool.get
+		if sc.ClientLifecycle != nil {
+			get = pool.dedicated
+		}
+		cl, cerr := get(ctx, &setupCalls, cfg)
+		if cerr != nil {
+			// One combination's client failing to register must not stop the rest of the run: report this scenario and carry on.
+			row.Result = "FAILED"
+			row.FailedConditions = []result.Condition{{Src: "e2e", Result: "FAILURE", Msg: fmt.Sprintf("client registration for config %s failed: %v", cfg.label(), cerr)}}
+			row.DurationMs = time.Since(start).Milliseconds()
+			logf("e2e: %-55s -> FAILED (client config %s: %v)", sc.Name, cfg.label(), cerr)
 			out = append(out, row)
 			continue
 		}
 
 		answers := mergeAnswers(r.Answers, sc.Credentials)
+		for _, k := range sc.OmitCredentials {
+			delete(answers, esignet.Normalize(k))
+		}
+
+		if sc.RequiresCredential != "" {
+			// An unrecognised name is a typo in the spec, not an unconfigured
+			// deployment. Skipping it would take the scenario out of the
+			// failure signal on a mistake — exactly what the skip must never
+			// be able to do — so it fails loudly instead.
+			if !esignet.KnownAnswerKey(sc.RequiresCredential) {
+				row.Result = "FAILED"
+				row.FailedConditions = []result.Condition{{Src: "e2e", Result: "FAILURE", Msg: fmt.Sprintf("scenario spec error: requires_credential %q is not a known answer key", sc.RequiresCredential)}}
+				row.DurationMs = time.Since(start).Milliseconds()
+				logf("e2e: %-55s -> FAILED (requires_credential %q is not a known answer key)", sc.Name, sc.RequiresCredential)
+				out = append(out, row)
+				continue
+			}
+			if answers[esignet.Normalize(sc.RequiresCredential)] == "" {
+				row.Result = "SKIPPED"
+				row.HarnessOutcome = result.OutcomeSkippedByHarness
+				row.OutcomeDetail = fmt.Sprintf("%s not configured for this deployment", sc.RequiresCredential)
+				row.DurationMs = time.Since(start).Milliseconds()
+				logf("e2e: %-55s -> SKIPPED (%s not configured)", sc.Name, sc.RequiresCredential)
+				out = append(out, row)
+				continue
+			}
+		}
+
 		preferred := append(esignet.AuthFactorTokens(sc.AuthFactor), esignet.IDTypeTokens(r.IDType)...)
 
-		claims, calls, consentSeen, protoAsserts, ferr := r.runScenario(ctx, priv, kid, clientID, spec.RedirectURI, sc, answers, preferred)
+		claims, calls, consentSeen, protoAsserts, ferr := r.runScenario(ctx, cl, spec.RedirectURI, sc, answers, preferred)
 		row.Calls = calls
 		row.DurationMs = time.Since(start).Milliseconds()
 
@@ -322,12 +433,25 @@ func (r *Runner) Run(ctx context.Context, spec Spec) []result.ModuleResult {
 		consentAssertions := assertConsent(sc, consentSeen)
 
 		loginField := fmt.Sprintf("login (acr=%s)", sc.AuthFactor)
+		if cfg != (ClientConfig{}) || sc.Flow != nil {
+			// Name the protocol combination in the row, so a failure reads as more than a bare login failure.
+			loginField = fmt.Sprintf("flow (acr=%s, client=%s)", sc.AuthFactor, cfg.label())
+		}
+		if sc.ClientLifecycle != nil {
+			loginField = fmt.Sprintf("flow (acr=%s, client %s)", sc.AuthFactor, sc.ClientLifecycle.label())
+		}
 		switch {
 		case ferr != nil && sc.ExpectLoginFailure:
 			// Negative case: rejection is the expected outcome, provided the consent and echo assertions hold.
 			row.Assertions = append([]result.Assertion{
 				{Field: loginField, Expected: "rejected", Actual: "rejected: " + ferr.Error(), Passed: true},
 			}, consentAssertions...)
+			if want := sc.ExpectErrorContains; want != "" {
+				row.Assertions = append(row.Assertions, result.Assertion{
+					Field: "rejection reason", Expected: "contains " + strconv.Quote(want),
+					Actual: ferr.Error(), Passed: strings.Contains(ferr.Error(), want),
+				})
+			}
 			row.Assertions = append(row.Assertions, protoAsserts...)
 			if conds := failedConditions(row.Assertions); len(conds) > 0 {
 				row.Result = "FAILED"
@@ -341,15 +465,25 @@ func (r *Runner) Run(ctx context.Context, spec Spec) []result.ModuleResult {
 			out = append(out, row)
 			continue
 		case ferr != nil && !sc.ExpectLoginFailure:
-			// Positive case that couldn't log in — real failure (may be a
-			// missing-credential ACR gap; reported, not silently skipped).
+			// Positive case that couldn't log in — real failure, reported rather than silently skipped.
 			row.Assertions = append([]result.Assertion{
 				{Field: loginField, Expected: "accepted", Actual: "rejected: " + ferr.Error(), Passed: false},
 			}, consentAssertions...)
 			row.Assertions = append(row.Assertions, protoAsserts...)
 			row.Result = "FAILED"
 			row.FailedConditions = []result.Condition{{Src: "e2e", Result: "FAILURE", Msg: ferr.Error()}}
-			logf("e2e: %-55s -> FAILED (login: %v)", sc.Name, ferr)
+			// A declared environment gap reports as KNOWN_ISSUE here too, not
+			// only on the claim-assertion path below: a scenario whose gap
+			// prevents login from completing at all (no mock MDS to answer a
+			// biometric capture, say) would otherwise be the one case the
+			// known_issue marker could not cover, and would block the run.
+			if sc.KnownIssue != "" {
+				row.HarnessOutcome = result.OutcomeKnownIssue
+				row.OutcomeDetail = sc.KnownIssue
+				logf("e2e: %-55s -> KNOWN ISSUE (login: %v: %s)", sc.Name, ferr, sc.KnownIssue)
+			} else {
+				logf("e2e: %-55s -> FAILED (login: %v)", sc.Name, ferr)
+			}
 			out = append(out, row)
 			continue
 		case ferr == nil && sc.ExpectLoginFailure:
@@ -405,8 +539,7 @@ func attachSetupCalls(out []result.ModuleResult, setupCalls []result.HTTPCall) {
 	out[0].Calls = result.CollapseCalls(merged)
 }
 
-// mergeAnswers overlays per-scenario credential overrides onto the plugin's base
-// identity answers, normalizing override keys the same way the driver does.
+// mergeAnswers overlays per-scenario credential overrides onto the plugin's base identity answers, normalizing override keys the same way the driver does.
 func mergeAnswers(base, overrides map[string]string) map[string]string {
 	out := make(map[string]string, len(base)+len(overrides))
 	maps.Copy(out, base)
@@ -423,7 +556,9 @@ func (r *Runner) registrationFailureRows(spec Spec, calls []result.HTTPCall, err
 		row.Calls = calls
 		return []result.ModuleResult{row}
 	}
-	envNotReady := r.Plugin == "mosip" && (r.PMSBaseURL == "" || r.AuthPartnerID == "" || r.PolicyID == "")
+	// A missing PMS setting and a bearer without the role PMS demands both mean the environment is not ready; report NOT_RUN, not red rows.
+	envNotReady := r.Plugin == "mosip" &&
+		(r.PMSBaseURL == "" || r.AuthPartnerID == "" || r.PolicyID == "" || errors.Is(err, errPMSForbidden))
 	out := make([]result.ModuleResult, 0, len(spec.Scenarios))
 	for i, sc := range spec.Scenarios {
 		row := result.ModuleResult{Surface: result.SurfaceE2E, Plugin: r.Plugin, Module: sc.Name}
@@ -452,32 +587,92 @@ func (r *Runner) errRow(name string, err error) result.ModuleResult {
 	}
 }
 
-// createClient registers the test client and returns the effective clientId for the rest of the flow.
-func (r *Runner) createClient(ctx context.Context, calls *[]result.HTTPCall, priv *rsa.PrivateKey, kid, requestedID string, spec Spec) (string, error) {
-	if r.Plugin == "mosip" {
-		return r.createClientViaPMS(ctx, calls, priv, kid, spec)
-	}
-	return r.createClientViaClientMgmt(ctx, calls, priv, kid, requestedID, spec)
+// testClient is one registered throwaway client and the key that authenticates it.
+type testClient struct {
+	priv     *rsa.PrivateKey
+	kid      string
+	clientID string
+	cfg      ClientConfig
 }
 
-// createClientViaClientMgmt registers the test client via eSignet client-mgmt
-// (admin bearer token). The harness picks the clientId and it is echoed back.
-func (r *Runner) createClientViaClientMgmt(ctx context.Context, calls *[]result.HTTPCall, priv *rsa.PrivateKey, kid, clientID string, spec Spec) (string, error) {
+// clientPool registers one client per distinct ClientConfig, on first use, and hands the same one back for every later scenario with that config.
+
+// Sharing matters beyond saving a call: the order-dependent consent scenarios assert a stored consent is reused, which only holds against one client.
+type clientPool struct {
+	runner  *Runner
+	spec    Spec
+	clients map[string]*testClient
+}
+
+func (p *clientPool) get(ctx context.Context, calls *[]result.HTTPCall, cfg ClientConfig) (*testClient, error) {
+	if cl, ok := p.clients[cfg.key()]; ok {
+		return cl, nil
+	}
+	cl, err := p.register(ctx, calls, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if p.clients == nil {
+		p.clients = map[string]*testClient{}
+	}
+	p.clients[cfg.key()] = cl
+	return cl, nil
+}
+
+// dedicated registers a client for one scenario's exclusive use and never caches it, since a deactivation on a pooled client would silently break every scenario sharing it.
+func (p *clientPool) dedicated(ctx context.Context, calls *[]result.HTTPCall, cfg ClientConfig) (*testClient, error) {
+	return p.register(ctx, calls, cfg)
+}
+
+// register mints a key and registers one new client for cfg.
+func (p *clientPool) register(ctx context.Context, calls *[]result.HTTPCall, cfg ClientConfig) (*testClient, error) {
+	r := p.runner
+	priv, err := generateRSA()
+	if err != nil {
+		return nil, fmt.Errorf("keygen: %w", err)
+	}
+	// Unique per client so two clients registered in the same second cannot collide on the kid or the client id.
+	stamp := strconv.FormatInt(time.Now().UnixNano(), 10)
+	cl := &testClient{priv: priv, kid: "e2e-" + stamp, cfg: cfg}
+	cl.clientID, err = r.createClient(ctx, calls, cl, "api-e2e-"+stamp, p.spec)
+	if err != nil {
+		return nil, err
+	}
+	if r.Logf != nil {
+		r.Logf("e2e: registered client %s (config: %s)", cl.clientID, cfg.label())
+	}
+	return cl, nil
+}
+
+// createClient registers the test client and returns the effective clientId for the rest of the flow.
+func (r *Runner) createClient(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, requestedID string, spec Spec) (string, error) {
+	if r.Plugin == "mosip" {
+		return r.createClientViaPMS(ctx, calls, cl, spec)
+	}
+	return r.createClientViaClientMgmt(ctx, calls, cl, requestedID, spec)
+}
+
+// createClientViaClientMgmt registers the test client via eSignet client-mgmt (admin bearer token); the harness picks the clientId and it is echoed back.
+func (r *Runner) createClientViaClientMgmt(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, clientID string, spec Spec) (string, error) {
+	request := map[string]any{
+		"clientId":          clientID,
+		"clientName":        "api e2e",
+		"clientNameLangMap": map[string]any{"eng": "api e2e"},
+		"relyingPartyId":    "api-e2e-rp",
+		"logoUri":           "https://example.org/logo.png",
+		"redirectUris":      []string{spec.RedirectURI},
+		"publicKey":         publicJWK(cl.priv, cl.kid),
+		"userClaims":        spec.UserClaims,
+		"authContextRefs":   spec.Acr,
+		"grantTypes":        []string{"authorization_code"},
+		"clientAuthMethods": []string{"private_key_jwt"},
+	}
+	if ac := cl.cfg.additionalConfig(); ac != nil {
+		request["additionalConfig"] = ac
+	}
 	reqBody := map[string]any{
 		"requestTime": time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
-		"request": map[string]any{
-			"clientId":          clientID,
-			"clientName":        "api e2e",
-			"clientNameLangMap": map[string]any{"eng": "api e2e"},
-			"relyingPartyId":    "api-e2e-rp",
-			"logoUri":           "https://example.org/logo.png",
-			"redirectUris":      []string{spec.RedirectURI},
-			"publicKey":         publicJWK(priv, kid),
-			"userClaims":        spec.UserClaims,
-			"authContextRefs":   spec.Acr,
-			"grantTypes":        []string{"authorization_code"},
-			"clientAuthMethods": []string{"private_key_jwt"},
-		},
+		"request":     request,
 	}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
@@ -497,36 +692,56 @@ func (r *Runner) createClientViaClientMgmt(ctx context.Context, calls *[]result.
 	return clientID, nil
 }
 
-// createClientViaPMS registers the test client through partner-management-service /oauth/client (v2).
-func (r *Runner) createClientViaPMS(ctx context.Context, calls *[]result.HTTPCall, priv *rsa.PrivateKey, kid string, spec Spec) (string, error) {
+// errPMSForbidden marks the one registration failure that is an environment gap rather than a defect: PMS refused the bearer for lack of a role.
+var errPMSForbidden = errors.New("PMS create client forbidden (KER-ATH-403)")
+
+// createClientViaPMS registers the test client through partner-management-service /oidc-clients — NOT /oauth/client, which IDA then refuses to authenticate (visible only by driving a login); the bearer needs the AUTH_PARTNER realm role, which a client_credentials service account does not carry (KER-ATH-403).
+func (r *Runner) createClientViaPMS(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, spec Spec) (string, error) {
 	if r.PMSBaseURL == "" || r.AuthPartnerID == "" || r.PolicyID == "" {
 		return "", fmt.Errorf("mosip client registration needs PMS_BASE_URL, AUTH_PARTNER_ID and AUTH_POLICY_ID")
 	}
+	request := map[string]any{
+		"name":              "api e2e",
+		"clientNameLangMap": map[string]any{"eng": "api e2e"},
+		"authPartnerId":     r.AuthPartnerID,
+		"policyId":          r.PolicyID,
+		"logoUri":           "https://example.org/logo.png",
+		"redirectUris":      []string{spec.RedirectURI},
+		"publicKey":         publicJWK(cl.priv, cl.kid),
+		"grantTypes":        []string{"authorization_code"},
+		"clientAuthMethods": []string{"private_key_jwt"},
+	}
+	// PMS silently drops additionalConfig on this endpoint (verified: round-tripping a client shows the field simply absent), so it is also sent here in case that ever changes, but the harness does not rely on it landing this way — see the patchAdditionalConfig call below.
+	ac := cl.cfg.additionalConfig()
+	if ac != nil {
+		request["additionalConfig"] = ac
+	}
 	reqBody := map[string]any{
+		// id and version are part of this endpoint's request wrapper, unlike /oauth/client which accepts requestTime alone.
+		"id":          "mosip.pms.create.oidc.client.post",
+		"version":     "1.0",
 		"requestTime": time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
-		"request": map[string]any{
-			"name":              "api e2e",
-			"clientNameLangMap": map[string]any{"eng": "api e2e"},
-			"authPartnerId":     r.AuthPartnerID,
-			"policyId":          r.PolicyID,
-			"logoUri":           "https://example.org/logo.png",
-			"redirectUris":      []string{spec.RedirectURI},
-			"publicKey":         publicJWK(priv, kid),
-			"grantTypes":        []string{"authorization_code"},
-			"clientAuthMethods": []string{"private_key_jwt"},
-		},
+		"metadata":    map[string]any{},
+		"request":     request,
 	}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return "", fmt.Errorf("marshal PMS request: %w", err)
 	}
-	url := strings.TrimRight(r.PMSBaseURL, "/") + "/oauth/client"
+	url := strings.TrimRight(r.PMSBaseURL, "/") + "/oidc-clients"
+	// PMS reads the admin token from a cookie named Authorization and rejects the Bearer header with KER-ATH-401, unlike eSignet's own client-mgmt.
 	status, rb, err := r.do(ctx, calls, "create client (PMS)", http.MethodPost, url,
-		map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + r.AdminToken}, string(body))
+		map[string]string{"Content-Type": "application/json", "Cookie": "Authorization=" + r.AdminToken}, string(body))
 	if err != nil {
 		return "", fmt.Errorf("create client via PMS: %w", err)
 	}
 	if code := firstErrorCode(rb); code != "" {
+		// The one rejection worth naming: /oidc-clients alone is gated on the AUTH_PARTNER realm role.
+		if code == "KER-ATH-403" {
+			return "", fmt.Errorf("%w: %s needs the AUTH_PARTNER realm role, "+
+				"which the client_credentials grant for keycloak.client_id does not carry — grant it that role, "+
+				"or point keycloak.client_id at a client that has it", errPMSForbidden, url)
+		}
 		return "", fmt.Errorf("PMS create client rejected (HTTP %d): %s", status, code)
 	}
 	if status < 200 || status > 299 {
@@ -543,29 +758,103 @@ func (r *Runner) createClientViaPMS(ctx context.Context, calls *[]result.HTTPCal
 	if resp.Response.ClientID == "" {
 		return "", fmt.Errorf("PMS create client: no clientId in response (HTTP %d): %s", status, snippet(rb))
 	}
+	if ac != nil {
+		if err := r.patchAdditionalConfig(ctx, calls, resp.Response.ClientID, ac); err != nil {
+			return "", fmt.Errorf("PMS created client %s but the eSignet additionalConfig patch failed: %w", resp.Response.ClientID, err)
+		}
+	}
 	return resp.Response.ClientID, nil
 }
 
+// patchAdditionalConfig sets additionalConfig through eSignet's own client-mgmt PATCH, which the engine actually reads for enforcement. No read-back is possible: ClientResponse.APIResponse() (esignet-service/internal/clientmgmt/model.go) strips every field but clientId and status from every client-mgmt response, additionalConfig included, on create/update/patch/get alike — confirmed live against esdev, not inferred. The protocol scenario this client is registered for is therefore the only real proof the patch took; a 2xx with no error code here is as far as this call itself can verify.
+func (r *Runner) patchAdditionalConfig(ctx context.Context, calls *[]result.HTTPCall, clientID string, ac map[string]any) error {
+	body, err := json.Marshal(map[string]any{
+		"requestTime": time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		"request":     map[string]any{"additionalConfig": ac},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal additionalConfig patch: %w", err)
+	}
+	status, rb, err := r.do(ctx, calls, "patch additionalConfig", http.MethodPatch, r.Base+"/client-mgmt/client/"+clientID,
+		map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + r.AdminToken}, string(body))
+	if err != nil {
+		return fmt.Errorf("patch additionalConfig: %w", err)
+	}
+	if code := firstErrorCode(rb); code != "" {
+		return fmt.Errorf("patch additionalConfig rejected (HTTP %d): %s", status, code)
+	}
+	if status < 200 || status > 299 {
+		return fmt.Errorf("patch additionalConfig failed (HTTP %d): %s", status, snippet(rb))
+	}
+	return nil
+}
+
+// scenarioConfigError reports why a scenario cannot be run at all, or "" when it is well formed; these are spec-file mistakes, caught before driving the flow.
+func scenarioConfigError(sc Scenario) string {
+	if sc.AuthFactor == "" {
+		return "auth_factor is required (otp|password|bio|kbi)"
+	}
+	// A rejected flow reaches no introspection, and the expected-rejection branch would report PASSED with no introspection call made.
+	if len(sc.Introspect) > 0 && sc.ExpectLoginFailure {
+		return "introspect and expect_login_failure are mutually exclusive — a rejected flow issues no token to introspect"
+	}
+	if msg := sc.ClientLifecycle.validate(); msg != "" {
+		return msg
+	}
+	return ""
+}
+
 // runScenario drives authorize/login/token/userinfo and returns claims, trace and protocol assertions.
-func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, clientID, redirectURI string, sc Scenario, answers map[string]string, preferred []string) (map[string]any, []result.HTTPCall, consentObservation, []result.Assertion, error) {
+func (r *Runner) runScenario(ctx context.Context, cl *testClient, redirectURI string, sc Scenario, answers map[string]string, preferred []string) (map[string]any, []result.HTTPCall, consentObservation, []result.Assertion, error) {
 	var calls []result.HTTPCall
-	verifier, challenge := pkce()
-	// proto collects the RP-side protocol checks (state, nonce) so they land in
-	// the report's Validation tab rather than only aborting the run.
+	// proto collects the RP-side protocol checks so they land in the report's Validation tab rather than only aborting the run.
 	var proto []result.Assertion
+
+	plan, perr := resolveFlow(cl.cfg, sc.Flow)
+	if perr != nil {
+		return nil, nil, consentObservation{}, proto, perr
+	}
+	// Validated before the flow is driven, so a mistyped selector costs a config error rather than a full login that then cannot be introspected.
+	introspectCases, ierr := resolveIntrospect(sc.Introspect)
+	if ierr != nil {
+		return nil, nil, consentObservation{}, proto, ierr
+	}
+	// One DPoP key for the whole flow: the proof at token must present the same thumbprint the PAR proof bound the auth code to.
+	var dp *dpopSigner
+	if plan.useDPoP {
+		alg, aerr := chooseDPoPAlg(r.DPoPAlgs)
+		if aerr != nil {
+			return nil, nil, consentObservation{}, proto, aerr
+		}
+		var derr error
+		if dp, derr = newDPoPSigner(alg); derr != nil {
+			return nil, nil, consentObservation{}, proto, derr
+		}
+	}
+
+	verifier, challenge := pkce()
 	state := "st-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 	nonce := "no-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
-	// authorize URL
+	// authorize parameters — pushed to /oauth2/par or sent on the authorize URL, depending on the plan, but identical either way.
 	q := url.Values{}
 	q.Set("response_type", "code")
-	q.Set("client_id", clientID)
+	q.Set("client_id", cl.clientID)
 	q.Set("scope", strings.Join(sc.Scopes, " "))
 	q.Set("redirect_uri", redirectURI)
 	q.Set("state", state)
 	q.Set("nonce", nonce)
-	q.Set("code_challenge", challenge)
-	q.Set("code_challenge_method", "S256")
+	switch plan.pkce {
+	case pkceS256:
+		q.Set("code_challenge", challenge)
+		q.Set("code_challenge_method", "S256")
+	case pkcePlain:
+		// The verifier itself is the challenge under the plain method, which FAPI2 forbids and eSignet is expected to reject.
+		q.Set("code_challenge", verifier)
+		q.Set("code_challenge_method", "plain")
+	case pkceNone:
+		// No challenge at all: a client with require_pkce must refuse.
+	}
 	if len(r.acrForClaims()) > 0 {
 		q.Set("acr_values", strings.Join(r.acrForClaims(), " "))
 	}
@@ -576,10 +865,32 @@ func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, cli
 		}
 		q.Set("claims", string(cj))
 	}
+
+	// Status changes are applied here, between building the request and sending it, so the stage name in the spec is literally where it happens.
+	lcAsserts, lcErr := r.applyAt(ctx, &calls, cl, sc.ClientLifecycle, stageBeforeAuthorize)
+	proto = append(proto, lcAsserts...)
+	if lcErr != nil {
+		return nil, calls, consentObservation{}, proto, lcErr
+	}
+
+	// Push the request first when the plan calls for it; per RFC 9126 the authorize URL then carries only client_id and the returned request_uri.
 	authURL := r.AuthEndpoint + "?" + q.Encode()
+	if plan.usePAR {
+		requestURI, aerr, ferr := r.pushAuthorizationRequest(ctx, &calls, cl, q, dp)
+		proto = append(proto, aerr...)
+		if ferr != nil {
+			return nil, calls, consentObservation{}, proto, ferr
+		}
+		authURL = r.AuthEndpoint + "?" + url.Values{
+			"client_id":   {cl.clientID},
+			"request_uri": {requestURI},
+		}.Encode()
+	}
 
 	// login via the shared driver (authorize -> flow/execute -> auth/callback)
 	driver := esignet.New(answers, preferred, r.TLSVerify, r.Timeout)
+	// Kept apart from `preferred`, which also carries auth-factor tokens like "otp" that every id tab's node name contains.
+	driver.UseIDType(esignet.IDTypeTokens(r.IDType))
 	if r.OTP != nil {
 		driver.SetOTPProvider(r.OTP)
 	}
@@ -591,8 +902,7 @@ func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, cli
 		return nil, calls, consentSeen, proto,
 			fmt.Errorf("login flow failed: %s", firstNonEmpty(fr.Error, "no redirect_uri"))
 	}
-	// state echo: an RP must reject a callback whose state is not the one it
-	// sent, otherwise a code from another authorization request is accepted.
+	// state echo: an RP must reject a callback whose state is not the one it sent, otherwise a code from another request is accepted.
 	gotState := stateFromRedirect(fr.RedirectURI)
 	proto = append(proto, result.Assertion{
 		Field: "authorize state echo", Expected: state, Actual: firstNonEmpty(gotState, "(absent)"),
@@ -603,12 +913,18 @@ func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, cli
 		return nil, calls, consentSeen, proto, err
 	}
 
+	lcAsserts, lcErr = r.applyAt(ctx, &calls, cl, sc.ClientLifecycle, stageAfterAuthorize)
+	proto = append(proto, lcAsserts...)
+	if lcErr != nil {
+		return nil, calls, consentSeen, proto, lcErr
+	}
+
 	// token exchange (private_key_jwt + PKCE): aud is the ISSUER, which is what eSignet validates against.
 	aud := r.Issuer
 	if aud == "" {
 		aud = r.TokenEndpoint
 	}
-	assertion, err := clientAssertion(priv, kid, clientID, aud)
+	assertion, err := clientAssertion(cl.priv, cl.kid, cl.clientID, aud)
 	if err != nil {
 		return nil, calls, consentSeen, proto, fmt.Errorf("client assertion: %w", err)
 	}
@@ -616,19 +932,32 @@ func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, cli
 		"grant_type":            {"authorization_code"},
 		"code":                  {code},
 		"redirect_uri":          {redirectURI},
-		"client_id":             {clientID},
-		"client_assertion_type": {"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"},
+		"client_id":             {cl.clientID},
+		"client_assertion_type": {clientAssertionTypeJWTBearer},
 		"client_assertion":      {assertion},
-		"code_verifier":         {verifier},
 	}
-	status, rb, err := r.do(ctx, &calls, "token", http.MethodPost, r.TokenEndpoint,
-		map[string]string{"Content-Type": "application/x-www-form-urlencoded"}, form.Encode())
+	// A flow that sent no challenge has no verifier to present.
+	if plan.pkce != pkceNone {
+		form.Set("code_verifier", verifier)
+	}
+
+	// The token proof normally uses the same key as the PAR proof; a mismatch scenario deliberately swaps in a second key to prove binding is enforced.
+	tokenSigner := dp
+	if plan.useDPoP && plan.dpopKeyMismatch {
+		other, oerr := newDPoPSigner(dp.alg)
+		if oerr != nil {
+			return nil, calls, consentSeen, proto, oerr
+		}
+		tokenSigner = other
+	}
+	status, rb, err := r.postWithDPoP(ctx, &calls, "token", r.TokenEndpoint, form.Encode(), tokenSigner, "")
 	if err != nil {
 		return nil, calls, consentSeen, proto, fmt.Errorf("token request: %w", err)
 	}
 	var tok struct {
 		AccessToken string `json:"access_token"`
 		IDToken     string `json:"id_token"`
+		TokenType   string `json:"token_type"`
 		Error       string `json:"error"`
 		ErrorDesc   string `json:"error_description"`
 	}
@@ -636,12 +965,39 @@ func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, cli
 	if tok.AccessToken == "" {
 		return nil, calls, consentSeen, proto, fmt.Errorf("token exchange failed (HTTP %d): %s", status, firstNonEmpty(tok.Error+" "+tok.ErrorDesc, snippet(rb)))
 	}
+	// What the introspection cases submit and are cross-checked against.
+	tk := tokenSet{accessToken: tok.AccessToken, idToken: tok.IDToken}
+	if plan.useDPoP {
+		tk.dpopJKT = tokenSigner.jkt
+	}
+
+	// A DPoP-bound token must be issued as token_type=DPoP, or a Bearer token here would silently undo the binding.
+	if plan.useDPoP {
+		proto = append(proto, result.Assertion{
+			Field: "token_type", Expected: "DPoP",
+			Actual: firstNonEmpty(tok.TokenType, "(absent)"),
+			Passed: strings.EqualFold(tok.TokenType, "DPoP"),
+		})
+		// cnf.jkt is the binding itself — the thumbprint of the key that must prove possession at every resource call.
+		if payload, derr := decodeJWTPayload(tok.AccessToken); derr == nil {
+			got := ""
+			if cnf, ok := payload["cnf"].(map[string]any); ok {
+				got, _ = cnf["jkt"].(string)
+			}
+			proto = append(proto, result.Assertion{
+				Field: "access_token cnf.jkt", Expected: tokenSigner.jkt,
+				Actual: firstNonEmpty(got, "(absent)"), Passed: got == tokenSigner.jkt,
+			})
+		}
+	}
 
 	// nonce echo: OIDC Core 3.1.3.7 requires the ID token to carry back the authorize request's nonce.
 	if tok.IDToken != "" {
 		got := ""
 		if payload, derr := decodeJWTPayload(tok.IDToken); derr == nil {
 			got, _ = payload["nonce"].(string)
+			// The subject the introspection response must agree with.
+			tk.sub, _ = payload["sub"].(string)
 		}
 		proto = append(proto, result.Assertion{
 			Field: "id_token nonce echo", Expected: nonce, Actual: firstNonEmpty(got, "(absent)"),
@@ -649,14 +1005,26 @@ func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, cli
 		})
 	}
 
-	// userinfo
-	ustatus, ub, err := r.do(ctx, &calls, "userinfo", http.MethodGet, r.UserinfoEndpoint,
-		map[string]string{"Authorization": "Bearer " + tok.AccessToken}, "")
+	lcAsserts, lcErr = r.applyAt(ctx, &calls, cl, sc.ClientLifecycle, stageAfterToken)
+	proto = append(proto, lcAsserts...)
+	if lcErr != nil {
+		return nil, calls, consentSeen, proto, lcErr
+	}
+
+	// userinfo — presented with the DPoP scheme and a proof carrying ath when the token is bound, with Bearer otherwise (a scenario can force Bearer on a bound token to check the resource endpoint honours the binding).
+	uheaders := map[string]string{"Authorization": "Bearer " + tok.AccessToken}
+	usigner := tokenSigner
+	if plan.useDPoP && !plan.bearerAtUserinfo {
+		uheaders["Authorization"] = "DPoP " + tok.AccessToken
+	} else {
+		// Bearer: no proof to sign, and none to retry with a nonce.
+		usigner = nil
+	}
+	ustatus, ub, err := r.getWithDPoP(ctx, &calls, "userinfo", r.UserinfoEndpoint, uheaders, usigner, tok.AccessToken)
 	if err != nil {
 		return nil, calls, consentSeen, proto, fmt.Errorf("userinfo request: %w", err)
 	}
-	// A JSON error body would otherwise parse as a claims map and surface later
-	// as a vague "claim X absent" instead of the actual HTTP failure.
+	// A JSON error body would otherwise parse as a claims map and surface later as a vague "claim X absent" instead of the real HTTP failure.
 	if ustatus < 200 || ustatus > 299 {
 		return nil, calls, consentSeen, proto, fmt.Errorf("userinfo request failed (HTTP %d): %s", ustatus, snippet(ub))
 	}
@@ -664,8 +1032,106 @@ func (r *Runner) runScenario(ctx context.Context, priv *rsa.PrivateKey, kid, cli
 	if err != nil {
 		return nil, calls, consentSeen, proto, fmt.Errorf("userinfo parse: %w", err)
 	}
+
+	// Introspection runs last, on tokens the flow has just proven usable, so a failure here is the endpoint's, not a stale token's.
+	if len(introspectCases) > 0 {
+		proto = append(proto, r.introspect(ctx, &calls, cl, introspectCases, tk)...)
+	}
 	return claims, calls, consentSeen, proto, nil
 }
 
+// requestURIPrefix is the URN namespace RFC 9126 reserves for PAR request URIs.
+const requestURIPrefix = "urn:ietf:params:oauth:request_uri:"
+
+// pushAuthorizationRequest posts the authorization parameters to /oauth2/par and returns the request_uri to drive authorize with; a DPoP proof sent here is what binds the resulting authorization code to the proof key.
+func (r *Runner) pushAuthorizationRequest(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, params url.Values, dp *dpopSigner) (string, []result.Assertion, error) {
+	if r.PAREndpoint == "" {
+		return "", nil, fmt.Errorf("this scenario requires PAR, but discovery advertises no pushed_authorization_request_endpoint")
+	}
+	aud := r.Issuer
+	if aud == "" {
+		aud = r.PAREndpoint
+	}
+	assertion, err := clientAssertion(cl.priv, cl.kid, cl.clientID, aud)
+	if err != nil {
+		return "", nil, fmt.Errorf("par client assertion: %w", err)
+	}
+	form := url.Values{}
+	maps.Copy(form, params)
+	form.Set("client_assertion_type", clientAssertionTypeJWTBearer)
+	form.Set("client_assertion", assertion)
+	if dp != nil {
+		// dpop_jkt states the binding in the request as well as the proof; the server rejects the pair when they disagree.
+		form.Set("dpop_jkt", dp.jkt)
+	}
+
+	status, rb, err := r.postWithDPoP(ctx, calls, "par", r.PAREndpoint, form.Encode(), dp, "")
+	if err != nil {
+		return "", nil, fmt.Errorf("par request: %w", err)
+	}
+	var resp struct {
+		RequestURI string `json:"request_uri"`
+		ExpiresIn  int64  `json:"expires_in"`
+		Error      string `json:"error"`
+		ErrorDesc  string `json:"error_description"`
+	}
+	_ = json.Unmarshal(rb, &resp)
+	if resp.RequestURI == "" {
+		return "", nil, fmt.Errorf("par failed (HTTP %d): %s", status, firstNonEmpty(resp.Error+" "+resp.ErrorDesc, snippet(rb)))
+	}
+	asserts := []result.Assertion{{
+		Field: "PAR request_uri", Expected: requestURIPrefix + "…",
+		Actual: resp.RequestURI, Passed: strings.HasPrefix(resp.RequestURI, requestURIPrefix),
+	}}
+	return resp.RequestURI, asserts, nil
+}
+
+// postWithDPoP posts a form, attaching a DPoP proof when dp is non-nil, retried exactly once on a use_dpop_nonce handshake.
+func (r *Runner) postWithDPoP(ctx context.Context, calls *[]result.HTTPCall, label, endpoint, body string, dp *dpopSigner, accessToken string) (int, []byte, error) {
+	headers := map[string]string{"Content-Type": "application/x-www-form-urlencoded"}
+	if dp == nil {
+		status, rb, err := r.do(ctx, calls, label, http.MethodPost, endpoint, headers, body)
+		return status, rb, err
+	}
+	for attempt := 0; ; attempt++ {
+		proof, err := dp.proof(http.MethodPost, endpoint, accessToken)
+		if err != nil {
+			return 0, nil, fmt.Errorf("%s dpop proof: %w", label, err)
+		}
+		headers["DPoP"] = proof
+		status, rb, respHeaders, err := r.doWithHeaders(ctx, calls, label, http.MethodPost, endpoint, headers, body)
+		if err != nil {
+			return status, rb, err
+		}
+		if attempt == 0 && isDPoPNonceError(rb) && dp.dpopNonceFrom(respHeaders) {
+			continue
+		}
+		return status, rb, nil
+	}
+}
+
 // acrForClaims returns the client's registered ACRs for the authorize request.
+
+// getWithDPoP is postWithDPoP for a resource read, retrying once on a RFC 9449 s8 DPoP-Nonce challenge; dp nil means Bearer, so the call is made once.
+func (r *Runner) getWithDPoP(ctx context.Context, calls *[]result.HTTPCall, label, endpoint string, headers map[string]string, dp *dpopSigner, accessToken string) (int, []byte, error) {
+	if dp == nil {
+		return r.do(ctx, calls, label, http.MethodGet, endpoint, headers, "")
+	}
+	for attempt := 0; ; attempt++ {
+		proof, err := dp.proof(http.MethodGet, endpoint, accessToken)
+		if err != nil {
+			return 0, nil, fmt.Errorf("%s dpop proof: %w", label, err)
+		}
+		headers["DPoP"] = proof
+		status, rb, respHeaders, err := r.doWithHeaders(ctx, calls, label, http.MethodGet, endpoint, headers, "")
+		if err != nil {
+			return status, rb, err
+		}
+		if attempt == 0 && isDPoPNonceError(rb) && dp.dpopNonceFrom(respHeaders) {
+			continue
+		}
+		return status, rb, nil
+	}
+}
+
 func (r *Runner) acrForClaims() []string { return r.acr }

--- a/api-test/internal/e2e/e2e_test.go
+++ b/api-test/internal/e2e/e2e_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -23,8 +24,7 @@ func specWith(names ...string) Spec {
 }
 
 func TestRegistrationFailureRows_EnvNotReadyWhenPartnerMissing(t *testing.T) {
-	// mosip with no PMS config -> every scenario reported ENV_NOT_READY (not run),
-	// so the testcases stay visible in the report while onboarding is pending.
+	// mosip with no PMS config -> every scenario reported ENV_NOT_READY (not run), staying visible while onboarding is pending.
 	r := &Runner{Plugin: "mosip"} // PMSBaseURL/AuthPartnerID/PolicyID all empty
 	spec := specWith("otp positive", "otp negative", "password positive")
 	rows := r.registrationFailureRows(spec, nil, errors.New("needs AUTH_PARTNER_ID"))
@@ -88,8 +88,7 @@ func TestAttachSetupCalls(t *testing.T) {
 	if out[0].Calls[0].Label != "create client" || out[0].Calls[1].Label != "flow/execute" {
 		t.Errorf("Calls not in chronological order: %+v", out[0].Calls)
 	}
-	// CollapseCalls renumbers on its own axis (chronological), which must not
-	// collide: both inputs numbered their own Seq from 1 independently.
+	// CollapseCalls renumbers chronologically, since both inputs numbered their own Seq from 1 independently.
 	if out[0].Calls[0].Seq != 1 || out[0].Calls[1].Seq != 2 {
 		t.Errorf("Calls not renumbered: %+v", out[0].Calls)
 	}
@@ -145,8 +144,7 @@ func TestAssertClaimsFailsOnUnverifiedJWS(t *testing.T) {
 	}
 }
 
-// mixedSpec mirrors a real spec file: several ACRs, positive and negative cases,
-// plus client-registration fields that must survive filtering.
+// mixedSpec mirrors a real spec file: several ACRs, positive/negative cases, plus client-registration fields that must survive filtering.
 func mixedSpec() Spec {
 	return Spec{
 		RedirectURI: "https://rp.example/cb",
@@ -254,8 +252,7 @@ func TestSelectRejectsBadRegex(t *testing.T) {
 
 // --- consent assertions -----------------------------------------------------
 
-// A scenario with no consent block must assert nothing about consent, so every
-// pre-existing scenario keeps its current pass/fail semantics.
+// A scenario with no consent block must assert nothing about consent, so every pre-existing scenario keeps its current pass/fail semantics.
 func TestAssertConsentNoSpecAssertsNothing(t *testing.T) {
 	if got := assertConsent(Scenario{Name: "x"}, consentObservation{prompted: true}); got != nil {
 		t.Fatalf("assertConsent with no spec produced %d assertion(s), want none", len(got))
@@ -288,8 +285,7 @@ func TestAssertConsentExpectPrompt(t *testing.T) {
 	}
 }
 
-// An empty ExpectPrompt asserts nothing about prompting — used by deny-only
-// scenarios that don't care whether this was a first or repeat authorization.
+// An empty ExpectPrompt asserts nothing about prompting — used by deny-only scenarios that don't care whether this was a first or repeat authorization.
 func TestAssertConsentEmptyExpectPromptSkipsThatCheck(t *testing.T) {
 	sc := Scenario{Consent: &ConsentSpec{}}
 	if got := assertConsent(sc, consentObservation{prompted: true}); len(got) != 0 {
@@ -297,8 +293,7 @@ func TestAssertConsentEmptyExpectPromptSkipsThatCheck(t *testing.T) {
 	}
 }
 
-// A deny that never took effect must FAIL: the scenario's claim assertions would
-// otherwise pass or fail for reasons unrelated to consent.
+// A deny that never took effect must FAIL, or the scenario's claim assertions would pass/fail for reasons unrelated to consent.
 func TestAssertConsentDenyRequiresSomethingWithheld(t *testing.T) {
 	sc := Scenario{Consent: &ConsentSpec{Deny: []string{"name"}}}
 
@@ -326,14 +321,25 @@ func TestShippedSpecsParseAndAreConsistent(t *testing.T) {
 				t.Fatalf("parse: %v", err)
 			}
 
-			// Every successful login stores a consent record keyed by its scopes+claims hash for the shared client.
+			// Every successful login stores a consent record keyed by scopes+claims hash and client config, since a differently-configured client is a different client.
 			var sawConsent, sawReuse bool
 			consented := map[string]string{}
 			for _, sc := range spec.Scenarios {
 				if sc.AuthFactor == "" {
 					t.Errorf("scenario %q has no auth_factor", sc.Name)
 				}
-				key := strings.Join(sc.Scopes, " ") + "|" + fmt.Sprint(sc.UserinfoClaims)
+				if msg := sc.ClientLifecycle.validate(); msg != "" {
+					t.Errorf("scenario %q: %s", sc.Name, msg)
+				}
+				cfg := ClientConfig{}
+				if sc.ClientConfig != nil {
+					cfg = *sc.ClientConfig
+				}
+				key := cfg.key() + "|" + strings.Join(sc.Scopes, " ") + "|" + fmt.Sprint(sc.UserinfoClaims)
+				// A scenario that changes its client's status gets a client of its own, so keying by name keeps it out of everyone else's consent bookkeeping.
+				if sc.ClientLifecycle != nil {
+					key += "|dedicated:" + sc.Name
+				}
 
 				if sc.Consent != nil {
 					sawConsent = true
@@ -345,8 +351,7 @@ func TestShippedSpecsParseAndAreConsistent(t *testing.T) {
 
 					switch strings.ToLower(sc.Consent.ExpectPrompt) {
 					case "no":
-						// Must repeat an earlier succeeding scenario's exact request, or
-						// the hash differs and the server re-prompts.
+						// Must repeat an earlier succeeding scenario's exact request, or the hash differs and the server re-prompts.
 						sawReuse = true
 						if _, ok := consented[key]; !ok {
 							t.Errorf("scenario %q expects NO prompt but no earlier succeeding scenario requested the same scopes/claims (%s)", sc.Name, key)
@@ -428,5 +433,70 @@ func TestRSAPubFromJWKRejectsDegenerateKeys(t *testing.T) {
 				t.Fatalf("rsaPubFromJWK accepted %s", tc.name)
 			}
 		})
+	}
+}
+
+// requireHTTPS is the last line of defense against sending AdminToken in cleartext; it must accept exactly absolute https URLs.
+func TestRequireHTTPSAcceptsAbsoluteHTTPS(t *testing.T) {
+	if err := requireHTTPS("esignet base URL", "https://esignet.example.org/v1/esignet"); err != nil {
+		t.Fatalf("requireHTTPS rejected a valid https URL: %v", err)
+	}
+}
+
+func TestRequireHTTPSRejectsNonHTTPS(t *testing.T) {
+	for _, tc := range []struct{ name, raw string }{
+		{"http scheme", "http://esignet.example.org/v1/esignet"},
+		{"empty", ""},
+		{"scheme only, no host", "https://"},
+		{"no scheme", "esignet.example.org/v1/esignet"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := requireHTTPS("esignet base URL", tc.raw); err == nil {
+				t.Fatalf("requireHTTPS accepted %q", tc.raw)
+			}
+		})
+	}
+}
+
+// An https base URL is worthless cover for AdminToken if the client isn't
+// actually validating the certificate on the other end of it -- TLSVerify:false
+// sets InsecureSkipVerify, which accepts any certificate a man-in-the-middle
+// presents. Run must refuse this combination before any request is sent,
+// the same way it already refuses a non-https base URL.
+func TestRunRejectsAdminTokenWithDisabledTLSVerify(t *testing.T) {
+	r := &Runner{Base: "https://esignet.example.org/v1/esignet", AdminToken: "t", TLSVerify: false}
+	rows := r.Run(context.Background(), specWith("otp positive"))
+
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].Result != "FAILED" {
+		t.Errorf("Result = %q, want FAILED", rows[0].Result)
+	}
+	found := false
+	for _, c := range rows[0].FailedConditions {
+		if strings.Contains(c.Msg, "TLS verification") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("FailedConditions = %+v, want one naming TLS verification", rows[0].FailedConditions)
+	}
+}
+
+// TLSVerify:true with AdminToken set must reach the ordinary https-URL check
+// (and fail there, since the test doesn't stand up a real server) rather than
+// being rejected for the TLS setting itself.
+func TestRunAllowsAdminTokenWithTLSVerifyEnabled(t *testing.T) {
+	r := &Runner{Base: "not-a-url", AdminToken: "t", TLSVerify: true}
+	rows := r.Run(context.Background(), specWith("otp positive"))
+
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	for _, c := range rows[0].FailedConditions {
+		if strings.Contains(c.Msg, "TLS verification") {
+			t.Errorf("rejected for TLS verification with TLSVerify:true: %+v", rows[0].FailedConditions)
+		}
 	}
 }

--- a/api-test/internal/e2e/introspect.go
+++ b/api-test/internal/e2e/introspect.go
@@ -1,0 +1,373 @@
+package e2e
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mosip/esignet/api-test/internal/result"
+)
+
+// RFC 7662 token introspection at /oauth2/introspect: an unrecognised token answers 200 with active=false (s2.2), never an error, and an inactive answer carries no other metadata (s4).
+
+// Token selectors: what a case submits in the "token" parameter.
+const (
+	introspectAccessToken = "access_token"
+	introspectIDToken     = "id_token"
+	introspectUnissued    = "unissued"
+	introspectNoToken     = "none"
+)
+
+// Client-authentication modes for the introspection call.
+const (
+	introspectAuthPrivateKeyJWT = "private_key_jwt"
+	introspectAuthNoAssertion   = "no_assertion"
+	introspectAuthWrongKey      = "wrong_key"
+	introspectAuthWrongAudience = "wrong_audience"
+)
+
+// wrongAudience is an issuer this deployment is not, for an assertion whose audience is deliberately somebody else's.
+const wrongAudience = "https://not-this-issuer.example.org"
+
+// IntrospectCase is one introspection request and what is expected back.
+type IntrospectCase struct {
+	// Name labels the case in the report, so a scenario running several says which one failed.
+	Name string `json:"name"`
+
+	// Token selects what is submitted: access_token (default), id_token, unissued (never minted), or none (omitted entirely).
+	Token string `json:"token"`
+
+	// Hint sets token_type_hint; omitted when empty, to prove the endpoint resolves the token without being told its type.
+	Hint string `json:"hint"`
+
+	// ClientAuth is how the call authenticates: private_key_jwt (default), no_assertion, wrong_key, or wrong_audience.
+	ClientAuth string `json:"client_auth"`
+
+	// ExpectStatus is the HTTP status the call must answer with. Defaults to 200.
+	ExpectStatus int `json:"expect_status"`
+
+	// ExpectActive asserts the "active" member; left unset, nothing is asserted, which is what an error case wants.
+	ExpectActive *bool `json:"expect_active"`
+
+	// ExpectPresent, ExpectValues and ExpectAbsent check response members; names may be dotted paths, values may use {{client_id}}/{{issuer}}/{{sub}}/{{dpop_jkt}} placeholders.
+	ExpectPresent []string          `json:"expect_present"`
+	ExpectValues  map[string]string `json:"expect_values"`
+	ExpectAbsent  []string          `json:"expect_absent"`
+
+	// ExpectError is the OAuth "error" member a rejection must carry.
+	ExpectError string `json:"expect_error"`
+}
+
+// resolve validates the case and fills in its defaults.
+func (c IntrospectCase) resolve() (IntrospectCase, error) {
+	out := c
+	switch strings.ToLower(strings.TrimSpace(c.Token)) {
+	case "", introspectAccessToken:
+		out.Token = introspectAccessToken
+	case introspectIDToken:
+		out.Token = introspectIDToken
+	case introspectUnissued:
+		out.Token = introspectUnissued
+	case introspectNoToken:
+		out.Token = introspectNoToken
+	default:
+		return out, fmt.Errorf("introspect.token %q is not one of access_token, id_token, unissued, none", c.Token)
+	}
+	switch strings.ToLower(strings.TrimSpace(c.ClientAuth)) {
+	case "", introspectAuthPrivateKeyJWT:
+		out.ClientAuth = introspectAuthPrivateKeyJWT
+	case introspectAuthNoAssertion:
+		out.ClientAuth = introspectAuthNoAssertion
+	case introspectAuthWrongKey:
+		out.ClientAuth = introspectAuthWrongKey
+	case introspectAuthWrongAudience:
+		out.ClientAuth = introspectAuthWrongAudience
+	default:
+		return out, fmt.Errorf("introspect.client_auth %q is not one of private_key_jwt, no_assertion, wrong_key, wrong_audience", c.ClientAuth)
+	}
+	if out.ExpectStatus == 0 {
+		out.ExpectStatus = http.StatusOK
+	}
+	if strings.TrimSpace(out.Name) == "" {
+		out.Name = out.Token + "/" + out.ClientAuth
+	}
+	return out, nil
+}
+
+// resolveIntrospect validates every case up front, so a mistyped selector fails the scenario before a login flow is driven for it.
+func resolveIntrospect(cases []IntrospectCase) ([]IntrospectCase, error) {
+	out := make([]IntrospectCase, 0, len(cases))
+	for i, c := range cases {
+		rc, err := c.resolve()
+		if err != nil {
+			return nil, fmt.Errorf("introspect case %d: %w", i+1, err)
+		}
+		out = append(out, rc)
+	}
+	return out, nil
+}
+
+// tokenSet is what a completed flow obtained, and the values an introspection response is cross-checked against.
+type tokenSet struct {
+	accessToken string
+	idToken     string
+	sub         string // sub of the id_token; "" when the flow returned none
+	dpopJKT     string // thumbprint the access token is bound to; "" when unbound
+}
+
+// introspect runs every case and returns the assertions they produced; it never returns an error, since a transport failure is itself a failed assertion.
+func (r *Runner) introspect(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, cases []IntrospectCase, tk tokenSet) []result.Assertion {
+	if r.IntrospectEndpoint == "" {
+		return []result.Assertion{{
+			Field: "introspection endpoint", Expected: "advertised in discovery",
+			Actual: "(absent) — this deployment publishes no introspection_endpoint", Passed: false,
+		}}
+	}
+	var out []result.Assertion
+	for _, c := range cases {
+		out = append(out, r.introspectOne(ctx, calls, cl, c, tk)...)
+	}
+	return out
+}
+
+func (r *Runner) introspectOne(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, c IntrospectCase, tk tokenSet) []result.Assertion {
+	field := func(what string) string { return fmt.Sprintf("introspection [%s] %s", c.Name, what) }
+
+	form, err := r.introspectForm(cl, c, tk)
+	if err != nil {
+		return []result.Assertion{{Field: field("request"), Expected: "built", Actual: err.Error(), Passed: false}}
+	}
+	headers := map[string]string{"Content-Type": "application/x-www-form-urlencoded"}
+	status, rb, err := r.do(ctx, calls, "introspect ("+c.Name+")", http.MethodPost, r.IntrospectEndpoint, headers, form.Encode())
+	if err != nil {
+		return []result.Assertion{{Field: field("request"), Expected: "completed", Actual: err.Error(), Passed: false}}
+	}
+
+	out := []result.Assertion{{
+		Field: field("HTTP status"), Expected: strconv.Itoa(c.ExpectStatus),
+		Actual: strconv.Itoa(status), Passed: status == c.ExpectStatus,
+	}}
+
+	var body map[string]any
+	if uerr := json.Unmarshal(rb, &body); uerr != nil {
+		return append(out, result.Assertion{
+			Field: field("response body"), Expected: "a JSON object",
+			Actual: snippet(rb), Passed: false,
+		})
+	}
+
+	if c.ExpectActive != nil {
+		want := *c.ExpectActive
+		got, isBool := body["active"].(bool)
+		out = append(out, result.Assertion{
+			Field: field("active"), Expected: strconv.FormatBool(want),
+			Actual: memberString(body, "active"), Passed: isBool && got == want,
+		})
+	}
+	if c.ExpectError != "" {
+		got, _ := body["error"].(string)
+		out = append(out, result.Assertion{
+			Field: field("error"), Expected: c.ExpectError,
+			Actual: firstNonEmpty(got, "(absent)"), Passed: got == c.ExpectError,
+		})
+	}
+
+	subs := introspectPlaceholders(r, cl, tk)
+	for _, path := range c.ExpectPresent {
+		_, present := lookupMember(body, path)
+		out = append(out, result.Assertion{
+			Field: field(path), Expected: "present", Actual: memberString(body, path), Passed: present,
+		})
+	}
+	for _, path := range sortedKeys(c.ExpectValues) {
+		expected := substitute(c.ExpectValues[path], subs)
+		v, present := lookupMember(body, path)
+		out = append(out, result.Assertion{
+			Field: field(path), Expected: expected, Actual: memberString(body, path),
+			Passed: present && matchesMember(v, expected),
+		})
+	}
+	for _, path := range c.ExpectAbsent {
+		_, present := lookupMember(body, path)
+		out = append(out, result.Assertion{
+			Field: field(path), Expected: "absent", Actual: memberString(body, path), Passed: !present,
+		})
+	}
+
+	// An active token must not already be expired, or a resource server could accept a token the authorization server itself considers dead.
+	if c.ExpectActive != nil && *c.ExpectActive {
+		if exp, ok := lookupMember(body, "exp"); ok {
+			if secs, isNum := exp.(float64); isNum {
+				at := time.Unix(int64(secs), 0).UTC()
+				out = append(out, result.Assertion{
+					Field: field("exp"), Expected: "in the future",
+					Actual: at.Format(time.RFC3339), Passed: at.After(time.Now()),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// introspectForm builds the request body for one case.
+func (r *Runner) introspectForm(cl *testClient, c IntrospectCase, tk tokenSet) (url.Values, error) {
+	form := url.Values{}
+	switch c.Token {
+	case introspectAccessToken:
+		form.Set("token", tk.accessToken)
+	case introspectIDToken:
+		if tk.idToken == "" {
+			return nil, fmt.Errorf("case needs an id_token, but the token response carried none")
+		}
+		form.Set("token", tk.idToken)
+	case introspectUnissued:
+		form.Set("token", unissuedToken())
+	case introspectNoToken:
+		// The parameter is deliberately left out.
+	}
+	if c.Hint != "" {
+		form.Set("token_type_hint", c.Hint)
+	}
+
+	// aud is the issuer, matching what the token call sends and what eSignet validates a client assertion against.
+	aud := r.Issuer
+	if aud == "" {
+		aud = r.IntrospectEndpoint
+	}
+	switch c.ClientAuth {
+	case introspectAuthNoAssertion:
+		form.Set("client_id", cl.clientID)
+	case introspectAuthPrivateKeyJWT, introspectAuthWrongAudience:
+		key := cl.priv
+		if c.ClientAuth == introspectAuthWrongAudience {
+			aud = wrongAudience
+		}
+		assertion, err := clientAssertion(key, cl.kid, cl.clientID, aud)
+		if err != nil {
+			return nil, fmt.Errorf("client assertion: %w", err)
+		}
+		setClientAuth(form, cl.clientID, assertion)
+	case introspectAuthWrongKey:
+		// A key the client never registered: correctly formed and audienced, but unverifiable against the registered JWK.
+		other, err := generateRSA()
+		if err != nil {
+			return nil, err
+		}
+		assertion, err := clientAssertion(other, cl.kid, cl.clientID, aud)
+		if err != nil {
+			return nil, fmt.Errorf("client assertion: %w", err)
+		}
+		setClientAuth(form, cl.clientID, assertion)
+	}
+	return form, nil
+}
+
+// setClientAuth writes the private_key_jwt members onto a form.
+func setClientAuth(form url.Values, clientID, assertion string) {
+	form.Set("client_id", clientID)
+	form.Set("client_assertion_type", clientAssertionTypeJWTBearer)
+	form.Set("client_assertion", assertion)
+}
+
+// unissuedToken is a random opaque value this deployment cannot have minted; opaque on purpose, since RFC 7662 s2.2 requires active:false whatever the shape.
+func unissuedToken() string {
+	raw := make([]byte, 32)
+	_, _ = rand.Read(raw)
+	return "unissued-" + b64(raw)
+}
+
+// introspectPlaceholders are the run-time values a spec file cannot know ahead of the run.
+func introspectPlaceholders(r *Runner, cl *testClient, tk tokenSet) map[string]string {
+	return map[string]string{
+		"{{client_id}}": cl.clientID,
+		"{{issuer}}":    r.Issuer,
+		"{{sub}}":       tk.sub,
+		"{{dpop_jkt}}":  tk.dpopJKT,
+	}
+}
+
+func substitute(s string, subs map[string]string) string {
+	for k, v := range subs {
+		s = strings.ReplaceAll(s, k, v)
+	}
+	return s
+}
+
+// lookupMember resolves a dotted path against a decoded JSON object.
+func lookupMember(m map[string]any, path string) (any, bool) {
+	var cur any = m
+	for _, seg := range strings.Split(path, ".") {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = obj[seg]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// memberString renders a member for the report, or "(absent)" when the path resolves to nothing.
+func memberString(m map[string]any, path string) string {
+	v, ok := lookupMember(m, path)
+	if !ok {
+		return "(absent)"
+	}
+	return introspectValue(v)
+}
+
+// matchesMember compares a response member against an expected string; an array matches when any element does, since RFC 7662 lets aud be a string or a list.
+func matchesMember(v any, expected string) bool {
+	if arr, ok := v.([]any); ok {
+		for _, e := range arr {
+			if introspectValue(e) == expected {
+				return true
+			}
+		}
+		return false
+	}
+	return introspectValue(v) == expected
+}
+
+// introspectValue renders a JSON member for the report; whole numbers print as integers, so an exp reads 1735689600 rather than 1.7356896e+09.
+func introspectValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return "null"
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		if t == math.Trunc(t) && math.Abs(t) < 1e15 {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return fmt.Sprintf("%v", t)
+		}
+		return string(b)
+	}
+}
+
+// sortedKeys orders a map's keys, so the assertion trace comes out in the same sequence every run rather than Go's randomized map order.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/api-test/internal/e2e/introspect_test.go
+++ b/api-test/internal/e2e/introspect_test.go
@@ -1,0 +1,315 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/mosip/esignet/api-test/internal/result"
+)
+
+func TestIntrospectCaseResolveDefaults(t *testing.T) {
+	got, err := IntrospectCase{}.resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Token != introspectAccessToken {
+		t.Errorf("token = %q, want %q", got.Token, introspectAccessToken)
+	}
+	if got.ClientAuth != introspectAuthPrivateKeyJWT {
+		t.Errorf("client_auth = %q, want %q", got.ClientAuth, introspectAuthPrivateKeyJWT)
+	}
+	if got.ExpectStatus != http.StatusOK {
+		t.Errorf("expect_status = %d, want 200", got.ExpectStatus)
+	}
+	// An unnamed case still has to be identifiable in the report.
+	if got.Name == "" {
+		t.Error("resolve left the case unnamed")
+	}
+}
+
+func TestIntrospectCaseResolveRejectsUnknownSelectors(t *testing.T) {
+	if _, err := (IntrospectCase{Token: "refresh_token"}).resolve(); err == nil {
+		t.Error("unknown token selector was accepted")
+	}
+	if _, err := (IntrospectCase{ClientAuth: "client_secret_basic"}).resolve(); err == nil {
+		t.Error("unknown client_auth mode was accepted")
+	}
+	// A mistyped selector must name the offending case, not just the field.
+	_, err := resolveIntrospect([]IntrospectCase{{}, {Token: "nope"}})
+	if err == nil || !strings.Contains(err.Error(), "case 2") {
+		t.Errorf("resolveIntrospect error = %v, want it to name case 2", err)
+	}
+}
+
+// A case must be able to assert against values only the run knows.
+func TestIntrospectPlaceholderSubstitution(t *testing.T) {
+	subs := introspectPlaceholders(
+		&Runner{Issuer: "https://issuer.example"},
+		&testClient{clientID: "cid-1"},
+		tokenSet{sub: "sub-1", dpopJKT: "jkt-1"},
+	)
+	for in, want := range map[string]string{
+		"{{client_id}}": "cid-1",
+		"{{issuer}}":    "https://issuer.example",
+		"{{sub}}":       "sub-1",
+		"{{dpop_jkt}}":  "jkt-1",
+		"literal":       "literal",
+	} {
+		if got := substitute(in, subs); got != want {
+			t.Errorf("substitute(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLookupMemberDottedPath(t *testing.T) {
+	var body map[string]any
+	if err := json.Unmarshal([]byte(`{"active":true,"cnf":{"jkt":"abc"},"aud":["cid-1","other"]}`), &body); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := lookupMember(body, "cnf.jkt"); !ok || v != "abc" {
+		t.Errorf("cnf.jkt = %v (ok=%v), want abc", v, ok)
+	}
+	if _, ok := lookupMember(body, "cnf.missing"); ok {
+		t.Error("cnf.missing resolved")
+	}
+	// A scalar is not an object, so a path through it must not resolve.
+	if _, ok := lookupMember(body, "active.nested"); ok {
+		t.Error("active.nested resolved")
+	}
+	// RFC 7662 lets aud be a string or a list; a case should not have to know which.
+	aud, _ := lookupMember(body, "aud")
+	if !matchesMember(aud, "cid-1") {
+		t.Error("aud array did not match one of its elements")
+	}
+	if matchesMember(aud, "cid-2") {
+		t.Error("aud array matched an element it does not contain")
+	}
+}
+
+// exp and iat are JSON numbers; a report reading 1.7356896e+09 helps nobody.
+func TestIntrospectValueRendersWholeNumbersAsIntegers(t *testing.T) {
+	for in, want := range map[any]string{
+		float64(1735689600): "1735689600",
+		float64(1.5):        "1.5",
+		true:                "true",
+		"openid":            "openid",
+		nil:                 "null",
+	} {
+		if got := introspectValue(in); got != want {
+			t.Errorf("introspectValue(%v) = %q, want %q", in, got, want)
+		}
+	}
+	if got := introspectValue([]any{"a", "b"}); got != `["a","b"]` {
+		t.Errorf("introspectValue(array) = %q", got)
+	}
+}
+
+// introspectForm is where a negative case is actually expressed, so each mode has to produce a materially different request.
+func TestIntrospectFormPerClientAuthMode(t *testing.T) {
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl := &testClient{priv: priv, kid: "k1", clientID: "cid-1"}
+	r := &Runner{Issuer: "https://issuer.example", IntrospectEndpoint: "https://issuer.example/oauth2/introspect"}
+	tk := tokenSet{accessToken: "at-1", idToken: "it-1"}
+
+	mustForm := func(c IntrospectCase) url.Values {
+		t.Helper()
+		rc, rerr := c.resolve()
+		if rerr != nil {
+			t.Fatalf("resolve: %v", rerr)
+		}
+		f, ferr := r.introspectForm(cl, rc, tk)
+		if ferr != nil {
+			t.Fatalf("introspectForm: %v", ferr)
+		}
+		return f
+	}
+
+	good := mustForm(IntrospectCase{Hint: "access_token"})
+	if good.Get("token") != "at-1" || good.Get("token_type_hint") != "access_token" {
+		t.Errorf("default case sent token=%q hint=%q", good.Get("token"), good.Get("token_type_hint"))
+	}
+	if good.Get("client_assertion_type") != clientAssertionTypeJWTBearer {
+		t.Errorf("client_assertion_type = %q", good.Get("client_assertion_type"))
+	}
+	if aud := audienceOf(t, good.Get("client_assertion")); aud != r.Issuer {
+		t.Errorf("assertion aud = %q, want the issuer %q", aud, r.Issuer)
+	}
+
+	// No hint at all, so the endpoint has to resolve the token unaided.
+	if _, sent := mustForm(IntrospectCase{})["token_type_hint"]; sent {
+		t.Error("a case with no hint still sent token_type_hint")
+	}
+
+	if got := mustForm(IntrospectCase{Token: introspectIDToken}).Get("token"); got != "it-1" {
+		t.Errorf("id_token case sent token=%q, want it-1", got)
+	}
+	if got := mustForm(IntrospectCase{Token: introspectUnissued}).Get("token"); got == "" || got == "at-1" || got == "it-1" {
+		t.Errorf("unissued case sent token=%q, want a value this deployment never issued", got)
+	}
+	if _, sent := mustForm(IntrospectCase{Token: introspectNoToken})["token"]; sent {
+		t.Error("the no-token case still sent a token parameter")
+	}
+
+	// client_id alone is not client authentication.
+	noAssertion := mustForm(IntrospectCase{ClientAuth: introspectAuthNoAssertion})
+	if noAssertion.Get("client_id") != "cid-1" || noAssertion.Get("client_assertion") != "" {
+		t.Errorf("no_assertion case sent client_id=%q assertion=%q", noAssertion.Get("client_id"), noAssertion.Get("client_assertion"))
+	}
+
+	// Signed by a key the client never registered: well-formed, right audience, unverifiable; must not accidentally be the registered key.
+	wrongKey := mustForm(IntrospectCase{ClientAuth: introspectAuthWrongKey})
+	if wrongKey.Get("client_assertion") == good.Get("client_assertion") {
+		t.Error("wrong_key reused the registered key's assertion")
+	}
+	if aud := audienceOf(t, wrongKey.Get("client_assertion")); aud != r.Issuer {
+		t.Errorf("wrong_key assertion aud = %q, want the issuer (only the key is wrong)", aud)
+	}
+
+	if aud := audienceOf(t, mustForm(IntrospectCase{ClientAuth: introspectAuthWrongAudience}).Get("client_assertion")); aud != wrongAudience {
+		t.Errorf("wrong_audience assertion aud = %q, want %q", aud, wrongAudience)
+	}
+
+	// A case asking for an id_token the flow never returned is a spec error, not a silent introspection of nothing.
+	rc, _ := IntrospectCase{Token: introspectIDToken}.resolve()
+	if _, err := r.introspectForm(cl, rc, tokenSet{accessToken: "at-1"}); err == nil {
+		t.Error("id_token case with no id_token was accepted")
+	}
+}
+
+func audienceOf(t *testing.T, assertion string) string {
+	t.Helper()
+	claims, err := decodeJWTPayload(assertion)
+	if err != nil {
+		t.Fatalf("decode assertion: %v", err)
+	}
+	aud, _ := claims["aud"].(string)
+	return aud
+}
+
+// A deployment that advertises no introspection_endpoint must produce a failed assertion naming that, rather than a silent pass or a nil-URL request.
+func TestIntrospectWithoutEndpointFailsExplicitly(t *testing.T) {
+	r := &Runner{}
+	got := r.introspect(context.Background(), &[]result.HTTPCall{}, &testClient{}, []IntrospectCase{{}}, tokenSet{})
+	if len(got) != 1 || got[0].Passed {
+		t.Fatalf("assertions = %+v, want one failure", got)
+	}
+	if !strings.Contains(got[0].Field, "introspection endpoint") {
+		t.Errorf("assertion field = %q", got[0].Field)
+	}
+}
+
+func TestIntrospectOneAssertsAgainstTheResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		form, _ := url.ParseQuery(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		if form.Get("token") != "at-1" {
+			_, _ = io.WriteString(w, `{"active":false}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"active":true,"client_id":"cid-1","sub":"sub-1","scope":"openid","exp":4102444800,"cnf":{"jkt":"jkt-1"}}`)
+	}))
+	defer srv.Close()
+
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl := &testClient{priv: priv, kid: "k1", clientID: "cid-1"}
+	r := &Runner{Issuer: srv.URL, IntrospectEndpoint: srv.URL, TLSVerify: false}
+	tk := tokenSet{accessToken: "at-1", sub: "sub-1", dpopJKT: "jkt-1"}
+
+	run := func(c IntrospectCase) []result.Assertion {
+		t.Helper()
+		rc, rerr := c.resolve()
+		if rerr != nil {
+			t.Fatalf("resolve: %v", rerr)
+		}
+		var calls []result.HTTPCall
+		return r.introspectOne(context.Background(), &calls, cl, rc, tk)
+	}
+
+	active := run(IntrospectCase{
+		Name: "active", ExpectActive: boolPtr(true),
+		ExpectPresent: []string{"scope"},
+		ExpectValues:  map[string]string{"client_id": "{{client_id}}", "sub": "{{sub}}", "cnf.jkt": "{{dpop_jkt}}"},
+	})
+	for _, a := range active {
+		if !a.Passed {
+			t.Errorf("assertion failed on a matching response: %s: want %q, got %q", a.Field, a.Expected, a.Actual)
+		}
+	}
+	// The exp cross-check is added for an active token, not declared by the case.
+	if !hasField(active, "exp") {
+		t.Error("no exp assertion was produced for an active token")
+	}
+
+	// RFC 7662 s4: an inactive answer must not leak metadata; this is the passing direction, the failing one is exercised below.
+	inactive := run(IntrospectCase{
+		Name: "unissued", Token: introspectUnissued, ExpectActive: boolPtr(false),
+		ExpectAbsent: []string{"sub"},
+	})
+	for _, a := range inactive {
+		if !a.Passed {
+			t.Errorf("assertion failed on the inactive response: %s: want %q, got %q", a.Field, a.Expected, a.Actual)
+		}
+	}
+
+	// A case whose expectation is wrong must fail rather than pass vacuously.
+	mismatch := run(IntrospectCase{Name: "mismatch", ExpectValues: map[string]string{"sub": "somebody-else"}})
+	if !anyFailed(mismatch) {
+		t.Error("a mismatched expected value passed")
+	}
+	if !anyFailed(run(IntrospectCase{Name: "wrong-status", ExpectStatus: http.StatusUnauthorized})) {
+		t.Error("a wrong expected status passed")
+	}
+	if !anyFailed(run(IntrospectCase{Name: "absent-member", ExpectPresent: []string{"username"}})) {
+		t.Error("expect_present passed for a member the response omits")
+	}
+	// The other direction for expect_absent: the active response does carry sub, so a case demanding its absence has to fail.
+	if !anyFailed(run(IntrospectCase{Name: "leaked-member", ExpectAbsent: []string{"sub"}})) {
+		t.Error("expect_absent passed for a member the response returns")
+	}
+}
+
+func hasField(as []result.Assertion, suffix string) bool {
+	for _, a := range as {
+		if strings.HasSuffix(a.Field, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyFailed(as []result.Assertion) bool {
+	for _, a := range as {
+		if !a.Passed {
+			return true
+		}
+	}
+	return false
+}
+
+// A scenario that both expects rejection and asks for introspection would be reported PASSED having introspected nothing, so it must be a config error.
+func TestScenarioConfigErrorCatchesUnreachableIntrospection(t *testing.T) {
+	ok := Scenario{AuthFactor: "otp", Introspect: []IntrospectCase{{}}}
+	if msg := scenarioConfigError(ok); msg != "" {
+		t.Errorf("well-formed scenario rejected: %s", msg)
+	}
+	bad := Scenario{AuthFactor: "otp", ExpectLoginFailure: true, Introspect: []IntrospectCase{{}}}
+	if msg := scenarioConfigError(bad); !strings.Contains(msg, "expect_login_failure") {
+		t.Errorf("scenarioConfigError = %q, want it to name expect_login_failure", msg)
+	}
+	if msg := scenarioConfigError(Scenario{}); !strings.Contains(msg, "auth_factor") {
+		t.Errorf("scenarioConfigError = %q, want it to name auth_factor", msg)
+	}
+}

--- a/api-test/internal/e2e/lifecycle.go
+++ b/api-test/internal/e2e/lifecycle.go
@@ -1,0 +1,154 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mosip/esignet/api-test/internal/result"
+)
+
+// Client statuses, spelled as eSignet stores and returns them.
+const (
+	statusActive   = "ACTIVE"
+	statusInactive = "INACTIVE"
+)
+
+// The points in the flow at which a scenario may flip its client's status; after_authorize also exercises the client-cache invalidation the status write triggers.
+const (
+	stageBeforeAuthorize = "before_authorize"
+	stageAfterAuthorize  = "after_authorize"
+	stageAfterToken      = "after_token"
+)
+
+// ClientLifecycle drives the registered client's status mid-scenario; a scenario carrying one gets its OWN client, since deactivating a shared one would silently break every other scenario using it.
+type ClientLifecycle struct {
+	// Deactivate names the stage at which the client is set INACTIVE.
+	Deactivate string `json:"deactivate"`
+
+	// Reactivate sets the client back to ACTIVE before the flow continues; it is the positive control proving the same plumbing leaves the client usable.
+	Reactivate bool `json:"reactivate"`
+}
+
+// stage returns the normalized deactivation stage, or "" when unset.
+func (l *ClientLifecycle) stage() string {
+	if l == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(l.Deactivate))
+}
+
+// validate reports why the lifecycle spec cannot be run, or "" when it is well formed.
+func (l *ClientLifecycle) validate() string {
+	if l == nil {
+		return ""
+	}
+	switch l.stage() {
+	case stageBeforeAuthorize, stageAfterAuthorize, stageAfterToken:
+		return ""
+	case "":
+		return "client_lifecycle.deactivate is required (" +
+			stageBeforeAuthorize + "|" + stageAfterAuthorize + "|" + stageAfterToken + ")"
+	default:
+		return fmt.Sprintf("client_lifecycle.deactivate %q is not a stage (%s|%s|%s)",
+			l.Deactivate, stageBeforeAuthorize, stageAfterAuthorize, stageAfterToken)
+	}
+}
+
+// label describes the lifecycle for the report, e.g. "deactivated before_authorize".
+func (l *ClientLifecycle) label() string {
+	if l == nil {
+		return ""
+	}
+	if l.Reactivate {
+		return "deactivated+reactivated " + l.stage()
+	}
+	return "deactivated " + l.stage()
+}
+
+// applyAt performs the lifecycle's status writes if stage is the one it names; a write eSignet refuses is an error, since the scenario's premise never held.
+func (r *Runner) applyAt(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, l *ClientLifecycle, stage string) ([]result.Assertion, error) {
+	if l == nil || l.stage() != stage {
+		return nil, nil
+	}
+	var out []result.Assertion
+	a, err := r.setClientStatus(ctx, calls, cl.clientID, statusInactive)
+	out = append(out, a...)
+	if err != nil {
+		return out, err
+	}
+	if l.Reactivate {
+		a, err = r.setClientStatus(ctx, calls, cl.clientID, statusActive)
+		out = append(out, a...)
+		if err != nil {
+			return out, err
+		}
+	}
+	return out, nil
+}
+
+// setClientStatus patches clientID to want and reads it back, always via eSignet's own client-mgmt (even for mosip) since PMS refuses reactivation (PMS_ESI_008).
+func (r *Runner) setClientStatus(ctx context.Context, calls *[]result.HTTPCall, clientID, want string) ([]result.Assertion, error) {
+	body, err := json.Marshal(map[string]any{
+		"requestTime": time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		"request":     map[string]any{"status": want},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal status patch: %w", err)
+	}
+	label := "set client " + strings.ToLower(want)
+	status, rb, err := r.do(ctx, calls, label, http.MethodPatch, r.Base+"/client-mgmt/client/"+clientID,
+		map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + r.AdminToken}, string(body))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", label, err)
+	}
+	if code := firstErrorCode(rb); code != "" {
+		return nil, fmt.Errorf("%s rejected (HTTP %d): %s", label, status, code)
+	}
+	if status < 200 || status > 299 {
+		return nil, fmt.Errorf("%s failed (HTTP %d): %s", label, status, snippet(rb))
+	}
+
+	// Read it back rather than trusting the patch response's echo, since the engine resolves clients through a cache the write is supposed to invalidate.
+	got, err := r.readClientStatus(ctx, calls, clientID)
+	if err != nil {
+		return nil, err
+	}
+	return []result.Assertion{{
+		Field: "client status (" + strings.ToLower(want) + ")", Expected: want,
+		Actual: got, Passed: got == want,
+	}}, nil
+}
+
+// readClientStatus GETs the client and returns its stored status.
+func (r *Runner) readClientStatus(ctx context.Context, calls *[]result.HTTPCall, clientID string) (string, error) {
+	status, rb, err := r.do(ctx, calls, "read client status", http.MethodGet, r.Base+"/client-mgmt/client/"+clientID,
+		map[string]string{"Authorization": "Bearer " + r.AdminToken}, "")
+	if err != nil {
+		return "", fmt.Errorf("read client status: %w", err)
+	}
+	if code := firstErrorCode(rb); code != "" {
+		return "", fmt.Errorf("read client status rejected (HTTP %d): %s", status, code)
+	}
+	if status < 200 || status > 299 {
+		return "", fmt.Errorf("read client status failed (HTTP %d): %s", status, snippet(rb))
+	}
+	var resp struct {
+		Response struct {
+			Status string `json:"status"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(rb, &resp); err != nil {
+		return "", fmt.Errorf("read client status: parse response (HTTP %d): %w", status, err)
+	}
+	return resp.Response.Status, nil
+}

--- a/api-test/internal/e2e/lifecycle_test.go
+++ b/api-test/internal/e2e/lifecycle_test.go
@@ -1,0 +1,191 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mosip/esignet/api-test/internal/result"
+)
+
+// clientMgmtStub serves just enough of /client-mgmt/client/{id} to record status writes and answer read-backs consistently.
+type clientMgmtStub struct {
+	status  string
+	patches []string
+	reads   int
+}
+
+func newClientMgmtStub(t *testing.T) (*clientMgmtStub, *Runner, func()) {
+	t.Helper()
+	st := &clientMgmtStub{status: statusActive}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case http.MethodPatch:
+			body, _ := io.ReadAll(req.Body)
+			var wrapper struct {
+				Request struct {
+					Status string `json:"status"`
+				} `json:"request"`
+			}
+			_ = json.Unmarshal(body, &wrapper)
+			st.status = wrapper.Request.Status
+			st.patches = append(st.patches, wrapper.Request.Status)
+			_, _ = io.WriteString(w, `{"response":{"clientId":"cid-1","status":"`+st.status+`"}}`)
+		case http.MethodGet:
+			st.reads++
+			_, _ = io.WriteString(w, `{"response":{"clientId":"cid-1","status":"`+st.status+`"}}`)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	return st, &Runner{Base: srv.URL, AdminToken: "t"}, srv.Close
+}
+
+func TestLifecycleValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		spec    *ClientLifecycle
+		wantErr bool
+	}{
+		{"nil is fine", nil, false},
+		{"before_authorize", &ClientLifecycle{Deactivate: stageBeforeAuthorize}, false},
+		{"after_authorize", &ClientLifecycle{Deactivate: stageAfterAuthorize}, false},
+		{"after_token", &ClientLifecycle{Deactivate: stageAfterToken}, false},
+		{"case and space insensitive", &ClientLifecycle{Deactivate: "  Before_Authorize "}, false},
+		{"empty stage", &ClientLifecycle{}, true},
+		{"unknown stage", &ClientLifecycle{Deactivate: "after_userinfo"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.spec.validate(); (got != "") != tc.wantErr {
+				t.Errorf("validate() = %q, wantErr %v", got, tc.wantErr)
+			}
+		})
+	}
+}
+
+// A mistyped stage must be caught as a spec error, or a lifecycle that never fires would let an inactive-client negative pass with the client still active.
+func TestScenarioConfigRejectsUnknownLifecycleStage(t *testing.T) {
+	sc := Scenario{AuthFactor: "otp", ClientLifecycle: &ClientLifecycle{Deactivate: "whenever"}}
+	msg := scenarioConfigError(sc)
+	if !strings.Contains(msg, "whenever") {
+		t.Errorf("scenarioConfigError = %q, want it to name the bad stage", msg)
+	}
+}
+
+func TestApplyAtOnlyFiresAtItsOwnStage(t *testing.T) {
+	st, r, done := newClientMgmtStub(t)
+	defer done()
+
+	var calls []result.HTTPCall
+	cl := &testClient{clientID: "cid-1"}
+	spec := &ClientLifecycle{Deactivate: stageAfterAuthorize}
+
+	for _, stage := range []string{stageBeforeAuthorize, stageAfterToken} {
+		if a, err := r.applyAt(context.Background(), &calls, cl, spec, stage); err != nil || a != nil {
+			t.Fatalf("applyAt(%s) = %v, %v; want no-op", stage, a, err)
+		}
+	}
+	if len(st.patches) != 0 {
+		t.Fatalf("patches = %v, want none before the named stage", st.patches)
+	}
+
+	asserts, err := r.applyAt(context.Background(), &calls, cl, spec, stageAfterAuthorize)
+	if err != nil {
+		t.Fatalf("applyAt: %v", err)
+	}
+	if len(st.patches) != 1 || st.patches[0] != statusInactive {
+		t.Errorf("patches = %v, want one %s", st.patches, statusInactive)
+	}
+	if len(asserts) != 1 || !asserts[0].Passed {
+		t.Errorf("assertions = %+v, want one passing status assertion", asserts)
+	}
+}
+
+// The read-back is the point of the assertion: a patch response echoing INACTIVE while the stored record stays ACTIVE must fail the scenario, not pass it.
+func TestSetClientStatusFailsWhenTheStoredStatusDisagrees(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if req.Method == http.MethodPatch {
+			_, _ = io.WriteString(w, `{"response":{"clientId":"cid-1","status":"INACTIVE"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"response":{"clientId":"cid-1","status":"ACTIVE"}}`)
+	}))
+	defer srv.Close()
+
+	r := &Runner{Base: srv.URL, AdminToken: "t"}
+	var calls []result.HTTPCall
+	asserts, err := r.setClientStatus(context.Background(), &calls, "cid-1", statusInactive)
+	if err != nil {
+		t.Fatalf("setClientStatus: %v", err)
+	}
+	if len(asserts) != 1 || asserts[0].Passed {
+		t.Errorf("assertions = %+v, want the status assertion to FAIL on the read-back", asserts)
+	}
+}
+
+func TestReactivateRestoresTheClient(t *testing.T) {
+	st, r, done := newClientMgmtStub(t)
+	defer done()
+
+	var calls []result.HTTPCall
+	cl := &testClient{clientID: "cid-1"}
+	spec := &ClientLifecycle{Deactivate: stageBeforeAuthorize, Reactivate: true}
+
+	asserts, err := r.applyAt(context.Background(), &calls, cl, spec, stageBeforeAuthorize)
+	if err != nil {
+		t.Fatalf("applyAt: %v", err)
+	}
+	if want := []string{statusInactive, statusActive}; len(st.patches) != 2 ||
+		st.patches[0] != want[0] || st.patches[1] != want[1] {
+		t.Errorf("patches = %v, want %v in that order", st.patches, want)
+	}
+	if st.status != statusActive {
+		t.Errorf("final status = %s, want %s — the control must leave the client usable", st.status, statusActive)
+	}
+	if len(asserts) != 2 {
+		t.Fatalf("assertions = %+v, want one per status write", asserts)
+	}
+	for _, a := range asserts {
+		if !a.Passed {
+			t.Errorf("assertion %+v failed", a)
+		}
+	}
+}
+
+// A refused status write means the scenario's premise never held, so reporting the flow's outcome afterwards would report a client whose status is unknown.
+func TestApplyAtErrorsWhenESignetRefusesTheWrite(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"errors":[{"errorCode":"invalid_client_id"}]}`)
+	}))
+	defer srv.Close()
+
+	r := &Runner{Base: srv.URL, AdminToken: "t"}
+	var calls []result.HTTPCall
+	_, err := r.applyAt(context.Background(), &calls, &testClient{clientID: "gone"},
+		&ClientLifecycle{Deactivate: stageBeforeAuthorize}, stageBeforeAuthorize)
+	if err == nil || !strings.Contains(err.Error(), "invalid_client_id") {
+		t.Errorf("applyAt error = %v, want it to name the rejection", err)
+	}
+}
+
+func TestLifecycleLabel(t *testing.T) {
+	for _, tc := range []struct {
+		spec *ClientLifecycle
+		want string
+	}{
+		{nil, ""},
+		{&ClientLifecycle{Deactivate: stageBeforeAuthorize}, "deactivated before_authorize"},
+		{&ClientLifecycle{Deactivate: stageAfterToken, Reactivate: true}, "deactivated+reactivated after_token"},
+	} {
+		if got := tc.spec.label(); got != tc.want {
+			t.Errorf("label() = %q, want %q", got, tc.want)
+		}
+	}
+}

--- a/api-test/internal/e2e/pms_additionalconfig_test.go
+++ b/api-test/internal/e2e/pms_additionalconfig_test.go
@@ -1,0 +1,128 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mosip/esignet/api-test/internal/result"
+)
+
+// pmsStub serves just enough of PMS's /oidc-clients and eSignet's /client-mgmt/client/{id} to prove additionalConfig is patched onto eSignet directly, since PMS drops it silently on registration. eSignet's client-mgmt responses never echo additionalConfig back (see patchAdditionalConfig), so unlike lifecycle_test.go's clientMgmtStub this one has no read-back to serve.
+type pmsStub struct {
+	dropOnRegister bool // mirrors PMS's real behaviour: additionalConfig sent to /oidc-clients never lands
+	stored         map[string]any
+	patches        int
+}
+
+func newPMSStub(t *testing.T, dropOnRegister bool) (*pmsStub, *Runner, func()) {
+	t.Helper()
+	st := &pmsStub{dropOnRegister: dropOnRegister}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oidc-clients", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !st.dropOnRegister {
+			var wrapper struct {
+				Request struct {
+					AdditionalConfig map[string]any `json:"additionalConfig"`
+				} `json:"request"`
+			}
+			body, _ := io.ReadAll(req.Body)
+			_ = json.Unmarshal(body, &wrapper)
+			st.stored = wrapper.Request.AdditionalConfig
+		}
+		_, _ = io.WriteString(w, `{"response":{"clientId":"pms-cid-1"}}`)
+	})
+	mux.HandleFunc("/client-mgmt/client/pms-cid-1", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if req.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		st.patches++
+		var wrapper struct {
+			Request struct {
+				AdditionalConfig map[string]any `json:"additionalConfig"`
+			} `json:"request"`
+		}
+		body, _ := io.ReadAll(req.Body)
+		_ = json.Unmarshal(body, &wrapper)
+		st.stored = wrapper.Request.AdditionalConfig
+		// Real eSignet echoes only clientId+status here, additionalConfig included, so the stub matches that shape rather than the more helpful one it could serve.
+		_, _ = io.WriteString(w, `{"response":{"clientId":"pms-cid-1","status":"ACTIVE"}}`)
+	})
+	srv := httptest.NewServer(mux)
+	r := &Runner{Base: srv.URL, PMSBaseURL: srv.URL, AuthPartnerID: "p1", PolicyID: "pol1", AdminToken: "t"}
+	return st, r, srv.Close
+}
+
+func newPKCEClient(t *testing.T) *testClient {
+	t.Helper()
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatalf("generateRSA: %v", err)
+	}
+	return &testClient{priv: priv, kid: "test-kid", cfg: ClientConfig{RequirePKCE: true}}
+}
+
+func TestCreateClientViaPMS_PatchesAdditionalConfigAfterPMSDropsIt(t *testing.T) {
+	st, r, closeSrv := newPMSStub(t, true) // PMS drops additionalConfig, same as the real deployment
+	defer closeSrv()
+
+	cl := newPKCEClient(t)
+	id, err := r.createClientViaPMS(context.Background(), &[]result.HTTPCall{}, cl, Spec{RedirectURI: "https://example.org/callback"})
+	if err != nil {
+		t.Fatalf("createClientViaPMS: %v", err)
+	}
+	if id != "pms-cid-1" {
+		t.Fatalf("clientID = %q, want pms-cid-1", id)
+	}
+	if st.patches != 1 {
+		t.Fatalf("patches = %d, want 1 — additionalConfig must be patched onto eSignet directly since PMS dropped it", st.patches)
+	}
+	if got := st.stored["require_pkce"]; got != true {
+		t.Errorf("patched require_pkce = %v, want true", got)
+	}
+}
+
+func TestCreateClientViaPMS_UnhardenedClientSkipsThePatchEntirely(t *testing.T) {
+	st, r, closeSrv := newPMSStub(t, true)
+	defer closeSrv()
+
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatalf("generateRSA: %v", err)
+	}
+	cl := &testClient{priv: priv, kid: "test-kid", cfg: ClientConfig{}} // zero value: unhardened
+	if _, err := r.createClientViaPMS(context.Background(), &[]result.HTTPCall{}, cl, Spec{RedirectURI: "https://example.org/callback"}); err != nil {
+		t.Fatalf("createClientViaPMS: %v", err)
+	}
+	if st.patches != 0 {
+		t.Errorf("patches = %d, want 0 — nothing to harden means no patch call at all", st.patches)
+	}
+}
+
+func TestCreateClientViaPMS_FailsWhenTheEsignetPatchIsRejected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oidc-clients", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"response":{"clientId":"pms-cid-3"}}`)
+	})
+	mux.HandleFunc("/client-mgmt/client/pms-cid-3", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"errors":[{"errorCode":"KER-ATH-403","errorMessage":"forbidden"}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	r := &Runner{Base: srv.URL, PMSBaseURL: srv.URL, AuthPartnerID: "p1", PolicyID: "pol1", AdminToken: "t"}
+
+	cl := newPKCEClient(t)
+	_, err := r.createClientViaPMS(context.Background(), &[]result.HTTPCall{}, cl, Spec{RedirectURI: "https://example.org/callback"})
+	if err == nil {
+		t.Fatal("createClientViaPMS: want an error when eSignet rejects the additionalConfig patch, got nil")
+	}
+}

--- a/api-test/internal/e2e/protocol.go
+++ b/api-test/internal/e2e/protocol.go
@@ -1,0 +1,133 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Per-client protocol hardening (PKCE, PAR, DPoP) is enforced at authorize, /oauth2/par, token, and userinfo respectively.
+
+// ClientConfig is the additionalConfig block a scenario's client is registered with; the zero value is unhardened.
+type ClientConfig struct {
+	RequirePKCE bool `json:"require_pkce"`
+	RequirePAR  bool `json:"require_pushed_authorization_requests"`
+	DPoPBound   bool `json:"dpop_bound_access_tokens"`
+}
+
+// additionalConfig renders the block for a client-registration request, or nil when nothing is switched on.
+func (c ClientConfig) additionalConfig() map[string]any {
+	if c == (ClientConfig{}) {
+		return nil
+	}
+	// Every switch is sent explicitly, including false ones, so the report shows what the client is rather than an absence.
+	return map[string]any{
+		"require_pkce":                          c.RequirePKCE,
+		"require_pushed_authorization_requests": c.RequirePAR,
+		"dpop_bound_access_tokens":              c.DPoPBound,
+	}
+}
+
+// key identifies the registered client this config needs; scenarios sharing a key share a client, which the order-dependent consent cases rely on.
+func (c ClientConfig) key() string {
+	return fmt.Sprintf("pkce=%t/par=%t/dpop=%t", c.RequirePKCE, c.RequirePAR, c.DPoPBound)
+}
+
+// label is the short human form used in report assertions and log lines.
+func (c ClientConfig) label() string {
+	var on []string
+	if c.RequirePKCE {
+		on = append(on, "pkce")
+	}
+	if c.RequirePAR {
+		on = append(on, "par")
+	}
+	if c.DPoPBound {
+		on = append(on, "dpop")
+	}
+	if len(on) == 0 {
+		return "none"
+	}
+	return strings.Join(on, "+")
+}
+
+// PKCE methods a scenario can ask the relying party to use.
+const (
+	pkceS256  = "S256"
+	pkcePlain = "plain"
+	pkceNone  = "none"
+)
+
+// FlowSpec overrides what the relying party sends; unset fields follow the client config, letting a field be set against it for a negative case.
+type FlowSpec struct {
+	// UsePAR pushes the authorization request to /oauth2/par first and drives authorize with the returned request_uri.
+	UsePAR *bool `json:"use_par"`
+
+	// UseDPoP sends a DPoP proof at PAR, token and userinfo, and presents the access token with the DPoP scheme instead of Bearer.
+	UseDPoP *bool `json:"use_dpop"`
+
+	// PKCE is S256 (default), plain, or none.
+	PKCE string `json:"pkce"`
+
+	// DPoPKeyMismatch mints a second proof key for the token call so the code bound at authorize cannot be redeemed; only meaningful with DPoP on.
+	DPoPKeyMismatch bool `json:"dpop_key_mismatch"`
+
+	// BearerAtUserinfo presents a DPoP-bound token with the Bearer scheme, which a resource endpoint honouring the binding must refuse.
+	BearerAtUserinfo bool `json:"bearer_at_userinfo"`
+}
+
+// flowPlan is the resolved answer to "what does the RP do for this scenario".
+type flowPlan struct {
+	usePAR           bool
+	useDPoP          bool
+	pkce             string
+	dpopKeyMismatch  bool
+	bearerAtUserinfo bool
+}
+
+// resolveFlow derives what the RP does from the client config, then applies the scenario's explicit overrides.
+func resolveFlow(cfg ClientConfig, f *FlowSpec) (flowPlan, error) {
+	// PKCE defaults to on regardless of require_pkce: an unhardened client still accepts the S256 the harness always sends.
+	plan := flowPlan{usePAR: cfg.RequirePAR, useDPoP: cfg.DPoPBound, pkce: pkceS256}
+	if f == nil {
+		return plan, nil
+	}
+	if f.UsePAR != nil {
+		plan.usePAR = *f.UsePAR
+	}
+	if f.UseDPoP != nil {
+		plan.useDPoP = *f.UseDPoP
+	}
+	if f.PKCE != "" {
+		switch strings.ToLower(f.PKCE) {
+		case strings.ToLower(pkceS256):
+			plan.pkce = pkceS256
+		case pkcePlain:
+			plan.pkce = pkcePlain
+		case pkceNone:
+			plan.pkce = pkceNone
+		default:
+			return plan, fmt.Errorf("flow.pkce %q is not one of S256, plain, none", f.PKCE)
+		}
+	}
+	plan.dpopKeyMismatch = f.DPoPKeyMismatch
+	plan.bearerAtUserinfo = f.BearerAtUserinfo
+	return plan, nil
+}
+
+// label describes the plan for the report, so a row says what was actually driven rather than only what the client required.
+func (p flowPlan) label() string {
+	parts := []string{"pkce=" + p.pkce}
+	if p.usePAR {
+		parts = append(parts, "par")
+	}
+	if p.useDPoP {
+		parts = append(parts, "dpop")
+	}
+	if p.dpopKeyMismatch {
+		parts = append(parts, "dpop-key-mismatch")
+	}
+	if p.bearerAtUserinfo {
+		parts = append(parts, "bearer-at-userinfo")
+	}
+	return strings.Join(parts, ",")
+}

--- a/api-test/internal/e2e/protocol_test.go
+++ b/api-test/internal/e2e/protocol_test.go
@@ -1,0 +1,457 @@
+package e2e
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestClientConfigAdditionalConfig(t *testing.T) {
+	// An unhardened client must register with no additionalConfig member at all.
+	if got := (ClientConfig{}).additionalConfig(); got != nil {
+		t.Errorf("zero config produced additionalConfig %v, want nil", got)
+	}
+
+	got := ClientConfig{RequirePKCE: true}.additionalConfig()
+	want := map[string]any{
+		"require_pkce":                          true,
+		"require_pushed_authorization_requests": false,
+		"dpop_bound_access_tokens":              false,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("additionalConfig = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("additionalConfig[%q] = %v, want %v", k, got[k], v)
+		}
+	}
+}
+
+func TestClientConfigKeyDistinguishesEveryCombination(t *testing.T) {
+	seen := map[string]ClientConfig{}
+	for _, pkce := range []bool{false, true} {
+		for _, par := range []bool{false, true} {
+			for _, dpop := range []bool{false, true} {
+				c := ClientConfig{RequirePKCE: pkce, RequirePAR: par, DPoPBound: dpop}
+				if prev, dup := seen[c.key()]; dup {
+					t.Fatalf("key %q collides: %+v and %+v would share a client", c.key(), prev, c)
+				}
+				seen[c.key()] = c
+			}
+		}
+	}
+	if len(seen) != 8 {
+		t.Errorf("got %d distinct keys, want 8", len(seen))
+	}
+	// A nil client_config must land on the same key as an explicit all-off one, so consent scenarios share a client with the plain ones.
+	if (ClientConfig{}).key() != (ClientConfig{RequirePKCE: false}).key() {
+		t.Error("zero and explicitly-false configs must share a key")
+	}
+}
+
+func TestResolveFlowFollowsClientConfigByDefault(t *testing.T) {
+	cfg := ClientConfig{RequirePAR: true, DPoPBound: true}
+	plan, err := resolveFlow(cfg, nil)
+	if err != nil {
+		t.Fatalf("resolveFlow: %v", err)
+	}
+	if !plan.usePAR || !plan.useDPoP {
+		t.Errorf("plan = %+v, want PAR and DPoP on to match the client config", plan)
+	}
+	// PKCE is always sent, whether or not the client demands it: an unhardened client still accepts S256.
+	if plan.pkce != pkceS256 {
+		t.Errorf("pkce = %q, want %q", plan.pkce, pkceS256)
+	}
+}
+
+func TestResolveFlowOverridesAgainstClientConfig(t *testing.T) {
+	cfg := ClientConfig{RequirePAR: true, DPoPBound: true}
+	plan, err := resolveFlow(cfg, &FlowSpec{UsePAR: boolPtr(false), UseDPoP: boolPtr(false)})
+	if err != nil {
+		t.Fatalf("resolveFlow: %v", err)
+	}
+	// This disagreement is the point of the negative case: the client requires both, the RP sends neither, and the server must refuse.
+	if plan.usePAR || plan.useDPoP {
+		t.Errorf("plan = %+v, want both overridden off", plan)
+	}
+}
+
+func TestResolveFlowPKCEModes(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"S256", pkceS256},
+		{"s256", pkceS256},
+		{"plain", pkcePlain},
+		{"none", pkceNone},
+		{"", pkceS256},
+	} {
+		plan, err := resolveFlow(ClientConfig{}, &FlowSpec{PKCE: tc.in})
+		if err != nil {
+			t.Fatalf("resolveFlow(%q): %v", tc.in, err)
+		}
+		if plan.pkce != tc.want {
+			t.Errorf("pkce %q -> %q, want %q", tc.in, plan.pkce, tc.want)
+		}
+	}
+	// A typo must not silently fall back to S256 and turn a negative case into a vacuous positive.
+	if _, err := resolveFlow(ClientConfig{}, &FlowSpec{PKCE: "S512"}); err == nil {
+		t.Error("resolveFlow accepted an unknown pkce mode")
+	}
+}
+
+func TestChooseDPoPAlg(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		supported []string
+		want      string
+	}{
+		{"prefers PS256 when both offered", []string{"RS256", "PS256"}, "PS256"},
+		{"falls back to RS256 when it is all that is offered", []string{"RS256"}, "RS256"},
+		{"ignores algs the harness cannot produce", []string{"ES256", "EdDSA", "RS256"}, "RS256"},
+		{"case insensitive", []string{"ps256"}, "PS256"},
+		// An empty advertisement means discovery doesn't publish the field at
+		// all, not that it excludes every alg -- defaultDPoPAlg is the right
+		// assumption there, and sending it is not fatal.
+		{"empty advertisement falls back", nil, defaultDPoPAlg},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := chooseDPoPAlg(tc.supported)
+			if err != nil {
+				t.Fatalf("chooseDPoPAlg(%v) returned an error: %v", tc.supported, err)
+			}
+			if got != tc.want {
+				t.Errorf("chooseDPoPAlg(%v) = %q, want %q", tc.supported, got, tc.want)
+			}
+		})
+	}
+}
+
+// An advertisement that names algorithms but none this harness can produce is
+// a real capability gap, not the "field absent" case above: falling back to
+// defaultDPoPAlg here would send a proof the server correctly rejects, and a
+// DPoP scenario would then blame the deployment for a rejection the harness
+// caused.
+func TestChooseDPoPAlgErrorsWhenNoAdvertisedAlgIsProducible(t *testing.T) {
+	_, err := chooseDPoPAlg([]string{"ES512"})
+	if err == nil {
+		t.Fatal("chooseDPoPAlg([ES512]) = nil error, want one naming the capability gap")
+	}
+	if !strings.Contains(err.Error(), "ES512") {
+		t.Errorf("error = %q, want it to name the unsupported advertisement", err)
+	}
+}
+
+// RFC 7638 section 3.1's worked example, pinning member ordering and the absence of whitespace in the hashed form.
+func TestJWKThumbprintMatchesRFC7638Example(t *testing.T) {
+	jwk := map[string]any{
+		"kty": "RSA",
+		"n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMs" +
+			"tn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajr" +
+			"n1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+		"e": "AQAB",
+	}
+	const want = "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+	got, err := jwkThumbprint(jwk)
+	if err != nil {
+		t.Fatalf("jwkThumbprint: %v", err)
+	}
+	if got != want {
+		t.Errorf("thumbprint = %q, want %q", got, want)
+	}
+}
+
+func TestJWKThumbprintRejectsNonRSA(t *testing.T) {
+	if _, err := jwkThumbprint(map[string]any{"kty": "EC", "crv": "P-256"}); err == nil {
+		t.Error("accepted a non-RSA JWK")
+	}
+}
+
+func TestNewDPoPSignerProofShape(t *testing.T) {
+	d, err := newDPoPSigner("PS256")
+	if err != nil {
+		t.Fatalf("newDPoPSigner: %v", err)
+	}
+	// The header jwk carries only the thumbprint members, so no private member can leak into a proof, which the server rejects outright.
+	if len(d.jwk) != 3 {
+		t.Errorf("proof jwk has %d members (%v), want exactly kty/n/e", len(d.jwk), d.jwk)
+	}
+	if jkt, err := jwkThumbprint(d.jwk); err != nil || jkt != d.jkt {
+		t.Errorf("jkt %q does not match its own jwk (%q, err %v)", d.jkt, jkt, err)
+	}
+
+	proof, err := d.proof(http.MethodPost, "https://esignet.example.org/oauth2/token?ignored=1", "")
+	if err != nil {
+		t.Fatalf("proof: %v", err)
+	}
+	parts := strings.Split(proof, ".")
+	if len(parts) != 3 {
+		t.Fatalf("proof is not a 3-part JWS: %q", proof)
+	}
+	hb, err := b64urlDecode(parts[0])
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	var hdr map[string]any
+	if err := json.Unmarshal(hb, &hdr); err != nil {
+		t.Fatalf("header not JSON: %v", err)
+	}
+	if hdr["typ"] != "dpop+jwt" {
+		t.Errorf("typ = %v, want dpop+jwt", hdr["typ"])
+	}
+	if hdr["alg"] != "PS256" {
+		t.Errorf("alg = %v, want PS256", hdr["alg"])
+	}
+
+	claims, err := decodeJWTPayload(proof)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if claims["htm"] != "POST" {
+		t.Errorf("htm = %v, want POST", claims["htm"])
+	}
+	// The query string must not appear in htu: the server canonicalises it away before comparing.
+	if claims["htu"] != "https://esignet.example.org/oauth2/token" {
+		t.Errorf("htu = %v, want the query stripped", claims["htu"])
+	}
+	if _, ok := claims["ath"]; ok {
+		t.Error("ath present on a proof with no access token")
+	}
+	if claims["jti"] == "" || claims["jti"] == nil {
+		t.Error("proof has no jti")
+	}
+}
+
+func TestDPoPProofBindsAccessTokenWithATH(t *testing.T) {
+	d, err := newDPoPSigner("RS256")
+	if err != nil {
+		t.Fatalf("newDPoPSigner: %v", err)
+	}
+	proof, err := d.proof(http.MethodGet, "https://esignet.example.org/oidc/userinfo", "the-access-token")
+	if err != nil {
+		t.Fatalf("proof: %v", err)
+	}
+	claims, err := decodeJWTPayload(proof)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	// Without ath, a proof minted for the token endpoint could be replayed against userinfo with a different token.
+	ath, _ := claims["ath"].(string)
+	if ath == "" {
+		t.Fatal("no ath on a resource-endpoint proof")
+	}
+	other, err := d.proof(http.MethodGet, "https://esignet.example.org/oidc/userinfo", "a-different-token")
+	if err != nil {
+		t.Fatalf("proof: %v", err)
+	}
+	otherClaims, _ := decodeJWTPayload(other)
+	if otherClaims["ath"] == ath {
+		t.Error("ath is the same for two different access tokens")
+	}
+}
+
+func TestDPoPProofJTIIsUnique(t *testing.T) {
+	d, err := newDPoPSigner("RS256")
+	if err != nil {
+		t.Fatalf("newDPoPSigner: %v", err)
+	}
+	// The server records each jti to reject replays, so a repeated one would fail the second call of any two-call flow.
+	seen := map[string]bool{}
+	for i := 0; i < 10; i++ {
+		proof, err := d.proof(http.MethodPost, "https://esignet.example.org/oauth2/token", "")
+		if err != nil {
+			t.Fatalf("proof: %v", err)
+		}
+		claims, _ := decodeJWTPayload(proof)
+		jti, _ := claims["jti"].(string)
+		if seen[jti] {
+			t.Fatalf("jti %q reused", jti)
+		}
+		seen[jti] = true
+	}
+}
+
+func TestDPoPNonceHandshake(t *testing.T) {
+	d, err := newDPoPSigner("RS256")
+	if err != nil {
+		t.Fatalf("newDPoPSigner: %v", err)
+	}
+	if !isDPoPNonceError([]byte(`{"error":"use_dpop_nonce"}`)) {
+		t.Error("use_dpop_nonce not recognised")
+	}
+	if isDPoPNonceError([]byte(`{"error":"invalid_dpop_proof"}`)) {
+		t.Error("a different error was read as a nonce request")
+	}
+
+	h := http.Header{}
+	h.Set("DPoP-Nonce", "server-nonce-1")
+	if !d.dpopNonceFrom(h) {
+		t.Fatal("a fresh nonce was not taken")
+	}
+	// Re-taking the same nonce would loop the retry forever against a server that keeps rejecting for some other reason.
+	if d.dpopNonceFrom(h) {
+		t.Error("the same nonce was taken twice")
+	}
+	proof, err := d.proof(http.MethodPost, "https://esignet.example.org/oauth2/token", "")
+	if err != nil {
+		t.Fatalf("proof: %v", err)
+	}
+	claims, _ := decodeJWTPayload(proof)
+	if claims["nonce"] != "server-nonce-1" {
+		t.Errorf("nonce = %v, want the one the server issued", claims["nonce"])
+	}
+}
+
+// PS256 is the alg FAPI2-configured deployments advertise, so it has to verify as RSA-PSS rather than PKCS#1 v1.5.
+func TestSignJWSPS256VerifiesAsPSS(t *testing.T) {
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	token, err := signJWS(priv, "PS256", map[string]any{"typ": "dpop+jwt"}, map[string]any{"jti": "x"})
+	if err != nil {
+		t.Fatalf("signJWS: %v", err)
+	}
+	parts := strings.Split(token, ".")
+	sig, err := b64urlDecode(parts[2])
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	if err := rsa.VerifyPSS(&priv.PublicKey, crypto.SHA256, sum[:], sig, nil); err != nil {
+		t.Errorf("PS256 signature does not verify as PSS: %v", err)
+	}
+	// And must NOT verify as PKCS#1 v1.5, or the alg header would be a lie.
+	if err := rsa.VerifyPKCS1v15(&priv.PublicKey, crypto.SHA256, sum[:], sig); err == nil {
+		t.Error("a PS256 signature verified as PKCS#1 v1.5")
+	}
+}
+
+// verifyJWS must hold a PS256 signature to the salt length RFC 7518 fixes it at, not auto-detect it and accept a non-conforming salt.
+func TestVerifyJWSRejectsANonStandardPS256Salt(t *testing.T) {
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []jwksKey{{
+			Kid: "k1",
+			Kty: "RSA",
+			N:   b64(priv.PublicKey.N.Bytes()),
+			E:   b64(big.NewInt(int64(priv.PublicKey.E)).Bytes()),
+		}}})
+	}))
+	defer srv.Close()
+
+	// Same signing input either way; only the salt length differs.
+	signWithSalt := func(saltLen int) string {
+		hdr := b64([]byte(`{"alg":"PS256","kid":"k1"}`))
+		pl := b64([]byte(`{"sub":"u1"}`))
+		sum := sha256.Sum256([]byte(hdr + "." + pl))
+		sig, serr := rsa.SignPSS(rand.Reader, priv, crypto.SHA256, sum[:],
+			&rsa.PSSOptions{SaltLength: saltLen, Hash: crypto.SHA256})
+		if serr != nil {
+			t.Fatalf("SignPSS(salt=%d): %v", saltLen, serr)
+		}
+		return hdr + "." + pl + "." + b64(sig)
+	}
+
+	// The conforming signature is the control: if this does not verify, the rejection below proves nothing.
+	if err := verifyJWS(context.Background(), signWithSalt(rsa.PSSSaltLengthEqualsHash), srv.URL, true); err != nil {
+		t.Fatalf("a hash-length-salt PS256 JWS failed to verify: %v", err)
+	}
+	if err := verifyJWS(context.Background(), signWithSalt(rsa.PSSSaltLengthAuto), srv.URL, true); err == nil {
+		t.Error("a PS256 JWS with a maximal salt was accepted; RFC 7518 fixes the salt at the hash length")
+	}
+}
+
+func TestSignJWSRejectsUnknownAlg(t *testing.T) {
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	if _, err := signJWS(priv, "HS256", nil, map[string]any{}); err == nil {
+		t.Error("signJWS accepted an alg it cannot produce")
+	}
+}
+
+func TestSignJWSAlgHeaderAlwaysMatchesTheScheme(t *testing.T) {
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	// A caller-supplied alg must not survive: header and signature scheme disagreeing is exactly what a verifier rejects.
+	token, err := signJWS(priv, "PS256", map[string]any{"alg": "RS256"}, map[string]any{})
+	if err != nil {
+		t.Fatalf("signJWS: %v", err)
+	}
+	hb, err := b64urlDecode(strings.Split(token, ".")[0])
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	var hdr map[string]any
+	if err := json.Unmarshal(hb, &hdr); err != nil {
+		t.Fatalf("header not JSON: %v", err)
+	}
+	if hdr["alg"] != "PS256" {
+		t.Errorf("alg = %v, want PS256 to have overridden the caller's value", hdr["alg"])
+	}
+}
+
+func TestFlowPlanLabel(t *testing.T) {
+	plan, err := resolveFlow(ClientConfig{RequirePAR: true, DPoPBound: true}, nil)
+	if err != nil {
+		t.Fatalf("resolveFlow: %v", err)
+	}
+	label := plan.label()
+	for _, want := range []string{"pkce=S256", "par", "dpop"} {
+		if !strings.Contains(label, want) {
+			t.Errorf("label %q does not mention %q", label, want)
+		}
+	}
+}
+
+func TestClientConfigLabel(t *testing.T) {
+	for _, tc := range []struct {
+		cfg  ClientConfig
+		want string
+	}{
+		{ClientConfig{}, "none"},
+		{ClientConfig{RequirePKCE: true}, "pkce"},
+		{ClientConfig{RequirePKCE: true, RequirePAR: true, DPoPBound: true}, "pkce+par+dpop"},
+	} {
+		if got := tc.cfg.label(); got != tc.want {
+			t.Errorf("label(%+v) = %q, want %q", tc.cfg, got, tc.want)
+		}
+	}
+}
+
+// Guards the assumption publicJWK and the DPoP jwk both rely on: a big.Int round-trip of the RSA exponent.
+func TestDPoPJWKExponentRoundTrips(t *testing.T) {
+	d, err := newDPoPSigner("RS256")
+	if err != nil {
+		t.Fatalf("newDPoPSigner: %v", err)
+	}
+	e, ok := d.jwk["e"].(string)
+	if !ok {
+		t.Fatalf("jwk e is %T, want string", d.jwk["e"])
+	}
+	eb, err := b64urlDecode(e)
+	if err != nil {
+		t.Fatalf("decode e: %v", err)
+	}
+	if got := int(new(big.Int).SetBytes(eb).Int64()); got != d.priv.E {
+		t.Errorf("e round-tripped to %d, want %d", got, d.priv.E)
+	}
+}

--- a/api-test/internal/esignet/answers.go
+++ b/api-test/internal/esignet/answers.go
@@ -6,6 +6,29 @@ import (
 	"github.com/mosip/esignet/api-test/internal/config"
 )
 
+// answerKeys are every key BuildAnswers can put into the answers map. It has to
+// be listed separately because put() drops empty values, so an unconfigured
+// credential is simply absent — indistinguishable by lookup from a key that
+// was never a credential at all.
+var answerKeys = []string{
+	"username", "individualId", "otp", "password", "biometric",
+	"fullName", "name", "dob", "captchaToken",
+}
+
+// KnownAnswerKey reports whether k names an answer BuildAnswers can supply.
+// A scenario naming anything else has a typo in its spec rather than an
+// unconfigured credential, and the difference matters: the first must be a
+// loud failure, while the second is a legitimate skip.
+func KnownAnswerKey(k string) bool {
+	n := Normalize(k)
+	for _, key := range answerKeys {
+		if Normalize(key) == n {
+			return true
+		}
+	}
+	return false
+}
+
 // BuildAnswers turns the eSignet login config into the driver's answers map.
 func BuildAnswers(c config.Esignet) map[string]string {
 	// The flow's username_input is the subject identifier, not a console login.
@@ -27,6 +50,7 @@ func BuildAnswers(c config.Esignet) map[string]string {
 		put("otp", c.OTP.Value)
 	}
 	put("password", c.Credentials.Password)
+	put("biometric", c.Credentials.Biometric)
 	put("fullName", c.Knowledge.FullName)
 	put("name", c.Knowledge.FullName)
 	put("dob", c.Knowledge.DOB)

--- a/api-test/internal/esignet/answers_test.go
+++ b/api-test/internal/esignet/answers_test.go
@@ -1,0 +1,43 @@
+package esignet
+
+import (
+	"testing"
+
+	"github.com/mosip/esignet/api-test/internal/config"
+)
+
+// A scenario's requires_credential is checked against these, so every key
+// BuildAnswers can actually supply has to be recognised — otherwise a real
+// credential would be rejected as a typo.
+func TestKnownAnswerKeyAcceptsEveryKeyBuildAnswersProduces(t *testing.T) {
+	built := BuildAnswers(config.Esignet{
+		Identity:    config.Identity{IndividualID: "id-1"},
+		Credentials: config.Credentials{Username: "u", Password: "p", Biometric: "b"},
+		Knowledge:   config.Knowledge{FullName: "n", DOB: "d"},
+		OTP:         config.OTP{Source: "static", Value: "111111"},
+	})
+	for k := range built {
+		if !KnownAnswerKey(k) {
+			t.Errorf("KnownAnswerKey(%q) = false, but BuildAnswers produced that key", k)
+		}
+	}
+}
+
+// Normalization means case and punctuation must not decide the answer.
+func TestKnownAnswerKeyIgnoresCaseAndPunctuation(t *testing.T) {
+	for _, k := range []string{"password", "Password", "full_name", "fullName", "captcha-token"} {
+		if !KnownAnswerKey(k) {
+			t.Errorf("KnownAnswerKey(%q) = false, want true", k)
+		}
+	}
+}
+
+// The point of the check: a typo must be distinguishable from an unconfigured
+// credential, so it can fail loudly instead of skipping the scenario.
+func TestKnownAnswerKeyRejectsUnknownNames(t *testing.T) {
+	for _, k := range []string{"pasword", "fingerprint", ""} {
+		if KnownAnswerKey(k) {
+			t.Errorf("KnownAnswerKey(%q) = true, want false", k)
+		}
+	}
+}

--- a/api-test/internal/esignet/driver.go
+++ b/api-test/internal/esignet/driver.go
@@ -63,7 +63,8 @@ func (p ConsentPolicy) denies(name string) bool {
 
 type Driver struct {
 	answers      map[string]string // normalized identifier -> value
-	preferred    []string          // preferred action tokens for ACR / login-id selection
+	preferred    []string          // preferred action tokens for the ACR (auth-factor) selection
+	idTokens     []string          // login-id-type tokens, matched against an action's nextNode (see selectAction)
 	tlsVerify    bool
 	timeout      time.Duration
 	maxHops      int
@@ -71,6 +72,9 @@ type Driver struct {
 	debug        bool
 	otp          OTPProvider   // dynamic OTP source; nil for static OTP
 	consent      ConsentPolicy // how to answer the consent step; zero value approves all
+
+	// followRejection carries an ERROR flow's errorAssertion through to the client redirect; off by default since e2e asserts denied consent is rejected, not redirected.
+	followRejection bool
 
 	// Per-Run observations, reset at the top of Run because the conformance
 	// orchestrator reuses one Driver across every module.
@@ -83,6 +87,12 @@ func (d *Driver) SetOTPProvider(p OTPProvider) { d.otp = p }
 
 // SetConsentPolicy installs a non-default consent answer.
 func (d *Driver) SetConsentPolicy(p ConsentPolicy) { d.consent = p }
+
+// SetFollowRejection controls whether a rejected flow is carried through to the client redirect (see followRejection).
+func (d *Driver) SetFollowRejection(v bool) { d.followRejection = v }
+
+// UseIDType sets the login-id-type preference; without it the driver submits on whichever tab it opens on, which the ID system rejects if that's the wrong id kind (IDA-MLC-009).
+func (d *Driver) UseIDType(tokens []string) { d.idTokens = tokens }
 
 func New(answers map[string]string, preferred []string, tlsVerify bool, timeout time.Duration) *Driver {
 	return &Driver{
@@ -109,6 +119,10 @@ type FlowResult struct {
 	// ConsentDenied lists the element names the driver withheld approval from,
 	// for the report's evidence trail.
 	ConsentDenied []string
+	// AuthorizeErrorCode is the errorCode eSignet put on its /error page when it rejected the authorize request.
+	AuthorizeErrorCode string
+	// LoginReached is the success signal for RunToLogin, which deliberately produces no RedirectURI.
+	LoginReached bool
 }
 
 func (r FlowResult) OK() bool { return r.RedirectURI != "" && r.Error == "" }
@@ -117,12 +131,23 @@ type flowResp struct {
 	FlowStatus     string `json:"flowStatus"`
 	ChallengeToken string `json:"challengeToken"`
 	Assertion      string `json:"assertion"`
-	Data           struct {
+	// ErrorAssertion is the signed assertion eSignet returns when a flow ends in ERROR; posting it to /oauth2/auth/callback yields an access_denied redirect.
+	ErrorAssertion string `json:"errorAssertion"`
+	// Error is the per-step rejection while the flow is still INCOMPLETE; without it a rejected OTP step gets re-submitted until it trips the deployment's lockout.
+	Error *struct {
+		Code    string `json:"code"`
+		Message struct {
+			DefaultValue string `json:"defaultValue"`
+		} `json:"message"`
+	} `json:"error"`
+	Data struct {
 		Inputs []struct {
 			Identifier string `json:"identifier"`
 		} `json:"inputs"`
+		// NextNode distinguishes the login-id tabs: every tab's submit ref is "submit_uin", only nextNode says which identifier it sends.
 		Actions []struct {
-			Ref string `json:"ref"`
+			Ref      string `json:"ref"`
+			NextNode string `json:"nextNode"`
 		} `json:"actions"`
 		// AdditionalData.ConsentPrompt is a JSON *string* holding the purposes the
 		// consent step is asking about. It only appears on the consent prompt.
@@ -147,7 +172,9 @@ type consentElement struct {
 }
 
 // consentDecision is the reply shape the ConsentExecutor expects, sent as a JSON-encoded string.
+// Approved must be sent explicitly: an absent field reads as false and the executor rejects the whole decision with FET-1066.
 type consentDecision struct {
+	Approved bool                     `json:"approved"`
 	Purposes []consentPurposeDecision `json:"purposes"`
 }
 
@@ -195,6 +222,9 @@ func buildConsentDecision(prompt string, policy ConsentPolicy) (string, []string
 		// A purpose with every element withheld is itself not approved.
 		if policy.DenyAll || (len(d.Elements) > 0 && !anyApproved) {
 			d.Approved = false
+		}
+		if d.Approved {
+			out.Approved = true
 		}
 		out.Purposes = append(out.Purposes, d)
 	}
@@ -309,18 +339,27 @@ func (s *session) do(ctx context.Context, label, method, u string, body []byte, 
 
 // Run drives one authorization request to a redirect_uri.
 func (d *Driver) Run(ctx context.Context, base, authorizeURL string) FlowResult {
+	return d.runFlow(ctx, base, authorizeURL, false)
+}
+
+// RunToLogin stops at the login page without authenticating, so par-ensure-reused-request-uri can prove a request_uri survives being revisited unauthenticated.
+func (d *Driver) RunToLogin(ctx context.Context, base, authorizeURL string) FlowResult {
+	return d.runFlow(ctx, base, authorizeURL, true)
+}
+
+func (d *Driver) runFlow(ctx context.Context, base, authorizeURL string, stopAtLogin bool) FlowResult {
 	// One Driver is reused for every module, so per-flow consent observations must start clean.
 	d.consentPrompted, d.consentDenied = false, nil
 
 	s := d.newSession()
-	fr := d.run(ctx, s, base, authorizeURL)
+	fr := d.run(ctx, s, base, authorizeURL, stopAtLogin)
 	fr.Calls = s.calls
 	fr.ConsentPrompted = d.consentPrompted
 	fr.ConsentDenied = d.consentDenied
 	return fr
 }
 
-func (d *Driver) run(ctx context.Context, s *session, base, authorizeURL string) FlowResult {
+func (d *Driver) run(ctx context.Context, s *session, base, authorizeURL string, stopAtLogin bool) FlowResult {
 	var fr FlowResult
 
 	current := authorizeURL
@@ -341,10 +380,21 @@ func (d *Driver) run(ctx context.Context, s *session, base, authorizeURL string)
 			target := resolve(current, loc)
 			q := queryOf(target)
 			if q.Get("authId") != "" && q.Get("executionId") != "" {
+				fr.LoginReached = true
+				if stopAtLogin {
+					return fr
+				}
 				return d.completeLogin(ctx, s, base, q.Get("authId"), q.Get("executionId"), fr)
 			}
 			if q.Get("code") != "" || q.Get("error") != "" {
 				fr.RedirectURI = target
+				return fr
+			}
+			// eSignet's /error page is an HTML SPA route, not an RP redirect; report the errorCode instead of following the hop and failing on the HTML.
+			if code := q.Get("errorCode"); code != "" {
+				fr.AuthorizeErrorCode = code
+				fr.Error = fmt.Sprintf("authorize returned eSignet's error page: %s (%s)",
+					code, q.Get("errorMessage"))
 				return fr
 			}
 			current = target
@@ -362,6 +412,8 @@ func (d *Driver) completeLogin(ctx context.Context, s *session, base, authID, ex
 	payload := map[string]any{"executionId": executionID}
 	// Freshness boundary: an OTP delivered before login started belongs to a previous flow.
 	flowStart := time.Now()
+	// Every input answered so far in this flow, re-sent in full on each step the way the browser does.
+	carriedInputs := map[string]string{}
 
 	for step := 0; step < d.maxFlowSteps; step++ {
 		pj, err := json.Marshal(payload)
@@ -397,9 +449,11 @@ func (d *Driver) completeLogin(ctx context.Context, s *session, base, authID, ex
 			}
 		}
 		var actionRefs []string
+		var actions []flowAction
 		for _, a := range r.Data.Actions {
 			if a.Ref != "" {
 				actionRefs = append(actionRefs, a.Ref)
+				actions = append(actions, flowAction{Ref: a.Ref, NextNode: a.NextNode})
 			}
 		}
 
@@ -410,11 +464,22 @@ func (d *Driver) completeLogin(ctx context.Context, s *session, base, authID, ex
 		}
 		if flowStatus != "" && flowStatus != "INCOMPLETE" {
 			fr.Steps = append(fr.Steps, result.FlowStep{FlowStatus: flowStatus, Inputs: inputIDs})
+			// A rejected flow's signed errorAssertion turns into an error=access_denied redirect.
+			if d.followRejection && r.ErrorAssertion != "" {
+				return d.deliverAssertion(ctx, s, base, authID, r.ErrorAssertion, fr)
+			}
 			fr.Error = fmt.Sprintf("flow terminated with status %q", flowStatus)
 			return fr
 		}
 
-		action, aerr := selectAction(actionRefs, d.preferred)
+		// The step was rejected but the flow is still INCOMPLETE; report it rather than looping to maxFlowSteps re-submitting the same view.
+		if r.Error != nil && r.Error.Code != "" {
+			fr.Steps = append(fr.Steps, result.FlowStep{FlowStatus: flowStatus, Inputs: inputIDs})
+			fr.Error = fmt.Sprintf("flow step rejected: %s (%s)", r.Error.Code, r.Error.Message.DefaultValue)
+			return fr
+		}
+
+		action, aerr := selectAction(actions, d.preferred, d.idTokens)
 		if aerr != "" {
 			fr.Steps = append(fr.Steps, result.FlowStep{FlowStatus: flowStatus, Inputs: inputIDs, Action: strings.Join(actionRefs, ",")})
 			fr.Error = aerr
@@ -428,6 +493,10 @@ func (d *Driver) completeLogin(ctx context.Context, s *session, base, authID, ex
 			return fr
 		}
 
+		// Every step re-sends all inputs accumulated so far, not just this view's — sending only `otp` leaves basic_auth with no username and misreports FET-1005 as a bad OTP.
+		for k, v := range inputs {
+			carriedInputs[k] = v
+		}
 		fr.Steps = append(fr.Steps, result.FlowStep{FlowStatus: flowStatus, Inputs: inputIDs, Action: action})
 
 		next := map[string]any{"executionId": executionID}
@@ -437,8 +506,13 @@ func (d *Driver) completeLogin(ctx context.Context, s *session, base, authID, ex
 		if action != "" {
 			next["action"] = action
 		}
-		if len(inputs) > 0 {
-			next["inputs"] = inputs
+		if len(carriedInputs) > 0 {
+			// Copied, not aliased: carriedInputs keeps growing before this payload is marshalled next iteration.
+			send := make(map[string]string, len(carriedInputs))
+			for k, v := range carriedInputs {
+				send[k] = v
+			}
+			next["inputs"] = send
 		}
 		payload = next
 	}
@@ -450,6 +524,11 @@ func (d *Driver) completeLogin(ctx context.Context, s *session, base, authID, ex
 		return fr
 	}
 
+	return d.deliverAssertion(ctx, s, base, authID, assertion, fr)
+}
+
+// deliverAssertion posts a flow assertion to /oauth2/auth/callback; eSignet routes on its claims to serve both a successful login and a rejected one (access_denied).
+func (d *Driver) deliverAssertion(ctx context.Context, s *session, base, authID, assertion string, fr FlowResult) FlowResult {
 	cbBody, cbStatus, _, err := s.do(ctx, "oauth2/auth/callback", http.MethodPost, base+"/oauth2/auth/callback", mustJSON(map[string]any{
 		"authId": authID, "assertion": assertion,
 	}), "application/json", true)
@@ -514,24 +593,51 @@ func (d *Driver) resolveInputs(identifiers []string, since time.Time, consentPro
 	return out, ""
 }
 
-// selectAction picks the happy-path action.
-func selectAction(actions, preferred []string) (string, string) {
+// flowAction is one selectable action of a flow view: its ref and the node it advances to (login-id tabs all submit under the same ref).
+type flowAction struct {
+	Ref      string
+	NextNode string
+}
+
+// selectAction picks the happy-path action; idTokens is kept apart from preferred because it matches nextNode, not ref.
+func selectAction(actions []flowAction, preferred, idTokens []string) (string, string) {
 	if len(actions) == 0 {
 		return "", ""
 	}
-	var candidates []string
+	var candidates []flowAction
 	for _, a := range actions {
-		if !containsAny(strings.ToLower(a), excludeActions) {
+		if !containsAny(strings.ToLower(a.Ref), excludeActions) {
 			candidates = append(candidates, a)
 		}
 	}
 	if len(candidates) == 0 {
-		return "", fmt.Sprintf("AMBIGUOUS_FLOW_ACTION: only excluded actions available=%v", actions)
+		return "", fmt.Sprintf("AMBIGUOUS_FLOW_ACTION: only excluded actions available=%v", refsOf(actions))
 	}
 	if len(candidates) == 1 {
-		return candidates[0], ""
+		return candidates[0].Ref, ""
 	}
 	isNav := func(c string) bool { return containsAny(strings.ToLower(c), navHints) }
+
+	// 0. login-id tab correction: switch tabs first if this view's submit would send the wrong id kind (IDA-MLC-009).
+	if len(idTokens) > 0 {
+		submitMatches, navToIDType := false, ""
+		for _, c := range candidates {
+			node := strings.ToLower(c.NextNode)
+			if node == "" || !containsAny(node, idTokens) {
+				continue
+			}
+			if isNav(c.Ref) {
+				if navToIDType == "" {
+					navToIDType = c.Ref
+				}
+			} else {
+				submitMatches = true
+			}
+		}
+		if !submitMatches && navToIDType != "" {
+			return navToIDType, ""
+		}
+	}
 
 	// 1. caller preference (skip navigation).
 	for _, pref := range preferred {
@@ -540,36 +646,36 @@ func selectAction(actions, preferred []string) (string, string) {
 			continue
 		}
 		for _, c := range candidates {
-			if !isNav(c) && strings.Contains(strings.ToLower(c), pref) {
-				return c, ""
+			if !isNav(c.Ref) && strings.Contains(strings.ToLower(c.Ref), pref) {
+				return c.Ref, ""
 			}
 		}
 	}
 	// 2. submit-like actions advance the flow, skipping navigation so a resend cannot beat the real submit.
 	for _, hint := range submitHints {
 		for _, c := range candidates {
-			if !isNav(c) && strings.Contains(strings.ToLower(c), hint) {
-				return c, ""
+			if !isNav(c.Ref) && strings.Contains(strings.ToLower(c.Ref), hint) {
+				return c.Ref, ""
 			}
 		}
 	}
 	// 3. generic happy-path (skip navigation).
 	for _, pref := range actionPreference {
 		for _, c := range candidates {
-			if !isNav(c) && strings.Contains(strings.ToLower(c), pref) {
-				return c, ""
+			if !isNav(c.Ref) && strings.Contains(strings.ToLower(c.Ref), pref) {
+				return c.Ref, ""
 			}
 		}
 	}
 	// 4. any non-navigation candidate.
-	var nonNav []string
+	var nonNav []flowAction
 	for _, c := range candidates {
-		if !isNav(c) {
+		if !isNav(c.Ref) {
 			nonNav = append(nonNav, c)
 		}
 	}
 	if len(nonNav) == 1 {
-		return nonNav[0], ""
+		return nonNav[0].Ref, ""
 	}
 	// 5. navigation tabs as a last resort, honouring the caller's IDTypeTokens preference first.
 	if len(nonNav) == 0 && len(candidates) > 0 {
@@ -579,14 +685,23 @@ func selectAction(actions, preferred []string) (string, string) {
 				continue
 			}
 			for _, c := range candidates {
-				if strings.Contains(strings.ToLower(c), pref) {
-					return c, ""
+				if strings.Contains(strings.ToLower(c.Ref), pref) {
+					return c.Ref, ""
 				}
 			}
 		}
-		return candidates[0], ""
+		return candidates[0].Ref, ""
 	}
-	return "", fmt.Sprintf("AMBIGUOUS_FLOW_ACTION: %d non-navigation actions available=%v (set esignet.auth_factor to disambiguate)", len(nonNav), candidates)
+	return "", fmt.Sprintf("AMBIGUOUS_FLOW_ACTION: %d non-navigation actions available=%v (set esignet.auth_factor to disambiguate)", len(nonNav), refsOf(candidates))
+}
+
+// refsOf renders actions for an error message.
+func refsOf(actions []flowAction) []string {
+	out := make([]string, 0, len(actions))
+	for _, a := range actions {
+		out = append(out, a.Ref)
+	}
+	return out
 }
 
 // ----- utils -----

--- a/api-test/internal/esignet/driver_test.go
+++ b/api-test/internal/esignet/driver_test.go
@@ -12,30 +12,65 @@ func TestSelectAction(t *testing.T) {
 	cases := []struct {
 		name      string
 		in        []string
+		nodes     map[string]string // action ref -> nextNode, for the login-id-tab cases
+		idTokens  []string
 		preferred []string
 		want      string
 		wantErr   bool
 	}{
-		{"single", []string{"login"}, nil, "login", false},
-		{"exclude-cancel", []string{"cancel", "login"}, nil, "login", false},
-		{"only-excluded", []string{"cancel", "reject", "deny"}, nil, "", true},
-		{"empty-ok", nil, nil, "", false},
-		{"prefer-login", []string{"otp-login", "consent"}, nil, "otp-login", false},
-		{"ambiguous", []string{"foo", "bar"}, nil, "", true},
-		{"send-otp", []string{"send-otp"}, nil, "send-otp", false},
-		{"acr-otp", []string{"acr_otp", "acr_password", "acr_bio", "acr_kbi"}, []string{"otp", "generated-code"}, "acr_otp", false},
-		{"acr-kbi", []string{"acr_otp", "acr_password", "acr_bio", "acr_kbi"}, []string{"kbi", "knowledge"}, "acr_kbi", false},
-		{"submit-over-tab-switch", []string{"submit_uin", "login_id_mobile", "login_id_email", "login_id_nrc", "BACK_BUTTON"}, []string{"otp", "generated-code", "mobile", "phone"}, "submit_uin", false},
-		{"proceed-over-resend", []string{"resend_otp", "action_proceed_kbi"}, nil, "action_proceed_kbi", false},
+		{name: "single", in: []string{"login"}, want: "login"},
+		{name: "exclude-cancel", in: []string{"cancel", "login"}, want: "login"},
+		{name: "only-excluded", in: []string{"cancel", "reject", "deny"}, wantErr: true},
+		{name: "empty-ok", in: nil, want: ""},
+		{name: "prefer-login", in: []string{"otp-login", "consent"}, want: "otp-login"},
+		{name: "ambiguous", in: []string{"foo", "bar"}, wantErr: true},
+		{name: "send-otp", in: []string{"send-otp"}, want: "send-otp"},
+		{name: "acr-otp", in: []string{"acr_otp", "acr_password", "acr_bio", "acr_kbi"},
+			preferred: []string{"otp", "generated-code"}, want: "acr_otp"},
+		{name: "acr-kbi", in: []string{"acr_otp", "acr_password", "acr_bio", "acr_kbi"},
+			preferred: []string{"kbi", "knowledge"}, want: "acr_kbi"},
+		{name: "submit-over-tab-switch", in: []string{"submit_uin", "login_id_mobile", "login_id_email", "login_id_nrc", "BACK_BUTTON"},
+			preferred: []string{"otp", "generated-code", "mobile", "phone"}, want: "submit_uin"},
+		{name: "proceed-over-resend", in: []string{"resend_otp", "action_proceed_kbi"}, want: "action_proceed_kbi"},
 		// Stage 5: a step offering only tab switches is progressable, so the
 		// first navigation action is taken rather than aborting as ambiguous.
-		{"nav-only-fallback", []string{"login_id_mobile", "login_id_email"}, nil, "login_id_mobile", false},
+		{name: "nav-only-fallback", in: []string{"login_id_mobile", "login_id_email"}, want: "login_id_mobile"},
 		// Stage 5 must honour the caller's IDTypeTokens preference among navigation-only candidates.
-		{"nav-honours-preference", []string{"login_id_mobile", "login_id_email"}, []string{"otp", "email"}, "login_id_email", false},
+		{name: "nav-honours-preference", in: []string{"login_id_mobile", "login_id_email"},
+			preferred: []string{"otp", "email"}, want: "login_id_email"},
+
+		// Stage 0, the login-id tab correction: with id_type set, switch tabs first if the default tab's submit sends the wrong kind.
+		{name: "id-tab-switch-to-mobile",
+			in:       []string{"submit_uin", "login_id_mobile", "login_id_email", "login_id_nrc", "BACK_BUTTON"},
+			nodes:    map[string]string{"submit_uin": "send_mosip_otp_uin", "login_id_mobile": "prompt_mobile_otp", "login_id_email": "prompt_email_otp", "login_id_nrc": "prompt_nrc_otp", "BACK_BUTTON": "prompt_acr"},
+			idTokens: []string{"mobile", "phone"}, preferred: []string{"otp", "generated-code"},
+			want: "login_id_mobile"},
+		// Already on the mobile tab: the correction must NOT fire again, or it would loop between tabs.
+		{name: "id-tab-already-correct-submits",
+			in:       []string{"submit_uin", "login_id_email", "BACK_BUTTON"},
+			nodes:    map[string]string{"submit_uin": "send_mosip_otp_mobile", "login_id_email": "prompt_email_otp", "BACK_BUTTON": "prompt_acr"},
+			idTokens: []string{"mobile", "phone"}, preferred: []string{"otp", "generated-code"},
+			want: "submit_uin"},
+		// id_type=uin on the UIN tab: no switch, submit straight away.
+		{name: "id-tab-uin-stays",
+			in:       []string{"submit_uin", "login_id_mobile", "BACK_BUTTON"},
+			nodes:    map[string]string{"submit_uin": "send_mosip_otp_uin", "login_id_mobile": "prompt_mobile_otp", "BACK_BUTTON": "prompt_acr"},
+			idTokens: []string{"uin"}, preferred: []string{"otp"},
+			want: "submit_uin"},
+		// No tab matches the id_type: fall through to the ordinary submit rather than picking an arbitrary tab.
+		{name: "id-tab-no-match-falls-through",
+			in:       []string{"submit_uin", "login_id_email", "BACK_BUTTON"},
+			nodes:    map[string]string{"submit_uin": "send_mosip_otp_uin", "login_id_email": "prompt_email_otp", "BACK_BUTTON": "prompt_acr"},
+			idTokens: []string{"mobile", "phone"}, preferred: []string{"otp"},
+			want: "submit_uin"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, errMsg := selectAction(c.in, c.preferred)
+			var actions []flowAction
+			for _, ref := range c.in {
+				actions = append(actions, flowAction{Ref: ref, NextNode: c.nodes[ref]})
+			}
+			got, errMsg := selectAction(actions, c.preferred, c.idTokens)
 			if c.wantErr && errMsg == "" {
 				t.Fatalf("want error, got action %q", got)
 			}

--- a/api-test/internal/httpx/httpx.go
+++ b/api-test/internal/httpx/httpx.go
@@ -3,6 +3,7 @@ package httpx
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -20,6 +21,17 @@ func NewClient(tlsVerify bool, timeout time.Duration) *http.Client {
 				//nolint:gosec // operator-controlled: only the suite's self-signed localhost cert is exempted via tlsVerify.
 				InsecureSkipVerify: !tlsVerify,
 			},
+		},
+		// Every caller of this client sends AdminToken or another bearer
+		// credential via the Authorization header. Refusing a redirect to a
+		// non-https target is defense in depth against a compromised or
+		// misconfigured server sending that header in cleartext, on top of
+		// (not instead of) requireHTTPS validating the request's own base URL.
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if req.URL.Scheme != "https" {
+				return fmt.Errorf("refusing redirect to non-https URL: %s", req.URL)
+			}
+			return nil
 		},
 		Timeout: timeout,
 	}

--- a/api-test/internal/httpx/httpx_test.go
+++ b/api-test/internal/httpx/httpx_test.go
@@ -1,0 +1,56 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Every caller of NewClient sends AdminToken (or another bearer credential)
+// via the Authorization header. A server that redirects to a plain-http
+// target must not have that request followed onto it -- CheckRedirect is the
+// defense-in-depth backstop for that, independent of whatever scheme the
+// caller's own base URL used.
+func TestNewClientRefusesRedirectToNonHTTPS(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound) // target.URL is http://, from httptest
+	}))
+	defer redirector.Close()
+
+	client := NewClient(true, 5*time.Second)
+	resp, err := client.Get(redirector.URL)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("client.Get followed a redirect to a non-https URL, want an error")
+	}
+}
+
+// A redirect to an https target must still be followed -- CheckRedirect blocks
+// the scheme downgrade specifically, not redirects in general.
+func TestNewClientAllowsRedirectToHTTPS(t *testing.T) {
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot) // distinct status so a followed redirect is unambiguous
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	client := NewClient(false, 5*time.Second) // TLSVerify:false so the test TLS certs are accepted
+	resp, err := client.Get(redirector.URL)
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTeapot {
+		t.Errorf("status = %d, want %d (the redirect to the https target should have been followed)", resp.StatusCode, http.StatusTeapot)
+	}
+}

--- a/api-test/internal/report/html.go
+++ b/api-test/internal/report/html.go
@@ -129,8 +129,7 @@ type Options struct {
 	Results     []result.ModuleResult
 }
 
-// Write emits <dir>/<plan>_<provider>_<ts>_t-<n>_p-<n>_f-<n>_sk-<n>_ki-<n>.{html,json}
-// and returns the HTML path.
+// Write emits <dir>/<plan>_<provider>_<ts>_t-<n>_p-<n>_f-<n>_sk-<n>_ki-<n>.{html,json} and returns the HTML path (f includes errored, so p+f+sk+ki sums to t).
 func Write(o Options) (string, error) {
 	dir := o.Dir
 	// Owner-only: the report and its sidecar carry the userinfo claims this
@@ -150,8 +149,8 @@ func Write(o Options) (string, error) {
 	}
 	plan := planLabel(o.Plans)
 	ts := time.Now().Format("20060102-150405")
-	// Total is every module, so a reader can tell whether p/f/sk/ki account for the whole run.
-	base := fmt.Sprintf("%s_%s_%s_t-%d_p-%d_f-%d_sk-%d_ki-%d", surfaceSlug(results), provider, ts, sum.Total, sum.Passed, sum.Failed, sum.Skipped, sum.Known)
+	// f is Summary.NotPassed, so it carries the errored modules too instead of leaving them unnamed.
+	base := fmt.Sprintf("%s_%s_%s_t-%d_p-%d_f-%d_sk-%d_ki-%d", surfaceSlug(results), provider, ts, sum.Total, sum.Passed, sum.NotPassed(), sum.Skipped, sum.Known)
 	// Never overwrite an existing report: if a same-second run produced the same
 	// counts, add a numeric suffix so both reports are kept.
 	stem := base

--- a/api-test/internal/report/html_test.go
+++ b/api-test/internal/report/html_test.go
@@ -109,8 +109,9 @@ func TestWriteRendersReport(t *testing.T) {
 		}
 	}
 	// The unique filename names the surfaces and encodes the counts, and a matching .json sidecar exists.
-	if base := filepath.Base(path); !strings.HasPrefix(base, "conformance_mosip_") || !strings.Contains(base, "t-5_p-1_f-1_sk-1_ki-1") {
-		t.Errorf("filename = %s, want conformance_mosip_<ts>_t-5_p-1_f-1_sk-1_ki-1", base)
+	// f counts the errored module too: 1 passed + 2 not passed + 1 skipped + 1 known = 5.
+	if base := filepath.Base(path); !strings.HasPrefix(base, "conformance_mosip_") || !strings.Contains(base, "t-5_p-1_f-2_sk-1_ki-1") {
+		t.Errorf("filename = %s, want conformance_mosip_<ts>_t-5_p-1_f-2_sk-1_ki-1", base)
 	}
 	jsons, _ := filepath.Glob(filepath.Join(dir, "*.json"))
 	if len(jsons) == 0 {
@@ -406,6 +407,32 @@ func TestSummarize(t *testing.T) {
 	}
 	if !s.HasFailures() {
 		t.Errorf("expected HasFailures = true")
+	}
+	// NotPassed folds in errored, warning and review, so the filename's four numbers account for every module.
+	if got := s.NotPassed(); got != 4 {
+		t.Errorf("NotPassed() = %d, want 4 (failed + warning + review + errored)", got)
+	}
+	if s.Passed+s.NotPassed()+s.Skipped+s.Known != s.Total {
+		t.Errorf("p+f+sk+ki = %d, want Total %d", s.Passed+s.NotPassed()+s.Skipped+s.Known, s.Total)
+	}
+}
+
+// The filename invariant has to hold for any mix of outcomes, not just the fixture above.
+func TestNotPassedAlwaysAccountsForTheTotal(t *testing.T) {
+	for _, rs := range [][]result.ModuleResult{
+		{},
+		{{Result: "PASSED", HarnessOutcome: result.OutcomeOK}},
+		{{HarnessError: "boom"}, {HarnessError: "boom"}},
+		{{HarnessOutcome: result.OutcomeEnvNotReady}, {Result: "SKIPPED", HarnessOutcome: result.OutcomeSkippedByHarness}},
+		{{HarnessOutcome: result.OutcomeKnownIssue}, {Result: "WARNING", HarnessOutcome: result.OutcomeOK}, {Result: "WEIRD"}},
+	} {
+		s := result.Summarize(rs)
+		if s.Passed+s.NotPassed()+s.Skipped+s.Known != s.Total {
+			t.Errorf("summary %+v: p+f+sk+ki != Total", s)
+		}
+		if s.NotPassed() < 0 {
+			t.Errorf("summary %+v: NotPassed() is negative", s)
+		}
 	}
 }
 

--- a/api-test/internal/result/result.go
+++ b/api-test/internal/result/result.go
@@ -179,6 +179,9 @@ func Summarize(rs []ModuleResult) Summary {
 // any harness error.
 func (s Summary) HasFailures() bool { return s.Failed > 0 || s.Errored > 0 }
 
+// NotPassed folds in Errored, Warning and Review, computed as Total-Passed-Skipped-Known so the report filename's counts can never silently drop errored modules like it used to.
+func (s Summary) NotPassed() int { return s.Total - s.Passed - s.Skipped - s.Known }
+
 // SurfaceGroup is the rows of one surface plus that surface's own tile counts.
 type SurfaceGroup struct {
 	Surface string

--- a/api-test/internal/wsotp/listener.go
+++ b/api-test/internal/wsotp/listener.go
@@ -22,7 +22,9 @@ type mailMessage struct {
 	Text    string `json:"text"`
 	HTML    string `json:"html"`
 	Subject string `json:"subject"`
-	To      struct {
+	// Date is send time, not arrival: the mock-SMTP server replays recent history on connect, so timing by arrival would hand a stale OTP to the flow as if it were live.
+	Date string `json:"date"`
+	To   struct {
 		Text  string `json:"text"`
 		Value []struct {
 			Address string `json:"address"`
@@ -146,9 +148,23 @@ func (l *Listener) ingest(data []byte, at time.Time) {
 		return
 	}
 	l.mu.Lock()
-	l.records = append(l.records, record{at: at, otp: otp, dest: recipients(m)})
+	l.records = append(l.records, record{at: sentAt(m, at), otp: otp, dest: recipients(m)})
 	l.pruneLocked(at)
 	l.mu.Unlock()
+}
+
+// sentAt is when the deployment sent the message, falling back to arrival time (see mailMessage.Date).
+func sentAt(m mailMessage, fallback time.Time) time.Time {
+	d := strings.TrimSpace(m.Date)
+	if d == "" {
+		return fallback
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, time.RFC1123Z, time.RFC1123} {
+		if t, err := time.Parse(layout, d); err == nil {
+			return t
+		}
+	}
+	return fallback
 }
 
 // retention bounds the buffer. One listener serves every module for the whole

--- a/api-test/internal/wsotp/wsotp_test.go
+++ b/api-test/internal/wsotp/wsotp_test.go
@@ -391,3 +391,28 @@ func TestIngestPrunesRecordsPastRetention(t *testing.T) {
 		t.Errorf("match = %q, want 222222", got)
 	}
 }
+
+// The mock-SMTP server replays recent history on connect, so timing by arrival would return a stale OTP as if it were live.
+func TestIngestUsesMessageDateNotArrival(t *testing.T) {
+	l := &Listener{}
+	now := time.Now()
+	// Replayed on connect: sent 8 minutes ago, read just now.
+	l.ingest([]byte(`{"type":"SMS","date":"`+now.Add(-8*time.Minute).UTC().Format(time.RFC3339Nano)+
+		`","text":"OTP is 111111","to":{"text":"3449351160"}}`), now)
+	flowStart := now.Add(-1 * time.Minute)
+	if got := l.match("", flowStart); got != "" {
+		t.Fatalf("replayed message matched as fresh: got OTP %q, want none", got)
+	}
+	// A genuinely live message, sent after the flow began.
+	l.ingest([]byte(`{"type":"SMS","date":"`+now.UTC().Format(time.RFC3339Nano)+
+		`","text":"OTP is 222222","to":{"text":"3449351160"}}`), now)
+	if got := l.match("", flowStart); got != "222222" {
+		t.Fatalf("live message: got %q, want 222222", got)
+	}
+	// No date at all: fall back to arrival time so behaviour is unchanged.
+	l2 := &Listener{}
+	l2.ingest([]byte(`{"text":"OTP is 333333","to":{"text":"x"}}`), now)
+	if got := l2.match("", flowStart); got != "333333" {
+		t.Fatalf("dateless message: got %q, want 333333 via arrival-time fallback", got)
+	}
+}

--- a/api-test/run-all.sh
+++ b/api-test/run-all.sh
@@ -179,7 +179,10 @@ wait_for_suite() {
   local deadline=$((SECONDS + wait_s))
   until curl "${curl_opts[@]}" "$base/api/runner/available" 2>/dev/null; do
     if (( SECONDS >= deadline )); then
-      echo "(conformance suite not reachable at $base after ${wait_s}s — proceeding anyway)" >&2
+      # Proceeding is deliberate, not a shrug: the surface's own preflight turns an
+      # unreachable suite into an ENV_NOT_READY row per plan, so the report says why
+      # it did not run. Bailing here would leave the api/e2e surfaces unrun as well.
+      echo "(conformance suite not reachable at $base after ${wait_s}s — running anyway; the surface will report ENV_NOT_READY)" >&2
       return 0
     fi
     sleep 2


### PR DESCRIPTION
Brings `api-test/` on `release-2.0.x` in line with `develop-go`.

`develop-go` had exactly one api-test commit that `release-2.0.x` did not: c381283f (the merge of #2448, itself #2359). Nothing had moved in the other direction. This cherry-picks that commit, after which the `api-test/` tree is byte-identical between the two branches.

## What it brings

- Per-client PKCE, PAR and DPoP switches driven through `additionalConfig`, with the RP side of DPoP (RFC 9449 proofs, RFC 7638 thumbprints, the PAR pre-step, `ath` binding at userinfo).
- Coverage for `/oauth2/introspect`.
- New feature files: client profiles, status, validation, patch-client, additional-config, inactive-client, introspect, system-info.
- The consent fix that sends the top-level `approved` field, without which every fresh consent prompt failed with FET-1066.

## What was left out

The original commit also carried a hunk against `.github/workflows/push-trigger.yml`. It edits the `build-uitest-esignet-local` job, which does not exist on `release-2.0.x`, and is an actionlint cleanup on the ui-test build rather than anything api-test. It is omitted here, so this PR touches `api-test/` only — 59 files, no collateral changes.

## Verification

- `api-test/` diff against `upstream/develop-go`: empty.
- Diff against `release-2.0.x` outside `api-test/`: empty.
- `go build ./...`, `go vet ./...` and `go test ./...` clean in both modules (`api-test` and `api-test/api`).

Signed-off-by: Nandhukumar <nandhukumare@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coverage for client activation status, partial updates, field validation, protocol configuration, token introspection, and system information endpoints.
  - Added end-to-end testing for PKCE, PAR, DPoP, inactive-client behavior, reactivation, and biometric credentials.
  - Added support for `ADMIN_TOKEN` authentication in suitable local test environments.
  - Conformance runs now default to the full profile and preserve partial reports after interrupted runs.

- **Bug Fixes**
  - Improved report counts, secure redirect handling, OTP freshness checks, and client-management request validation.

- **Documentation**
  - Expanded configuration, scenario, troubleshooting, and conformance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->