### PR TITLE
Revert "Temp fix to oidc-ui build job (#2526)"

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -86,6 +86,8 @@ jobs:
       SERVICE_LOCATION: oidc-ui
       BUILD_ARTIFACT: oidc
       NPM_BUILD_TYPE: BOB
+      NODE_VERSION: "22"
+      ZIP_DIR: dist
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
Reverts #2526.

That PR removed `NODE_VERSION: "22"` and `ZIP_DIR: dist` from the `build-oidc-ui` job in `.github/workflows/push-trigger.yml` as a temporary fix. This restores those inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to use Node.js 22.
  * Configured packaging to include the distribution output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->