### PR TITLE
MOSIP-45541: Skip known-issue UI scenarios and report them with bug ID

### DIFF
--- a/ui-test/src/main/java/base/BaseTest.java
+++ b/ui-test/src/main/java/base/BaseTest.java
@@ -133,7 +133,15 @@ public class BaseTest extends AdminTestUtil {
 		utils.ClaimsUtil.clearCachedRenderedAuthFactors();
 		String browser = BaseTestUtil.getBrowserForScenario(scenario);
 		String lang = BaseTestUtil.getThreadLocalLanguage();
-		ExtentReportManager.createTest(scenario.getName() + " [" + browser + " | " + lang + "]");
+		String testName = scenario.getName() + " [" + browser + " | " + lang + "]";
+		String bugId = runners.Runner.getKnownIssueBugId(scenario.getName());
+		if (bugId != null) {
+			String displayId = runners.Runner.formatBugDisplayId(bugId);
+			testName += " | Known Issue " + displayId;
+			ExtentReportManager.createTest(testName, "Known Issues", displayId);
+		} else {
+			ExtentReportManager.createTest(testName);
+		}
 		ExtentReportManager
 				.logStep("Scenario Started: " + scenario.getName() + " | Browser: " + browser + " | Language: " + lang);
 	}
@@ -146,11 +154,13 @@ public class BaseTest extends AdminTestUtil {
 
 		LOGGER.info("Initializing WebDriver...");
 
-		if (runners.Runner.knownIssues.containsKey(scenario.getName())) {
-			String bugId = runners.Runner.knownIssues.get(scenario.getName());
-			LOGGER.info("Skipping Known Issue Scenario: " + scenario.getName() + " | Bug: " + bugId);
+		String knownIssueBugId = runners.Runner.getKnownIssueBugId(scenario.getName());
+		if (knownIssueBugId != null) {
+			String displayId = runners.Runner.formatBugDisplayId(knownIssueBugId);
+			String bugUrl = runners.Runner.getKnownIssueUrl(knownIssueBugId);
+			LOGGER.info("Skipping Known Issue Scenario: " + scenario.getName() + " | Bug: " + displayId);
 			isKnownIssueScenario.set(true);
-			skipWithReason("Known Issue - Skipped: " + scenario.getName() + " | " + bugId);
+			skipKnownIssue(scenario.getName(), displayId, bugUrl);
 		}
 		isKnownIssueScenario.set(false);
 
@@ -466,15 +476,18 @@ public class BaseTest extends AdminTestUtil {
 				ExtentReportManager.getTest().fail("❌ Scenario Failed: " + scenario.getName());
 
 			} else if (scenario.getStatus().toString().equalsIgnoreCase("SKIPPED")
-					&& runners.Runner.knownIssues.containsKey(scenario.getName())) {
+					&& runners.Runner.isKnownIssue(scenario.getName())) {
 
-				String bugId = runners.Runner.knownIssues.get(scenario.getName());
-				String bugUrl = "https://mosip.atlassian.net/browse/" + bugId;
+				String bugId = runners.Runner.getKnownIssueBugId(scenario.getName());
+				String displayId = runners.Runner.formatBugDisplayId(bugId);
+				String bugUrl = runners.Runner.getKnownIssueUrl(bugId);
 
 				ExtentReportManager.incrementKnownIssue();
-				attachScenarioScreenshot(driver, scenario);
-				ExtentReportManager.getTest().skip(
-						"🟠 Skipped due to Known Issue → <a href='" + bugUrl + "' target='_blank'>" + bugId + "</a>");
+				if (driver != null) {
+					attachScenarioScreenshot(driver, scenario);
+				}
+				ExtentReportManager.getTest().skip("🟠 Known Issue " + displayId
+						+ " → <a href='" + bugUrl + "' target='_blank'>" + bugUrl + "</a>");
 
 			} else if (scenario.getStatus().toString().equalsIgnoreCase("SKIPPED")) {
 
@@ -542,6 +555,12 @@ public class BaseTest extends AdminTestUtil {
 	private void skipWithReason(String reason) {
 		ExtentReportManager.getTest().warning(reason);
 		throw new SkipException(reason);
+	}
+
+	private void skipKnownIssue(String scenarioName, String displayId, String bugUrl) {
+		ExtentReportManager.getTest().skip("🟠 Known Issue " + displayId
+				+ " → <a href='" + bugUrl + "' target='_blank'>" + bugUrl + "</a>");
+		throw new SkipException("Known Issue - Skipped: " + scenarioName + " | " + displayId);
 	}
 
 	@Before(value = "@mobile", order = 1)

--- a/ui-test/src/main/java/runners/Runner.java
+++ b/ui-test/src/main/java/runners/Runner.java
@@ -500,7 +500,10 @@ public class Runner extends AbstractTestNGCucumberTests {
 
 				if (parts.length == 2) {
 					String bugId = parts[0].trim();
-					String scenarioName = parts[1].trim().replaceAll("\\s+", " ");
+					String scenarioName = normalizeScenarioName(parts[1]);
+					if (scenarioName.regionMatches(true, 0, "Scenario:", 0, "Scenario:".length())) {
+						scenarioName = normalizeScenarioName(scenarioName.substring("Scenario:".length()));
+					}
 
 					knownIssues.put(scenarioName, bugId);
 				}
@@ -511,5 +514,44 @@ public class Runner extends AbstractTestNGCucumberTests {
 		} catch (Exception e) {
 			LOGGER.warning("Error reading Known_Issues.txt: " + e.getMessage());
 		}
+	}
+
+	public static String getKnownIssueBugId(String scenarioName) {
+		if (scenarioName == null) {
+			return null;
+		}
+		return knownIssues.get(normalizeScenarioName(scenarioName));
+	}
+
+	public static boolean isKnownIssue(String scenarioName) {
+		return getKnownIssueBugId(scenarioName) != null;
+	}
+
+	public static String formatBugDisplayId(String bugId) {
+		if (bugId == null || bugId.isBlank()) {
+			return "";
+		}
+		if (bugId.startsWith("http://") || bugId.startsWith("https://")) {
+			int lastSlash = bugId.lastIndexOf('/');
+			return lastSlash >= 0 && lastSlash < bugId.length() - 1 ? "#" + bugId.substring(lastSlash + 1) : bugId;
+		}
+		return bugId.matches("\\d+") ? "#" + bugId : bugId;
+	}
+
+	public static String getKnownIssueUrl(String bugId) {
+		if (bugId == null || bugId.isBlank()) {
+			return "";
+		}
+		if (bugId.startsWith("http://") || bugId.startsWith("https://")) {
+			return bugId;
+		}
+		if (bugId.matches("\\d+")) {
+			return "https://github.com/mosip/esignet/issues/" + bugId;
+		}
+		return "https://mosip.atlassian.net/browse/" + bugId;
+	}
+
+	private static String normalizeScenarioName(String name) {
+		return name == null ? "" : name.trim().replaceAll("\\s+", " ");
 	}
 }

--- a/ui-test/src/main/java/utils/ExtentReportManager.java
+++ b/ui-test/src/main/java/utils/ExtentReportManager.java
@@ -52,7 +52,14 @@ public class ExtentReportManager {
 	}
 
 	public static synchronized ExtentTest createTest(String testName) {
+		return createTest(testName, (String[]) null);
+	}
+
+	public static synchronized ExtentTest createTest(String testName, String... categories) {
 		ExtentTest test = extent.createTest(testName);
+		if (categories != null && categories.length > 0) {
+			test.assignCategory(categories);
+		}
 		testThread.set(test);
 		return test;
 	}

--- a/ui-test/src/main/resources/config/Known_Issues.txt
+++ b/ui-test/src/main/resources/config/Known_Issues.txt
@@ -1,3 +1,13 @@
-#Add the Known Issue scenario with its bug id here
-#Ex:bugId------scenario
-#Ex:ES-1234------Verify the notification when OTP requested
+# Known Issues — skipped at runtime and reported in the Known Issues bucket.
+# Format: BUGID------Scenario Name
+# BUGID can be:
+#   - a GitHub issue number (e.g. 2249) → https://github.com/mosip/esignet/issues/2249
+#   - a Jira key (e.g. ES-1234) → https://mosip.atlassian.net/browse/ES-1234
+#   - a full URL
+# Scenario Name must match the Cucumber scenario name (the text after "Scenario:").
+#
+#Ex: 2249------Verify the notification when OTP requested
+#Ex: ES-1234------Verify the notification when OTP requested
+
+2249------TC_Browser_Compatibility_check_01 - Verify the text labels, elements in browser compatibility screen
+2249------Verify the Okay button is clickable on the browser compatibility screen


### PR DESCRIPTION
## Summary
- Load `ui-test/src/main/resources/config/Known_Issues.txt` (`BUGID------Scenario Name`) at suite start and skip matching Cucumber scenarios before WebDriver starts, so they are not counted as Failures.
- Report skipped scenarios in the Extent **Known Issues** category with the bug ID in the test name, a clickable GitHub/Jira link, and the `-KI-` count in the report filename.
- Seed the list with the two Browser Compatibility scenarios tracked by https://github.com/mosip/esignet/issues/2249. Adding a new line to the file is enough to skip another scenario.

## Test plan
- [ ] Confirm `Known Issues Loaded` logs both Browser Compatibility scenario names mapped to `2249`
- [ ] Run the ui-test suite and verify those two scenarios are skipped (not failed)
- [ ] Open the Extent report: Categories shows Known Issues / #2249 with a link to GitHub issue 2249
- [ ] Report filename includes `-KI-2` (or the matching known-issue count)
- [ ] Unlisted scenarios still pass/fail/skip as before