### PR TITLE
fix(oidc-ui): set proxy_http_version 1.1 for backend proxy_pass locations

### DIFF
--- a/helm/oidc-ui/templates/configmap.yaml
+++ b/helm/oidc-ui/templates/configmap.yaml
@@ -37,6 +37,8 @@ data:
 
         location /v1/esignet/ {
           proxy_pass         http://{{ .Values.oidc_ui.oidc_service_host }}/;
+          proxy_http_version 1.1;
+          proxy_set_header   Connection "";
           proxy_redirect     off;
           proxy_set_header   Host $host;
           proxy_set_header   X-Real-IP $remote_addr;
@@ -48,6 +50,8 @@ data:
     
         location /v1/esignet/actuator/ {
           proxy_pass         http://{{ .Values.oidc_ui.oidc_service_host }}/;
+          proxy_http_version 1.1;
+          proxy_set_header   Connection "";
           proxy_redirect     off;
           proxy_set_header   Host $host;
           proxy_set_header   X-Real-IP $remote_addr;
@@ -59,6 +63,8 @@ data:
     
         location /.well-known/jwks.json {
           proxy_pass         http://{{ .Values.oidc_ui.oidc_service_host }}/oauth2/jwks;
+          proxy_http_version 1.1;
+          proxy_set_header   Connection "";
           proxy_redirect     off;
           proxy_set_header   Host $host;
           proxy_set_header   X-Real-IP $remote_addr;
@@ -73,6 +79,8 @@ data:
         
         location /.well-known/openid-configuration {
           proxy_pass         http://{{ .Values.oidc_ui.oidc_service_host }}/.well-known/openid-configuration;
+          proxy_http_version 1.1;
+          proxy_set_header   Connection "";
           proxy_redirect     off;
           proxy_set_header   Host $host;
           proxy_set_header   X-Real-IP $remote_addr;
@@ -87,6 +95,8 @@ data:
     
         location /.well-known/oauth-authorization-server {
           proxy_pass         http://{{ .Values.oidc_ui.oidc_service_host }}/.well-known/oauth-authorization-server;
+          proxy_http_version 1.1;
+          proxy_set_header   Connection "";
           proxy_redirect     off;
           proxy_set_header   Host $host;
           proxy_set_header   X-Real-IP $remote_addr;


### PR DESCRIPTION
### What

`oidc-ui`'s nginx `proxy_pass` blocks never set `proxy_http_version`, so nginx sends **HTTP/1.0** to the `esignet` backend by default. Since `helm/esignet/templates/service.yaml` names the backend Service port `http`, Istio (when sidecar injection is enabled) applies a strict HTTP/1.1-only codec on that port's inbound Envoy listener, which rejects the HTTP/1.0 request with `426 Upgrade Required`.

This fix adds to every proxied `location` block:
```nginx
proxy_http_version 1.1;
proxy_set_header   Connection "";
```

### Why

Standard nginx guidance when proxying to any HTTP/1.1-capable (keep-alive) upstream. Fixes the 426 without any Istio/Service changes.

### How I verified

Root-caused by testing the same request as HTTP/1.0 vs HTTP/1.1 directly against the backend Service from inside the mesh (via the `oidc-ui` pod's istio-proxy sidecar):
- `curl --http1.0 http://<esignet-service>/v1/esignet/...` → `426 Upgrade Required` from `istio-envoy`
- `curl --http1.1` (same URL) → normal response from the app

Applied this exact patch live to a running deployment's `nginx.conf` ConfigMap and confirmed the endpoint changed from `426 Upgrade Required` to a normal backend response (`405 Method Not Allowed` for a GET on a POST-only endpoint, i.e. correctly reaching the app).

Fixes #2559
