### PR TITLE
Remove NODE_VERSION and ZIP_DIR from oidc-ui build job

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -85,8 +85,6 @@ jobs:
       SERVICE_LOCATION: oidc-ui
       BUILD_ARTIFACT: oidc
       NPM_BUILD_TYPE: BOB
-      NODE_VERSION: "22"
-      ZIP_DIR: dist
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
Backport of #2526 to `release-2.0.x`.

`mosip/kattu` commit b9db8b19 ("Refactor npm-build.yml for input simplification", 21 Aug 2026) removed the `NODE_VERSION` and `ZIP_DIR` inputs from `npm-build.yml`. We call that workflow at `@develop`, so `push-trigger.yml` stopped validating and every push to `release-2.0.x` has ended in `startup_failure` since 28 Aug — no build, no Sonar, no docker images.

```
.github/workflows/push-trigger.yml (Line: 88, Col: 21): Invalid input, NODE_VERSION is not defined in the referenced workflow.
.github/workflows/push-trigger.yml (Line: 89, Col: 16): Invalid input, ZIP_DIR is not defined in the referenced workflow.
```

This drops the two lines, identical to the fix already on `develop-go`. No other changes.

Fixes #2551

Signed-off-by: Swapnil <swapnil.mohanty@technoforte.co.in>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated build workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->