### PR TITLE
Log runtime store namespaces instead of keys

### DIFF
--- a/esignet-service/internal/engine/runtimestores/inmemory/privacy_test.go
+++ b/esignet-service/internal/engine/runtimestores/inmemory/privacy_test.go
@@ -1,0 +1,47 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package inmemory
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+)
+
+func (ts *ServiceTestSuite) TestRuntimeKeysStayOutOfDebugLogs() {
+	t := ts.T()
+	if os.Getenv("ESIGNET_RUNTIME_LOG_TEST_CHILD") == "1" {
+		store := newInMemoryStore("test")
+		ctx := context.Background()
+		if err := store.Put(ctx, providers.NamespaceAuthzCode, "private-authorization-code", []byte("private-stored-value"), 60); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.PutIfNotExists(ctx, providers.NamespaceAuthzCode, "private-authorization-code-other", []byte("private-stored-value"), 60); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Take(ctx, providers.NamespaceAuthzCode, "private-authorization-code"); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	// Initialize the process-wide logger at debug level without changing other tests.
+	command := exec.Command(os.Args[0], "-test.run=^TestServiceTestSuite$/^TestRuntimeKeysStayOutOfDebugLogs$")
+	command.Env = append(os.Environ(), "ESIGNET_RUNTIME_LOG_TEST_CHILD=1", "LOG_LEVEL=debug")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child debug-log regression failed: %v", err)
+	}
+	if strings.Contains(string(output), "private-authorization-code") || strings.Contains(string(output), "private-stored-value") {
+		t.Fatal("runtime key or value entered debug log")
+	}
+	if strings.Count(string(output), `"namespace"`) != 3 {
+		t.Fatal("expected all three debug operations to retain namespace diagnostics")
+	}
+}

--- a/esignet-service/internal/engine/runtimestores/inmemory/service.go
+++ b/esignet-service/internal/engine/runtimestores/inmemory/service.go
@@ -58,7 +58,7 @@ func (s *inMemoryStore) Put(ctx context.Context, namespace providers.RuntimeStor
 	s.data[s.getFormattedKey(namespace, key)] = e
 	s.mu.Unlock()
 
-	s.logger.Debug(ctx, "Stored in memory", applog.String("key", key))
+	s.logger.Debug(ctx, "Stored in memory", applog.String("namespace", string(namespace)))
 	return nil
 }
 
@@ -81,7 +81,7 @@ func (s *inMemoryStore) PutIfNotExists(ctx context.Context, namespace providers.
 	s.data[fk] = e
 	s.mu.Unlock()
 
-	s.logger.Debug(ctx, "Stored in memory", applog.String("key", key))
+	s.logger.Debug(ctx, "Stored in memory", applog.String("namespace", string(namespace)))
 	return true, nil
 }
 
@@ -141,7 +141,7 @@ func (s *inMemoryStore) Take(ctx context.Context, namespace providers.RuntimeSto
 		return nil, nil
 	}
 
-	s.logger.Debug(ctx, "Taken from memory", applog.String("key", key))
+	s.logger.Debug(ctx, "Taken from memory", applog.String("namespace", string(namespace)))
 	return e.value, nil
 }
 

--- a/esignet-service/internal/engine/runtimestores/redisstore/privacy_test.go
+++ b/esignet-service/internal/engine/runtimestores/redisstore/privacy_test.go
@@ -1,0 +1,49 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package redisstore
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+
+	applog "github.com/mosip/esignet/internal/log"
+)
+
+func (ts *ServiceTestSuite) TestRuntimeKeysStayOutOfDebugLogs() {
+	t := ts.T()
+	if os.Getenv("ESIGNET_RUNTIME_LOG_TEST_CHILD") == "1" {
+		store := &redisStore{client: &fakeRedisClient{getDelVal: "private-stored-value"}, logger: applog.GetLogger()}
+		ctx := context.Background()
+		if err := store.Put(ctx, providers.NamespaceAuthzCode, "private-authorization-code", []byte("private-stored-value"), 60); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.PutIfNotExists(ctx, providers.NamespaceAuthzCode, "private-authorization-code-other", []byte("private-stored-value"), 60); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Take(ctx, providers.NamespaceAuthzCode, "private-authorization-code"); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	// Initialize the process-wide logger at debug level without changing other tests.
+	command := exec.Command(os.Args[0], "-test.run=^TestServiceTestSuite$/^TestRuntimeKeysStayOutOfDebugLogs$")
+	command.Env = append(os.Environ(), "ESIGNET_RUNTIME_LOG_TEST_CHILD=1", "LOG_LEVEL=debug")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child debug-log regression failed: %v", err)
+	}
+	if strings.Contains(string(output), "private-authorization-code") || strings.Contains(string(output), "private-stored-value") {
+		t.Fatal("runtime key or value entered debug log")
+	}
+	if strings.Count(string(output), `"namespace"`) != 3 {
+		t.Fatal("expected all three debug operations to retain namespace diagnostics")
+	}
+}

--- a/esignet-service/internal/engine/runtimestores/redisstore/service.go
+++ b/esignet-service/internal/engine/runtimestores/redisstore/service.go
@@ -76,7 +76,7 @@ func (r *redisStore) Put(ctx context.Context, namespace providers.RuntimeStoreNa
 		return fmt.Errorf("failed to store in Redis: %w", err)
 	}
 
-	r.logger.Debug(ctx, "Stored in Redis", applog.String("key", key))
+	r.logger.Debug(ctx, "Stored in Redis", applog.String("namespace", string(namespace)))
 	return nil
 }
 
@@ -99,7 +99,7 @@ func (r *redisStore) PutIfNotExists(ctx context.Context, namespace providers.Run
 		return false, fmt.Errorf("failed to store in Redis: %w", err)
 	}
 
-	r.logger.Debug(ctx, "Stored in Redis", applog.String("key", key))
+	r.logger.Debug(ctx, "Stored in Redis", applog.String("namespace", string(namespace)))
 	return ok == "OK", nil
 }
 
@@ -153,7 +153,7 @@ func (r *redisStore) Take(ctx context.Context, namespace providers.RuntimeStoreN
 		return nil, fmt.Errorf("failed to take data from Redis: %w", err)
 	}
 
-	r.logger.Debug(ctx, "Taken from Redis", applog.String("key", key))
+	r.logger.Debug(ctx, "Taken from Redis", applog.String("namespace", string(namespace)))
 	return data, nil
 }
 


### PR DESCRIPTION
Runtime-store debug events now identify the store namespace instead of emitting each entry's key. Apply the same behavior to `Put`, `PutIfNotExists`, and `Take` in the Redis and in-memory providers; storage behavior is unchanged.

Add regressions to both existing service test suites that initialize debug logging in an isolated process, exercise all three operations, and require namespace diagnostics while excluding synthetic keys and values.

Validation:

- The new regressions fail against unchanged upstream code and pass with this change.
- `GOTOOLCHAIN=go1.26.0 ./make.sh test` passes all 25 test packages with race detection and coverage.
- Focused lint for `./internal/engine/runtimestores/...` passes with zero issues.
- Full `./make.sh lint` reports the same three existing SA1019 findings as unchanged upstream runtime source, in PKCS#11 key handling and security JWKS parsing. No findings are in changed files.
- `git diff --check` passes.
