### PR TITLE
#2560,#2565 fix the docker images, corrected branch in postgres-init-…

### DIFF
--- a/deploy/esignet/install.sh
+++ b/deploy/esignet/install.sh
@@ -86,9 +86,7 @@ function installing_esignet() {
   COPY_UTIL=../copy_cm_func.sh
   $COPY_UTIL configmap postgres-config postgres $NS
   $COPY_UTIL configmap redis-config redis $NS
-  $COPY_UTIL configmap keycloak-host keycloak $NS
   $COPY_UTIL secret redis redis $NS
-  $COPY_UTIL secret keycloak-client-secrets keycloak $NS
 
   MOSIP_ESIGNET_HOST_DOMAIN=$(kubectl -n $NS get cm esignet-global -o jsonpath={.data.mosip-esignet-host})
   if [[ -z "$MOSIP_ESIGNET_HOST_DOMAIN" ]]; then

--- a/deploy/postgres/init_values.yaml
+++ b/deploy/postgres/init_values.yaml
@@ -17,4 +17,4 @@ databases:
         key: postgres-password
     dml: 1
     repoUrl: https://github.com/mosip/esignet.git
-    branch: develop-go
+    branch: release-2.0.x

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -52,8 +52,8 @@ service:
 
 image:
   registry: docker.io
-  repository: mosipdev/esignet
-  tag: develop-go
+  repository: mosipqa/esignet
+  tag: 2.0.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/helm/oidc-ui/values.yaml
+++ b/helm/oidc-ui/values.yaml
@@ -51,8 +51,8 @@ service:
 
 image:
   registry: docker.io
-  repository: mosipdev/oidc-ui
-  tag: develop
+  repository: mosipqa/oidc-ui
+  tag: 2.0.x
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
…values.yml file, and keycloak host issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated eSignet and OIDC UI deployments to use the 2.0.x release images.
  - Updated the eSignet database configuration to use the 2.0.x release branch.

- **Deployment Configuration**
  - Simplified eSignet secret synchronization to copy only the required Redis secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->