### PR TITLE
#2434 Add Go-based esignet-apitestrig Helm chart and deploy wrapper

### DIFF
--- a/deploy/esignet-apitestrig/.gitignore
+++ b/deploy/esignet-apitestrig/.gitignore
@@ -1,0 +1,1 @@
+values.secret.yaml

--- a/deploy/esignet-apitestrig/README.md
+++ b/deploy/esignet-apitestrig/README.md
@@ -1,77 +1,113 @@
-# APITESTRIG
+# eSignet API Test Rig (Go)
 
 ## Introduction
-ApiTestRig will test the working of APIs of the esignet modules.
+Runs the Go-based [`api-test`](../../api-test) harness against the eSignet
+deployment in this cluster, via the
+[`../../helm/esignet-apitestrig`](../../helm/esignet-apitestrig) chart.
+
+`install.sh` mirrors [`../esignet/install.sh`](../esignet/install.sh)'s own
+pattern: `helm repo add`/`helm repo update` against the published
+[`mosip-helm`](https://mosip.github.io/mosip-helm) repo, then
+`helm upgrade --install` by chart name and `CHART_VERSION`, not a local
+path. **This only works once `helm/esignet-apitestrig` has merged upstream
+and MOSIP's CI has published it** — until then, `helm install` fails with
+"chart not found", which is expected while this lives on a feature branch.
+Bump `install.sh`'s `CHART_VERSION` alongside `helm/esignet-apitestrig/Chart.yaml`'s
+own `version` whenever either changes.
+
+`install.sh` only asks two questions:
+1. the eSignet base URL (the one thing that realistically changes every run)
+2. whether you've actually reviewed/updated `values.yaml`
+
+Everything else that used to be an interactive prompt — Keycloak, TLS
+verification, the test identity, OTP/PMS settings, surfaces, report storage,
+conformance suite/plan config, cron schedule — is now a value in one of two
+files you edit directly beforehand.
+
+## Setup
+
+1. **`values.yaml`** (tracked in git) — non-secret settings. Open it and
+   fill in your environment's Keycloak token URL, OTP/PMS values, surfaces,
+   report storage, etc. Defaults are pre-filled from a known-working
+   configuration as a starting point — check every value, don't assume they
+   fit your environment.
+
+2. **`values.secret.yaml`** (gitignored) — secrets. Copy the example and
+   fill in real values:
+   ```bash
+   cp values.secret.yaml.example values.secret.yaml
+   ```
+   Holds `KEYCLOAK_CLIENT_SECRET`, the test identity (`INDIVIDUAL_ID` —
+   PII, kept out of `values.yaml`/git deliberately), and S3 access/secret
+   keys. `install.sh` refuses to run without this file present.
+
+3. **Conformance plan config** — `values.yaml` defaults to running
+   `conformance,api,e2e` with the in-pod suite
+   (`apitestrig.conformanceSuite.enabled: true`), which needs a private plan
+   config (a JWKS). Paste your real plan JSON into
+   `apitestrig.conformancePlanConfig.files` in `values.secret.yaml`
+   (placeholders are there by default in `values.secret.yaml.example`) —
+   `helm upgrade` renders it into a Secret itself as part of `./install.sh`,
+   no separate `kubectl` step needed. Filenames must match
+   `plans[].config_file`'s basename exactly (see `config.mosip.json`'s own
+   `_comment` block) — typically `esignet-config.json` and
+   `esignet-fapi2-config.json`.
+
+   (If you'd rather manage this Secret yourself outside of Helm — sealed-secrets,
+   external-secrets, etc. — set `apitestrig.conformancePlanConfig.existingSecret`
+   to that Secret's name in `values.yaml` instead, and leave `files` out of
+   `values.secret.yaml`.)
+
+   Without a filled-in plan, the run fails with a `config_file ... not
+   readable` error. If you don't have these plan files yet, set
+   `apitestrig.surfaces: "api,e2e"` in `values.yaml` until you do — see
+   "Conformance surface" below for
+   details.
+
 ## Install
-There are two ways to store reports:
-
-S3 Storage – Run the install script directly and provide the required S3 configuration values.
-
-NFS Storage – Create the necessary directory on the NFS server and then proceed with the installation.
-
-* Create a directory for apitestrig on the NFS server at `/srv/nfs/mosip/<sandbox>/apitestrig/`:
-```
-mkdir -p /srv/nfs/mosip/<sandbox>/apitestrig/
-```
-* Ensure the directory has 777 permissions:
-```
-chmod 777 /srv/nfs/mosip/<sandbox>/apitestrig
-```
-* Add the following entry to the /etc/exports file:
-```
-/srv/nfs/mosip/<sandbox>/apitestrig *(rw,sync,no_root_squash,no_all_squash,insecure,subtree_check)
-```
-* Apply export command
-```
-sudo exportfs -rav
-```
-* Restart the nfs-server
-```
-sudo systemctl restart nfs-kernel-server
-```
-* Once the nfs-kernel-server is up, log out from the NFS server and continue the deployment from your local machine.
-
-* Review `values.yaml` and, Make sure to enable required modules for apitestrig operation.
-```
-NOTE: Uncomment and configure the 'mosip_components_base_urls' section in 'values.yaml' if the eSignet and Signup services,
-are deployed on a separate cluster and rely on platform modules from another cluster.
-```
-* run `./install.sh`.
-```
+```bash
 ./install.sh
 ```
-
-* During the execution of the `install.sh` script, a prompt appears requesting information regarding the presence of a public domain and a valid SSL certificate on the server.
-* If the server lacks a public domain and a valid SSL certificate, it is advisable to select the `n` option. Opting it will enable the `init-container` with an `emptyDir` volume and include it in the deployment process.
-* The init-container will proceed to download the server's self-signed SSL certificate and mount it to the specified location within the container's Java keystore (i.e., `cacerts`) file.
-* This particular functionality caters to scenarios where the script needs to be employed on a server utilizing self-signed SSL certificates.
-* If the report is stored in NFS, use the scp command to copy the reports to your local machine.
+You'll be prompted for the eSignet base URL, then asked to confirm
+`values.yaml` is ready. Everything else comes from the two files above.
 
 ## Uninstall
-* To uninstall ApiTestRig, run `delete.sh` script.
-```sh
-./delete.sh 
+```bash
+./delete.sh
 ```
 
-## Run apitestrig manually
+## Conformance surface
+Set `apitestrig.surfaces: "conformance,api,e2e"` in `values.yaml`, plus:
+- `apitestrig.conformancePlanConfig.enabled: true`, plus either the plan JSON
+  in `values.secret.yaml`'s `conformancePlanConfig.files` (the default here) or
+  `existingSecret` pointing at a Secret you manage yourself — see
+  [`helm/esignet-apitestrig/README.md`](../../helm/esignet-apitestrig/README.md#conformance-plan-config).
+- Either `apitestrig.conformanceSuite.enabled: true` to run the suite
+  in-pod (no separate deployment, no Kubernetes version requirement — see
+  that same README's "Running the conformance suite itself" section), or
+  point `apitestrig.extraEnvVars.CONFORMANCE_BASE_URL` at a suite you're
+  running elsewhere.
+
+Without the plan config Secret, the conformance surface fails with a
+`config_file ... not readable` error — see
+[mosip/esignet#2434](https://github.com/mosip/esignet/issues/2434) §5a/§6ii
+for background.
+
+## Run manually
 
 #### Rancher UI
-* Run apitestrig manually via Rancher UI.
-  ![apitestrig-2.png](../../docs/apitestrig-2.png)
-* There are two modes of apitestrig `smoke` & `smokeAndRegression`.
-* By default, apitestrig will execute with `smokeAndRegression`. <br>
-  If you want to run apitestrig with only `smoke`. <br>
-  You have to update the `apitestrig` configmap and rerun the specific apitestrig job.
+Trigger the CronJob's job manually from the Rancher UI, same as any other
+CronJob.
 
 #### CLI
-* Download Kubernetes cluster `kubeconfig` file from `rancher dashboard` to your local.
-  ![apitestrig-1.png](../../docs/apitestrig-1.png)
-* Install `kubectl` package to your local machine.
-* Run apitestrig manually via CLI by creating a new job from an existing k8s cronjob.
-  ```
-  kubectl --kubeconfig=<k8s-config-file> -n apitestrig create job --from=cronjob/<cronjob-name> <job-name>
-  ```
-  example:
-  ```
-  kubectl --kubeconfig=/home/xxx/Downloads/qa4.config -n apitestrig create job --from=cronjob/cronjob-apitestrig-masterdata cronjob-apitestrig-masterdata
-  ```
+```sh
+kubectl --kubeconfig=<k8s-config-file> -n esignet create job \
+  --from=cronjob/esignet-apitestrig <job-name>
+```
+
+Reports land wherever `values.yaml`'s `reports.*` settings point — a PVC at
+`/app/out` inside the pod (`reports.persistence.enabled: true`), and/or
+S3/MinIO (`reports.s3.enabled: true`). For the PVC case:
+```sh
+kubectl -n esignet cp <pod-name>:/app/out ./out
+```

--- a/deploy/esignet-apitestrig/delete.sh
+++ b/deploy/esignet-apitestrig/delete.sh
@@ -1,30 +1,29 @@
 #!/bin/bash
-# Uninstalls apitestrig
+# Uninstalls the eSignet api-test rig (Go harness).
 ## Usage: ./delete.sh [kubeconfig]
 
 if [ $# -ge 1 ] ; then
   export KUBECONFIG=$1
 fi
 
+NS=esignet
+RELEASE_NAME=esignet-apitestrig
+
 function deleting_apitestrig() {
-  NS=esignet
-  while true; do
-      read -p "Are you sure you want to delete apitestrig helm charts?(Y/n) " yn
-      if [ $yn = "Y" ]
-        then
-          helm -n $NS delete esignet-apitestrig
-          break
-        else
-          break
-      fi
-  done
+  read -rp "Are you sure you want to delete $RELEASE_NAME in namespace $NS? (Y/n) " yn
+  if [[ "$yn" == "Y" || "$yn" == "y" ]]; then
+    helm -n "$NS" delete "$RELEASE_NAME"
+
+    echo ""
+    echo "NOTE: reports remain in the configured S3 bucket after 'helm delete'."
+    echo "Reports contain the test identity (PII). Apply the bucket retention"
+    echo "policy or delete the report objects when they are no longer needed."
+  fi
   return 0
 }
 
-# set commands for error handling.
-set -e
-set -o errexit   ## set -e : exit the script if any statement returns a non-true return value
-set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable
-set -o errtrace  # trace ERR through 'time command' and other functions
-set -o pipefail  # trace ERR through pipes
-deleting_apitestrig   # calling function
+set -o errexit
+set -o nounset
+set -o errtrace
+set -o pipefail
+deleting_apitestrig

--- a/deploy/esignet-apitestrig/install.sh
+++ b/deploy/esignet-apitestrig/install.sh
@@ -1,193 +1,92 @@
 #!/bin/bash
-# Installs apitestrig
+# Installs the eSignet api-test rig (Go harness) from the published
+# mosip-helm chart repo.
 ## Usage: ./install.sh [kubeconfig]
+#
+# Mirrors ../esignet/install.sh's own pattern: helm repo add + install by
+# name/version from mosip-helm, not a local chart path. This only works once
+# helm/esignet-apitestrig has actually merged upstream and MOSIP's CI has
+# published it there -- until then, `helm install` below will fail with
+# "chart not found", which is expected while this is still on a feature
+# branch.
+#
+# Only two prompts -- everything else lives in values.yaml (tracked in git,
+# edit it directly) and values.secret.yaml (gitignored, holds
+# KEYCLOAK_CLIENT_SECRET / the test identity / S3 keys -- copy
+# values.secret.yaml.example to get started).
 
 if [ $# -ge 1 ] ; then
   export KUBECONFIG=$1
 fi
 
-NS=esignet
-CHART_VERSION=0.0.1-develop
-COPY_UTIL=../copy_cm_func.sh
+set -o errexit
+set -o nounset
+set -o errtrace
+set -o pipefail
 
-echo Create $NS namespace
-kubectl create ns $NS
+NS=esignet
+RELEASE_NAME=esignet-apitestrig
+CHART_VERSION=0.0.1-develop
+VALUES_FILE=values.yaml
+SECRET_VALUES_FILE=values.secret.yaml
 
 function installing_apitestrig() {
+  if [[ ! -f "$SECRET_VALUES_FILE" ]]; then
+    echo "ERROR: $SECRET_VALUES_FILE not found."
+    echo "Copy ${SECRET_VALUES_FILE}.example to $SECRET_VALUES_FILE and fill in"
+    echo "KEYCLOAK_CLIENT_SECRET, the test identity, and S3 keys; EXITING."
+    exit 1
+  fi
+
+  # Catches the case where someone copies the example/template files and
+  # runs install.sh without actually filling them in -- these placeholders
+  # would otherwise reach Helm and land in real Secret/ConfigMap objects.
+  if grep -qE '"changeme"' "$SECRET_VALUES_FILE" "$VALUES_FILE"; then
+    echo "ERROR: $SECRET_VALUES_FILE and/or $VALUES_FILE still contain the"
+    echo "\"changeme\" placeholder value."
+    echo "Fill in real values for every field marked '# UPDATE ...' before"
+    echo "running this script; EXITING."
+    exit 1
+  fi
+
+  echo "Create $NS namespace (if it doesn't already exist)"
+  kubectl create ns $NS || true
+
+  helm repo add mosip https://mosip.github.io/mosip-helm
   helm repo update
 
-  echo echo Copy Secrtes
-  $COPY_UTIL secret postgres-postgresql postgres $NS
-
-  echo "Delete s3, db, & apitestrig configmap if exists"
-  kubectl -n $NS delete --ignore-not-found=true configmap s3
-  kubectl -n $NS delete --ignore-not-found=true configmap db
-  kubectl -n $NS delete --ignore-not-found=true configmap apitestrig
-
-  DB_HOST=$( kubectl -n esignet get cm esignet-global -o json  |jq -r '.data."mosip-api-internal-host"' )
-  API_INTERNAL_HOST=$( kubectl -n esignet get cm esignet-global -o json  |jq -r '.data."mosip-api-internal-host"' )
-  ENV_USER=$( kubectl -n esignet get cm esignet-global -o json |jq -r '.data."mosip-api-internal-host"' | awk -F '.' '/api-internal/{print $1"."$2}')
-
-  read -p "Please enter the time(hr) to run the cronjob every day (time: 0-23) : " time
-  if [ -z "$time" ]; then
-     echo "ERROT: Time cannot be empty; EXITING;";
-     exit 1;
+  # Best-effort default, same as before: read eSignet's own host if it's
+  # deployed in this namespace. Falls back to a bare prompt if not found.
+  ESIGNET_HOST=$(kubectl -n "$NS" get cm esignet-global -o json 2>/dev/null | jq -r '.data."mosip-esignet-host"' 2>/dev/null || true)
+  DEFAULT_BASE_URL=""
+  if [[ -n "$ESIGNET_HOST" && "$ESIGNET_HOST" != "null" ]]; then
+    DEFAULT_BASE_URL="https://$ESIGNET_HOST/v1/esignet"
   fi
-  if ! [ $time -eq $time ] 2>/dev/null; then
-     echo "ERROR: Time $time is not a number; EXITING;";
-     exit 1;
-  fi
-  if [ $time -gt 23 ] || [ $time -lt 0 ] ; then
-     echo "ERROR: Time should be in range ( 0-23 ); EXITING;";
-     exit 1;
+  read -rp "eSignet base URL${DEFAULT_BASE_URL:+ [$DEFAULT_BASE_URL]}: " MOSIP_ESIGNET_BASE_URL
+  MOSIP_ESIGNET_BASE_URL="${MOSIP_ESIGNET_BASE_URL:-$DEFAULT_BASE_URL}"
+  if [[ -z "$MOSIP_ESIGNET_BASE_URL" ]]; then
+    echo "ERROR: eSignet base URL is required; EXITING."
+    exit 1
   fi
 
-  echo "Do you have public domain & valid SSL? (Y/n) "
-  echo "Y: if you have public domain & valid ssl certificate"
-  echo "n: If you don't have a public domain and a valid SSL certificate. Note: It is recommended to use this option only in development environments."
-  read -p "" flag
-
-  if [ -z "$flag" ]; then
-    echo "'flag' was provided; EXITING;"
-    exit 1;
-  fi
-  ENABLE_INSECURE=''
-  if [ "$flag" = "n" ]; then
-    ENABLE_INSECURE='--set enable_insecure=true';
+  read -rp "Have you reviewed/updated $VALUES_FILE for this environment? (Y/n): " values_confirmed
+  values_confirmed=$(printf '%s' "$values_confirmed" | tr '[:upper:]' '[:lower:]')
+  if [[ "$values_confirmed" != "y" ]]; then
+    echo "Update $VALUES_FILE first (Keycloak/OTP/PMS settings, surfaces,"
+    echo "report storage, etc.), then re-run this script; EXITING."
+    exit 1
   fi
 
-  read -p "Please provide the retention days to remove old reports ( Default: 3 )" reportExpirationInDays
+  echo ""
+  echo "Installing $RELEASE_NAME (mosip/esignet-apitestrig, version $CHART_VERSION) in namespace $NS ..."
+  helm -n $NS upgrade --install $RELEASE_NAME mosip/esignet-apitestrig --version $CHART_VERSION \
+    -f "$VALUES_FILE" \
+    -f "$SECRET_VALUES_FILE" \
+    --set apitestrig.extraEnvVars.MOSIP_ESIGNET_BASE_URL="$MOSIP_ESIGNET_BASE_URL" \
+    --wait
 
-  if [[ -z $reportExpirationInDays ]]; then
-    reportExpirationInDays=3
-  fi
-  if ! [[ $reportExpirationInDays =~ ^[0-9]+$ ]]; then
-    echo "The variable \"reportExpirationInDays\" should contain only number; EXITING";
-    exit 1;
-  fi
-
-  read -p "Please provide slack webhook URL to notify server end issues on your slack channel : " slackWebhookUrl
-
-  if [ -z $slackWebhookUrl ]; then
-    echo "slack webhook URL not provided; EXITING;"
-    exit 1;
-  fi
-
- valid_inputs=("yes" "no")
- eSignetDeployed=""
-
- while [[ ! " ${valid_inputs[@]} " =~ " ${eSignetDeployed} " ]]; do
-     read -p "Is the eSignet service deployed? (yes/no): " eSignetDeployed
-     eSignetDeployed=${eSignetDeployed,,}  # Convert input to lowercase
- done
-
- if [[ $eSignetDeployed == "yes" ]]; then
-     echo "eSignet service is deployed. Proceeding with installation..."
- else
-     echo "eSignet service is not deployed. hence will be skipping esignet related test-cases..."
- fi
-  read -p "Is values.yaml for apitestrig chart set correctly as part of pre-requisites? (Y/n) : " yn;
-  if [[ $yn = "Y" ]] || [[ $yn = "y" ]] ; then
-    NFS_OPTION=''
-    S3_OPTION=''
-    config_complete=false  # flag to check if S3 or NFS is configured
-    while [ "$config_complete" = false ]; do
-      read -p "Do you have S3 details for storing apitestrig reports? (Y/n) : " ans
-      if [[ "$ans" == "y" || "$ans" == "Y" ]]; then
-        read -p "Please provide S3 host: " s3_host
-        if [[ -z $s3_host ]]; then
-          echo "S3 host not provided; EXITING;"
-          exit 1;
-        fi
-        read -p "Please provide S3 region: " s3_region
-        if [[ $s3_region == *[' !@#$%^&*()+']* ]]; then
-          echo "S3 region should not contain spaces or special characters; EXITING;"
-          exit 1;
-        fi
-
-        read -p "Please provide S3 access key: " s3_user_key
-        if [[ -z $s3_user_key ]]; then
-          echo "S3 access key not provided; EXITING;"
-          exit 1;
-        fi
-
-        read -p "Please provide S3 secret key: " s3_user_secret
-        if [[ -z $s3_user_secret ]]; then
-          echo "S3 secret key not provided; EXITING;"
-          exit 1;
-        fi
-
-        S3_OPTION="--set apitestrig.configmaps.s3.s3-host=$s3_host --set apitestrig.configmaps.s3.s3-user-key=$s3_user_key --set secrets.s3.s3-user-secret=$s3_user_secret --set apitestrig.configmaps.s3.s3-region=$s3_region"
-        push_reports_to_s3="yes"
-        config_complete=true
-      elif [[ "$ans" == "n" || "$ans" == "N" ]]; then
-        push_reports_to_s3="no"
-        read -p "Since S3 details are not available, do you want to use NFS directory mount for storing reports? (y/n) : " answer
-        if [[ $answer == "Y" ]] || [[ $answer == "y" ]]; then
-            # Storage class selection first
-          echo "Please select the storage class for NFS:"
-          echo "1. nfs-client"
-          echo "2. nfs-csi"
-          
-          read -p "Enter your choice (1 or 2): " storage_choice
-          
-          if [[ "$storage_choice" == "1" ]]; then
-            storage_class="nfs-client"
-          elif [[ "$storage_choice" == "2" ]]; then
-            storage_class="nfs-csi"
-          else
-            echo "Invalid choice. Exiting"
-            exit 1;
-          fi
-          read -p "Please provide NFS Server IP: " nfs_server
-          if [[ -z $nfs_server ]]; then
-            echo "NFS server not provided; EXITING."
-            exit 1;
-          fi
-          read -p "Please provide NFS directory to store reports from NFS server (e.g. /srv/nfs/mosip/<sandbox>/apitestrig/), make sure permission is 777 for the folder: " nfs_path
-          if [[ -z $nfs_path ]]; then
-            echo "NFS Path not provided; EXITING."
-            exit 1;
-          fi
-          NFS_OPTION="--set apitestrig.volumes.reports.storageClass=$storage_class --set apitestrig.volumes.reports.nfs.server=$nfs_server --set apitestrig.volumes.reports.nfs.path=$nfs_path"
-          config_complete=true
-        else
-          echo "Please rerun the script with either S3 or NFS server details."
-          exit 1;
-        fi
-      else
-        echo "Invalid input. Please respond with Y (yes) or N (no)."
-      fi
-    done
-    echo Installing esignet apitestrig
-    helm -n $NS install esignet-apitestrig mosip/apitestrig \
-    --set crontime="0 $time * * *" \
-    -f values.yaml  \
-    --version $CHART_VERSION \
-    $NFS_OPTION \
-    $S3_OPTION \
-    --set apitestrig.variables.push_reports_to_s3=$push_reports_to_s3 \
-    --set apitestrig.configmaps.db.db-server="$DB_HOST" \
-    --set apitestrig.configmaps.db.db-su-user="postgres" \
-    --set apitestrig.configmaps.db.db-port="5432" \
-    --set apitestrig.configmaps.apitestrig.ENV_USER="$ENV_USER" \
-    --set apitestrig.configmaps.apitestrig.ENV_ENDPOINT="https://$API_INTERNAL_HOST" \
-    --set apitestrig.configmaps.apitestrig.ENV_TESTLEVEL="smokeAndRegression" \
-    --set apitestrig.configmaps.apitestrig.reportExpirationInDays="$reportExpirationInDays" \
-    --set apitestrig.configmaps.apitestrig.slack-webhook-url="$slackWebhookUrl" \
-    --set apitestrig.configmaps.apitestrig.eSignetDeployed="$eSignetDeployed" \
-    --set apitestrig.configmaps.apitestrig.NS="$NS" \
-    $ENABLE_INSECURE
-
-    echo Installed esignet apitestrig.
-    return 0
-  fi  
+  echo "Installed $RELEASE_NAME."
+  return 0
 }
 
-# set commands for error handling.
-set -e
-set -o errexit   ## set -e : exit the script if any statement returns a non-true return value
-set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable
-set -o errtrace  # trace ERR through 'time command' and other functions
-set -o pipefail  # trace ERR through pipes
-installing_apitestrig   # calling function
+installing_apitestrig

--- a/deploy/esignet-apitestrig/values.secret.yaml.example
+++ b/deploy/esignet-apitestrig/values.secret.yaml.example
@@ -1,0 +1,26 @@
+# Copy this file to values.secret.yaml (gitignored) and fill in real values.
+# install.sh loads values.secret.yaml if present; it refuses to proceed
+# without it.
+
+apitestrig:
+  extraEnvVarsSecret:
+    KEYCLOAK_CLIENT_SECRET: "changeme"       # UPDATE with the PMS client secret
+    INDIVIDUAL_ID: "changeme"                # UPDATE with your test identity -- PII, keep out of git
+
+  # Conformance runs by default (values.yaml's apitestrig.surfaces), which
+  # needs this private plan config (a JWKS) -- Helm renders it into a
+  # Secret itself as part of ./install.sh, no separate kubectl step.
+  # Filenames must match plans[].config_file's basename exactly (see
+  # config.mosip.json's own _comment block) -- paste your real plan JSON
+  # below in place of the placeholders.
+  conformancePlanConfig:
+    files:
+      esignet-config.json: |
+        REPLACE_WITH_REAL_OIDCC_PLAN_JSON
+      esignet-fapi2-config.json: |
+        REPLACE_WITH_REAL_FAPI2_PLAN_JSON
+
+reports:
+  s3:
+    accessKey: "changeme"   # UPDATE with your S3/MinIO access key
+    secretKey: "changeme"   # UPDATE with your S3/MinIO secret key

--- a/deploy/esignet-apitestrig/values.yaml
+++ b/deploy/esignet-apitestrig/values.yaml
@@ -1,40 +1,95 @@
-modules:
-  esignet:
+# Secrets (KEYCLOAK_CLIENT_SECRET, the test identity, S3 keys) do NOT belong
+# in this file -- it's tracked in git. Put those in values.secret.yaml
+# instead (gitignored; copy values.secret.yaml.example to get started).
+
+image:
+  repository: mosipdev/apitest-esignet
+  tag: develop-go
+  pullPolicy: Always
+
+triggerKind: cronjob
+crontime: "0 8 * * *"   # hour 0-23, matches the old "time" prompt
+
+apitestrig:
+  # The image ships data/config/config.{mock,mosip,sunbird}.json baked in.
+  # This deploy wrapper runs the harness against a real MOSIP-flavoured
+  # eSignet, hence config.mosip.json. Switch to config.mock.json if you're
+  # pointing this at a mock-plugin eSignet instead.
+  configFile: /app/data/config/config.mosip.json
+
+  # "api,e2e" or "conformance,api,e2e". config.mosip.json's own run.surfaces
+  # defaults to ["conformance","api","e2e"], and conformance needs a private
+  # plan config (conformancePlanConfig below) plus a reachable
+  # CONFORMANCE_BASE_URL -- see https://github.com/mosip/esignet/issues/2434
+  # §5a/§6ii. Both are wired up below (conformancePlanConfig.existingSecret +
+  # conformanceSuite.enabled) so this works by default -- if either isn't
+  # actually set up yet in your namespace, drop back to "api,e2e" until it is.
+  surfaces: "conformance,api,e2e"
+
+  extraEnvVars:
+    # --- Keycloak ---
+    KEYCLOAK_TOKEN_URL: "https://iam.sandbox.mosip.net/auth/realms/mosip/protocol/openid-connect/token"   # UPDATE 'sandbox' to your environment
+    KEYCLOAK_CLIENT_ID: "mosip-pms-client"   # blank = config file's own default
+
+    # --- TLS ---
+    # Self-signed/internal certs? Set both to "false" (was the y/N prompt).
+    ESIGNET_TLS_VERIFY: "false"
+    API_TLS_VERIFY: "false"
+    CONFORMANCE_TLS_VERIFY: "false"
+
+    # --- Test identity (non-secret half; ID_TYPE only) ---
+    ID_TYPE: "uin"   # uin | vid | phone | email
+
+    # --- OTP / PMS -- required by config.mosip.json, shipped blank there ---
+    # (see the config file's own _comment block and issue #2434 §4)
+    OTP_WS_URL: "https://smtp.sandbox.mosip.net"   # UPDATE 'sandbox' to your environment
+    OTP_RECIPIENT_EMAIL: "provide phone number or email for fetching OTP"   # UPDATE with your test identity's contact
+    PMS_BASE_URL: "https://api-internal.sandbox.mosip.net/v1/partnermanager"   # UPDATE 'sandbox' to your environment
+    AUTH_PARTNER_ID: "auth partner ID to create client ID"   # UPDATE with your auth partner ID
+    AUTH_POLICY_ID: "policy ID to create client ID"   # UPDATE with your policy ID
+
+    # --- Conformance (only used if apitestrig.surfaces includes it) ---
+    # https://localhost.emobix.co.uk:8443 resolves to 127.0.0.1 via public
+    # DNS -- with apitestrig.conformanceSuite.enabled below (in-pod suite),
+    # that's what makes it reachable at all. Must match whatever your plan
+    # file's client_ids were registered against in eSignet if you change it.
+    CONFORMANCE_BASE_URL: "https://localhost.emobix.co.uk:8443"
+
+  # See helm/esignet-apitestrig/README.md "Conformance plan config". The actual
+  # plan JSON content lives in values.secret.yaml (it's private-key
+  # material) -- existingSecret stays blank so Helm renders it from
+  # apitestrig.conformancePlanConfig.files there. Without that filled in,
+  # this surface fails with a "config_file ... not readable" error.
+  conformancePlanConfig:
     enabled: true
-    image:
-      repository: mosipdev/apitest-esignet
-      tag: develop
-      pullPolicy: Always
+    existingSecret: ""
 
-extraEnvVarsCM:
-  - esignet-global
-  - s3
-  - keycloak-host
-  - db
-  - apitestrig
-
-extraEnvVarsSecret:
-  - apitestrig-esignet-apitestrig
-  - s3-esignet-apitestrig
-  - keycloak-client-secrets
-  - postgres-postgresql
+  # See helm/esignet-apitestrig/README.md "Running the conformance suite itself" --
+  # runs mongodb+server+nginx as extra containers in this pod so
+  # CONFORMANCE_BASE_URL=https://localhost.emobix.co.uk:8443 just works.
+  # No K8s version requirement (regular containers + shareProcessNamespace +
+  # a reaper container, not native sidecars).
+  conformanceSuite:
+    enabled: true
 
 resources:
   limits:
-    cpu: 300m
-    memory: 500Mi
+    cpu: "1"
+    memory: 1Gi
   requests:
-    cpu: 300m
-    memory: 500Mi
+    cpu: 200m
+    memory: 512Mi
 
-apitestrig:
-  configmaps:
-    apitestrig:
-      # Wait time (in milliseconds) after UIN generation in IDREPO before proceeding
-      uinGenerationProcessingDelayTimeInMilliSeconds: "90000"
+reports:
+  # Set persistence.enabled: false if you only want S3 (below), no local PVC.
+  persistence:
+    enabled: false
+    storageClass: ""
+    existingClaim: ""
 
-      # Wait time (in milliseconds) after VID generation in Resident before proceeding
-      vidGenerationProcessingDelayTimeInMilliSeconds: "90000"
-
-      # Maximum number of retry attempts for UIN availability check during OTP generation
-      uinGenMaxLoopCount: "20"
+  s3:
+    enabled: true
+    endpoint: "your s3 url"   # UPDATE with your S3/MinIO endpoint
+    bucket: "your bucket name"   # UPDATE with your bucket name
+    pathPrefix: "go"
+    insecure: true   # self-signed cert or plain http

--- a/helm/esignet-apitestrig/.helmignore
+++ b/helm/esignet-apitestrig/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.orig
+*.tmp
+*.bak
+*.swp

--- a/helm/esignet-apitestrig/Chart.yaml
+++ b/helm/esignet-apitestrig/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: esignet-apitestrig
+description: A Helm chart to deploy the Go-based eSignet API test rig (api-test)
+type: application
+version: 0.0.1-develop
+appVersion: ""
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+home: https://mosip.io
+keywords:
+  - mosip
+  - esignet
+  - apitestrig
+maintainers:
+  - email: info@mosip.io
+    name: MOSIP

--- a/helm/esignet-apitestrig/README.md
+++ b/helm/esignet-apitestrig/README.md
@@ -1,0 +1,205 @@
+# esignet-apitestrig (eSignet, Go)
+
+> Named `esignet-apitestrig`, not `apitestrig` — that name is already used by
+> [`mosip-functional-tests/helm/apitestrig`](https://github.com/mosip/mosip-functional-tests/tree/develop/helm/apitestrig)
+> (the Java-based test rig), a structurally incompatible chart. Keeping this
+> distinct avoids any collision if both ever end up in the same chart
+> repository (e.g. `mosip-helm`).
+
+Helm chart to run the Go-based [`api-test`](../../api-test) harness against a
+deployed eSignet instance, either on a schedule (`CronJob`) or as a one-off
+run (`Job`).
+
+Modeled on
+[`mosip-functional-tests/helm/apitestrig`](https://github.com/mosip/mosip-functional-tests/tree/develop/helm/apitestrig),
+adapted for this harness's single-image, single-binary, config-file-driven
+design (see `api-test/Dockerfile` and `api-test/run-all.sh`) rather than the
+Java testrig's one-image-per-module model.
+
+## Prerequisites
+
+- The eSignet deployment this rig targets must already be reachable from the
+  cluster (`apitestrig.extraEnvVars.MOSIP_ESIGNET_BASE_URL`).
+- If you plan to run the `conformance` surface, it needs a real OpenID
+  Conformance Suite to talk to — either point
+  `apitestrig.extraEnvVars.CONFORMANCE_BASE_URL` at one already running
+  elsewhere, or set `apitestrig.conformanceSuite.enabled: true` to run one
+  in-pod (see "Running the conformance suite itself" below) — this chart
+  does not do either for you automatically. Either way you also need the
+  private plan config via `apitestrig.conformancePlanConfig` (see
+  "Conformance plan config" below).
+  Without both, leave `conformance` out of `apitestrig.surfaces` — the config
+  files this chart's images ship (`config.mosip.json` etc.) default to
+  including it, and will fail with a "config_file ... not readable" error
+  otherwise (see [mosip/esignet#2434](https://github.com/mosip/esignet/issues/2434)).
+- `helm dependency build` (pulls the Bitnami `common` chart used for labels
+  and image-name helpers).
+
+## Quick start
+
+```bash
+cd helm/esignet-apitestrig
+helm dependency build
+
+# One-off run against a deployed environment, api+e2e only
+helm install apitestrig-smoke . \
+  --set triggerKind=job \
+  --set apitestrig.surfaces=api\\,e2e \
+  --set apitestrig.extraEnvVars.MOSIP_ESIGNET_BASE_URL=https://esignet.example.net/v1/esignet \
+  --set apitestrig.extraEnvVars.KEYCLOAK_TOKEN_URL=https://keycloak.example.net/realms/mosip/protocol/openid-connect/token \
+  --set apitestrig.extraEnvVarsSecret.KEYCLOAK_CLIENT_SECRET=<secret>
+```
+
+```bash
+# Nightly regression against the mosip config
+helm install apitestrig . \
+  --set apitestrig.extraEnvVars.MOSIP_ESIGNET_BASE_URL=https://esignet.example.net/v1/esignet \
+  --set apitestrig.extraEnvVarsSecret.KEYCLOAK_CLIENT_SECRET=<secret>
+```
+
+## Configuration model
+
+The image already bakes in `data/config/config.{mock,mosip,sunbird}.json` —
+`apitestrig.configFile` just selects the in-image path (default:
+`config.mosip.json`). Set `apitestrig.configOverride` only if you need a
+config that isn't one of the shipped ones; it's rendered into a ConfigMap and
+mounted instead.
+
+Layering, matching `run-all.sh`'s own precedence (file → `config.local.json`
+overlay → environment):
+
+| Layer | Source | Values key |
+|---|---|---|
+| Base config | baked into image, or `configOverride` | `apitestrig.configFile` / `apitestrig.configOverride` |
+| Credentials overlay | mounted Secret, at `CONFIG_LOCAL` | `apitestrig.configLocal.*` |
+| Non-secret overrides | container env | `apitestrig.extraEnvVars` |
+| Secret overrides | container env via `secretKeyRef` | `apitestrig.extraEnvVarsSecret` |
+| Shared cluster config/secrets | `envFrom` | `apitestrig.extraEnvVarsCM` / `extraEnvVarsSecretRefs` |
+
+`apitestrig.configLocal.existingSecret` lets you supply the overlay via a
+Secret you manage outside Helm (sealed-secrets, external-secrets, etc.)
+instead of `apitestrig.configLocal.data` in values.
+
+## Reports
+
+`REPORT_DIR` is set to `reports.mountPath` (default `/app/out`). By default
+it's backed by a PVC (`reports.persistence`) — set
+`reports.persistence.existingClaim` to reuse a PVC across runs.
+
+To also (or instead) push each run's report to S3-compatible storage (AWS S3
+or MinIO), set `reports.s3.enabled: true` plus `reports.s3.endpoint`,
+`.bucket`, and credentials (`reports.s3.accessKey`/`secretKey`, or
+`reports.s3.existingSecret` to supply your own Secret). This adds a second
+`report-uploader` container to the pod that waits for the harness to finish
+(run-all.sh has no S3 awareness of its own, so completion is signalled via a
+marker file on the shared reports volume) and then runs `mc cp` to upload
+everything under `reports.s3.pathPrefix/<UTC timestamp>/` in the bucket. Set
+`reports.persistence.enabled: false` if you don't want a PVC kept around once
+reports are pushed to S3 — the reports volume becomes an `emptyDir` instead.
+
+```bash
+helm upgrade --install apitestrig . \
+  --set reports.s3.enabled=true \
+  --set reports.s3.endpoint=http://minio.minio:9000 \
+  --set reports.s3.bucket=apitestrig-reports \
+  --set reports.s3.accessKey=<key> \
+  --set reports.s3.secretKey=<secret> \
+  --set reports.persistence.enabled=false   # optional: skip the PVC entirely
+```
+
+## Conformance plan config
+
+The `conformance` surface needs a private plan config (a JWKS, per
+[`api-test/docs/conformance-suite.md`](../../api-test/docs/conformance-suite.md))
+at exactly the relative path the selected config's `plans[].config_file`
+names — always `conformance-suite-private/<file>.json`. Set
+`apitestrig.conformancePlanConfig.enabled: true` and either point
+`existingSecret` at a Secret you manage out-of-band (one key per plan file,
+e.g. `esignet-config.json`), or fill in `files` for a Helm-managed one:
+
+```bash
+kubectl create secret generic esignet-conformance-plan -n esignet \
+  --from-file=esignet-config.json=./conformance-suite-private/esignet-config.json \
+  --from-file=esignet-fapi2-config.json=./conformance-suite-private/esignet-fapi2-config.json
+```
+
+**`CONFORMANCE_BASE_URL` must match whatever host your plan file's
+`client`/`client2` were registered against in eSignet** (redirect URI
+`<CONFORMANCE_BASE_URL>/test/a/<alias>/callback`) — the harness calls back
+into the suite using that exact URL (`internal/conformance/client.go`'s
+`DeliverCallback`), so changing it means re-registering those clients. If
+your plan was built against the suite's own conventional local address
+(`https://localhost.emobix.co.uk:8443`), keep using that literal value
+rather than pointing at a different Service URL, even once the suite is
+actually running elsewhere — see `apitestrig.conformanceSuite` below for how
+that stays consistent automatically when running the suite in-pod.
+
+## Running the conformance suite itself (`apitestrig.conformanceSuite`)
+
+The `conformance` surface is a *client* — it needs a real OpenID Conformance
+Suite server to talk to; it can't run standalone. `apitestrig.conformanceSuite`
+runs the suite (mongodb + server + nginx) as regular containers in the same
+pod, using the exact images/env from
+[`api-test/docker-compose.yml`](../../api-test/docker-compose.yml)'s own
+local-dev recipe:
+
+```bash
+helm upgrade --install apitestrig . \
+  --set 'apitestrig.surfaces=conformance\,api\,e2e' \
+  --set apitestrig.conformancePlanConfig.enabled=true \
+  --set apitestrig.conformancePlanConfig.existingSecret=esignet-conformance-plan \
+  --set apitestrig.extraEnvVars.CONFORMANCE_BASE_URL=https://localhost.emobix.co.uk:8443 \
+  --set apitestrig.conformanceSuite.enabled=true
+```
+
+`https://localhost.emobix.co.uk:8443` already resolves to `127.0.0.1` via
+public DNS, and pod containers share a network namespace regardless of
+container type — so once the suite's containers are up, that URL just
+reaches them directly, no separate Service needed and no client
+re-registration required. No Kubernetes version requirement for this part.
+
+**The one real wrinkle**: mongodb/server/httpd are long-running processes
+that never exit on their own, and a Job only completes once *every*
+container in the pod exits — left alone, they'd block every run from ever
+completing. Fixed with `shareProcessNamespace: true` on the pod plus a small
+`conformance-reaper` container that waits for the same completion marker
+`report-uploader` already watches for, then kills the suite's processes by
+name (`mongod`, `java`, `nginx`) so their containers exit and the Job can
+finish — a well-established pattern from before native sidecars existed
+(K8s 1.28), and it works on any Kubernetes version. Note `shareProcessNamespace`
+means every container in this pod can see and signal every other container's
+processes — acceptable here since this pod only ever runs images this chart
+already controls, but worth knowing if you're auditing it.
+
+Nothing here enforces startup ordering (mongo ready before server, server
+before httpd) the way native sidecars would — this relies on the same
+"loose" ordering `api-test/docker-compose.yml`'s own `depends_on` (without
+healthcheck conditions) already relies on: Spring Boot retries its Mongo
+connection on startup, and the harness's own `SUITE_WAIT_SECONDS` retries
+reaching the suite through httpd.
+
+Three details are **assumed, not yet verified against a real cluster**:
+the suite server's internal port (not actually used by anything in this
+design, but worth knowing if you need to debug it directly), whether the
+nginx image's baked-in config proxies to hostnames `server`/`mongodb`
+(Docker Compose's automatic per-service DNS) — a `hostAliases` entry maps
+both to `127.0.0.1` to cover that, but it's inferred from Compose
+convention, not confirmed against the image itself — and whether `mongod`/
+`java`/`nginx` are actually the process names these images report (standard
+for these kinds of images, but not confirmed). If reaping doesn't work,
+`apitestrig.conformanceSuite.reaper.processNames` is where to fix it.
+
+
+The `client_id`s inside that plan file must already be pre-registered in
+eSignet as `private_key_jwt`, with a redirect URI of
+`<CONFORMANCE_BASE_URL>/test/a/<alias>/callback` — an environment-provisioning
+step this chart can't do for you.
+
+## CronJob vs Job
+
+- `triggerKind: cronjob` (default) — scheduled via `crontime`, mirrors the
+  reference chart's nightly-run model.
+- `triggerKind: job` — a single run per `helm install`/`helm upgrade`, handy
+  for CI-triggered smoke tests against a freshly-deployed environment. The Job
+  name is suffixed with `.Release.Revision` so repeated `helm upgrade` calls
+  don't collide with an already-completed Job.

--- a/helm/esignet-apitestrig/templates/NOTES.txt
+++ b/helm/esignet-apitestrig/templates/NOTES.txt
@@ -1,0 +1,27 @@
+eSignet api-test rig ({{ .Values.triggerKind }}) has been deployed.
+
+Config in use : {{ include "apitestrig.configPath" . }}
+{{- if .Values.apitestrig.surfaces }}
+Surfaces      : {{ .Values.apitestrig.surfaces }}
+{{- else }}
+Surfaces      : (from the selected config file's run.surfaces)
+{{- end }}
+Reports       : {{ .Values.reports.mountPath }}
+{{- if .Values.reports.persistence.enabled }}
+                PVC: {{ include "apitestrig.reportsClaimName" . }}
+{{- end }}
+
+{{- if eq .Values.triggerKind "cronjob" }}
+
+Scheduled: {{ .Values.crontime }}
+To trigger a run right now:
+  kubectl create job --from=cronjob/{{ include "common.names.fullname" . }} \
+    -n {{ .Release.Namespace }} {{ include "common.names.fullname" . }}-manual-$(date +%s)
+{{- else }}
+
+Follow this run:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -f
+{{- end }}
+
+To pull the consolidated HTML report out of the reports volume:
+  kubectl cp -n {{ .Release.Namespace }} <pod-name>:{{ .Values.reports.mountPath }} ./out

--- a/helm/esignet-apitestrig/templates/_helpers.tpl
+++ b/helm/esignet-apitestrig/templates/_helpers.tpl
@@ -1,0 +1,406 @@
+{{/*
+Return the proper image name
+*/}}
+{{- define "apitestrig.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "apitestrig.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "apitestrig.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (printf "%s" (include "common.names.fullname" .)) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the -c value to pass to run-all.sh: the mounted custom config when
+apitestrig.configOverride is set, otherwise the in-image path from
+apitestrig.configFile.
+*/}}
+{{- define "apitestrig.configPath" -}}
+{{- if .Values.apitestrig.configOverride -}}
+/app/custom-config/config.json
+{{- else -}}
+{{ .Values.apitestrig.configFile }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the Secret backing the config.local.json overlay, whether
+Helm-managed or user-supplied via existingSecret.
+*/}}
+{{- define "apitestrig.configLocalSecretName" -}}
+{{- if .Values.apitestrig.configLocal.existingSecret -}}
+{{ .Values.apitestrig.configLocal.existingSecret }}
+{{- else -}}
+{{ include "common.names.fullname" . }}-config-local
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the Secret backing the conformance plan config files.
+*/}}
+{{- define "apitestrig.conformancePlanConfigSecretName" -}}
+{{- if .Values.apitestrig.conformancePlanConfig.existingSecret -}}
+{{ .Values.apitestrig.conformancePlanConfig.existingSecret }}
+{{- else -}}
+{{ include "common.names.fullname" . }}-conformance-plan
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the Secret backing extraEnvVarsSecret.
+*/}}
+{{- define "apitestrig.envSecretName" -}}
+{{ include "common.names.fullname" . }}-env
+{{- end -}}
+
+{{/*
+Name of the Secret backing S3 report-push credentials.
+*/}}
+{{- define "apitestrig.s3SecretName" -}}
+{{- if .Values.reports.s3.existingSecret -}}
+{{ .Values.reports.s3.existingSecret }}
+{{- else -}}
+{{ include "common.names.fullname" . }}-s3
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the PVC backing the reports volume.
+*/}}
+{{- define "apitestrig.reportsClaimName" -}}
+{{- if .Values.reports.persistence.existingClaim -}}
+{{ .Values.reports.persistence.existingClaim }}
+{{- else -}}
+{{ include "common.names.fullname" . }}-reports
+{{- end -}}
+{{- end -}}
+
+{{/*
+The shared pod spec used by both cronjob.yaml and job.yaml, so the two
+trigger kinds can never drift out of sync with each other.
+*/}}
+{{- define "apitestrig.podTemplate" -}}
+metadata:
+  annotations:
+    sidecar.istio.io/inject: {{ .Values.istio.sidecarInject | quote }}
+    {{- if .Values.podAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.podLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  restartPolicy: Never
+  {{- if .Values.apitestrig.conformanceSuite.enabled }}
+  shareProcessNamespace: true
+  {{- end }}
+  serviceAccountName: {{ include "apitestrig.serviceAccountName" . }}
+  {{- include "apitestrig.imagePullSecrets" . | nindent 2 }}
+  {{- if .Values.podSecurityContext.enabled }}
+  securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.hostAliases .Values.apitestrig.conformanceSuite.enabled }}
+  hostAliases:
+    {{- if .Values.apitestrig.conformanceSuite.enabled }}
+    {{/*
+    ASSUMED, NOT YET VERIFIED: the httpd image's baked-in nginx.conf proxies
+    to hostnames "server"/"mongodb" (Compose's automatic per-service DNS)
+    rather than a configurable upstream -- see values.yaml's
+    apitestrig.conformanceSuite comment. Test before relying on this.
+    */}}
+    - ip: 127.0.0.1
+      hostnames:
+        - server
+        - mongodb
+    {{- end }}
+    {{- if .Values.hostAliases }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.affinity }}
+  affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tolerations }}
+  tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: apitestrig
+      image: {{ include "apitestrig.image" . }}
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      {{- if .Values.containerSecurityContext.enabled }}
+      securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.reports.s3.enabled }}
+      {{/*
+      S3 push needs to know when the harness is done (run-all.sh has no S3
+      awareness of its own), so wrap it in a shell that drops a completion
+      marker on the shared reports volume for the uploader container to
+      watch for, then exits with the harness's own exit code.
+
+      NOTE: .Values.command is intentionally NOT honoured here (unlike the
+      non-S3 branch below) -- this branch must own the full command line to
+      inject the completion-marker logic, so a custom command can't be
+      layered in without conflicting with that. .Values.args is inlined
+      directly into this single shell string (not rendered as a separate
+      argv list via common.tplvalues.render like the non-S3 branch), so an
+      args entry containing a Helm template expression renders differently
+      here than in that branch -- stick to plain strings in
+      .Values.args if you also set reports.s3.enabled.
+      */}}
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          set -o pipefail
+          ./run-all.sh -c {{ include "apitestrig.configPath" . | trim | quote }}{{ if .Values.apitestrig.surfaces }} -s {{ .Values.apitestrig.surfaces | quote }}{{ end }}{{ range .Values.args }} {{ . | quote }}{{ end }}
+          rc=$?
+          touch {{ printf "%s/.rig-complete" .Values.reports.mountPath | quote }}
+          exit $rc
+      {{- else }}
+      {{- if .Values.command }}
+      command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 8 }}
+      {{- end }}
+      args:
+        - "-c"
+        - {{ include "apitestrig.configPath" . | trim | quote }}
+        {{- if .Values.apitestrig.surfaces }}
+        - "-s"
+        - {{ .Values.apitestrig.surfaces | quote }}
+        {{- end }}
+        {{- if .Values.args }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      env:
+        - name: REPORT_DIR
+          value: {{ .Values.reports.mountPath | quote }}
+        {{- if .Values.apitestrig.configLocal.enabled }}
+        - name: CONFIG_LOCAL
+          value: "/app/secrets/config.local.json"
+        {{- end }}
+        {{- range $key, $value := .Values.apitestrig.extraEnvVars }}
+        {{- if $value }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- range $key, $value := .Values.apitestrig.extraEnvVarsSecret }}
+        {{- if $value }}
+        - name: {{ $key }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "apitestrig.envSecretName" $ }}
+              key: {{ $key }}
+        {{- end }}
+        {{- end }}
+      envFrom:
+        {{- range .Values.apitestrig.extraEnvVarsCM }}
+        - configMapRef:
+            name: {{ . }}
+        {{- end }}
+        {{- range .Values.apitestrig.extraEnvVarsSecretRefs }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
+      volumeMounts:
+        - name: reports
+          mountPath: {{ .Values.reports.mountPath }}
+        {{- if .Values.apitestrig.configLocal.enabled }}
+        - name: config-local
+          mountPath: /app/secrets
+          readOnly: true
+        {{- end }}
+        {{- if .Values.apitestrig.configOverride }}
+        - name: custom-config
+          mountPath: /app/custom-config
+          readOnly: true
+        {{- end }}
+        {{- if .Values.apitestrig.conformancePlanConfig.enabled }}
+        - name: conformance-plan-config
+          mountPath: /app/conformance-suite-private
+          readOnly: true
+        {{- end }}
+      resources: {{- toYaml .Values.resources | nindent 8 }}
+    {{- if .Values.reports.s3.enabled }}
+    - name: report-uploader
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.reports.s3.image "global" .Values.global) }}
+      imagePullPolicy: {{ .Values.reports.s3.image.pullPolicy }}
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set -e
+          export HOME=/tmp
+          until [ -f {{ printf "%s/.rig-complete" .Values.reports.mountPath | quote }} ]; do
+            sleep 5
+          done
+          [ "$S3_INSECURE" = "true" ] && export MC_INSECURE=true
+          # mc alias set puts credentials in this process's own argv, which
+          # shareProcessNamespace: true (used when apitestrig.conformanceSuite
+          # is also enabled) makes visible to every other container in this
+          # pod via /proc/<pid>/cmdline. MC_HOST_target avoids that entirely --
+          # NOTE: this assumes S3_ACCESS_KEY/S3_SECRET_KEY contain no
+          # "@", ":", "/" or "#" characters; URL-encode them first if they do.
+          SCHEME=${S3_ENDPOINT%%://*}
+          HOSTPART=${S3_ENDPOINT#*://}
+          export MC_HOST_target="$SCHEME://$S3_ACCESS_KEY:$S3_SECRET_KEY@$HOSTPART"
+          mc mb --ignore-existing "target/$S3_BUCKET"
+          # IST is UTC+5:30. Computed as raw seconds rather than TZ=Asia/Kolkata
+          # so this doesn't depend on a timezone database being present in
+          # this minimal image -- pure arithmetic on the epoch, then format
+          # the shifted value "as UTC" to get the correct IST wall-clock time.
+          IST_EPOCH=$(( $(date -u +%s) + 19800 ))
+          DEST="target/$S3_BUCKET/$S3_PATH_PREFIX/$(date -u -d @$IST_EPOCH +%Y-%m-%d_%H-%M)"
+          mc cp --recursive {{ .Values.reports.mountPath }}/ "$DEST/"
+          echo "Uploaded reports to $DEST"
+      env:
+        - name: S3_ENDPOINT
+          value: {{ .Values.reports.s3.endpoint | quote }}
+        - name: S3_BUCKET
+          value: {{ .Values.reports.s3.bucket | quote }}
+        - name: S3_PATH_PREFIX
+          value: {{ .Values.reports.s3.pathPrefix | quote }}
+        - name: S3_INSECURE
+          value: {{ .Values.reports.s3.insecure | quote }}
+        - name: S3_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "apitestrig.s3SecretName" . }}
+              key: {{ .Values.reports.s3.existingSecretAccessKeyKey }}
+        - name: S3_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "apitestrig.s3SecretName" . }}
+              key: {{ .Values.reports.s3.existingSecretSecretKeyKey }}
+      volumeMounts:
+        - name: reports
+          mountPath: {{ .Values.reports.mountPath }}
+          readOnly: true
+    {{- end }}
+    {{- if .Values.apitestrig.conformanceSuite.enabled }}
+    {{/*
+    Regular containers, not initContainers -- no K8s version requirement,
+    but nothing here enforces startup ordering the way native sidecars
+    would. Each of these apps is expected to retry its own dependency
+    connections on startup (Spring Boot retries Mongo; the harness's own
+    SUITE_WAIT_SECONDS already retries reaching the suite through httpd) --
+    the same "loose" ordering api-test/docker-compose.yml itself relies on
+    via depends_on without healthcheck conditions.
+
+    Listed after apitestrig/report-uploader (rather than before) so that
+    tools showing only a pod's "primary" image -- e.g. Rancher's CronJob
+    list view -- summarize it as apitestrig, not whichever of these
+    happens to be first; this has no effect on how Kubernetes runs them.
+    */}}
+    - name: conformance-mongodb
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.apitestrig.conformanceSuite.mongodb.image "global" .Values.global) }}
+      imagePullPolicy: {{ .Values.apitestrig.conformanceSuite.mongodb.image.pullPolicy }}
+      resources: {{- toYaml .Values.apitestrig.conformanceSuite.mongodb.resources | nindent 8 }}
+
+    - name: conformance-server
+      image: {{ include "common.images.image" (dict "imageRoot" (merge (dict "tag" .Values.apitestrig.conformanceSuite.imageTag) .Values.apitestrig.conformanceSuite.server.image) "global" .Values.global) }}
+      imagePullPolicy: {{ .Values.apitestrig.conformanceSuite.server.image.pullPolicy }}
+      env:
+        - name: BASE_URL
+          value: "https://localhost.emobix.co.uk:8443"
+        - name: MONGODB_HOST
+          value: "127.0.0.1"
+        - name: SPRING_PROFILES_ACTIVE
+          value: {{ .Values.apitestrig.conformanceSuite.server.springProfile | quote }}
+        - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GITLAB_CLIENTID
+          value: "unused"
+        - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GITLAB_CLIENTSECRET
+          value: "unused"
+        - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENTID
+          value: "unused"
+        - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENTSECRET
+          value: "unused"
+      resources: {{- toYaml .Values.apitestrig.conformanceSuite.server.resources | nindent 8 }}
+
+    - name: conformance-httpd
+      image: {{ include "common.images.image" (dict "imageRoot" (merge (dict "tag" .Values.apitestrig.conformanceSuite.imageTag) .Values.apitestrig.conformanceSuite.httpd.image) "global" .Values.global) }}
+      imagePullPolicy: {{ .Values.apitestrig.conformanceSuite.httpd.image.pullPolicy }}
+      resources: {{- toYaml .Values.apitestrig.conformanceSuite.httpd.resources | nindent 8 }}
+
+    {{/*
+    Waits for the same completion marker report-uploader watches for, then
+    kills the suite's processes by name (needs shareProcessNamespace: true,
+    set above, to see PIDs across containers) so mongodb/server/httpd exit
+    and the Job can complete -- they never exit on their own otherwise.
+    */}}
+    - name: conformance-reaper
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.apitestrig.conformanceSuite.reaper.image "global" .Values.global) }}
+      imagePullPolicy: {{ .Values.apitestrig.conformanceSuite.reaper.image.pullPolicy }}
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          until [ -f {{ printf "%s/.rig-complete" .Values.reports.mountPath | quote }} ]; do
+            sleep 5
+          done
+          # Give report-uploader a moment to finish reading the volume first.
+          sleep 5
+          # Reads /proc/<pid>/comm directly rather than parsing `ps` output --
+          # a kernel feature, not a ps feature, so it works regardless of
+          # which ps applet variant this busybox build shipped with.
+          for pid_dir in /proc/[0-9]*; do
+            pid=${pid_dir#/proc/}
+            comm=$(cat "$pid_dir/comm" 2>/dev/null) || continue
+            for name in {{ .Values.apitestrig.conformanceSuite.reaper.processNames | join " " }}; do
+              if [ "$comm" = "$name" ]; then
+                kill "$pid" 2>/dev/null
+              fi
+            done
+          done
+          exit 0
+      volumeMounts:
+        - name: reports
+          mountPath: {{ .Values.reports.mountPath }}
+          readOnly: true
+    {{- end }}
+  volumes:
+    - name: reports
+      {{- if .Values.reports.persistence.enabled }}
+      persistentVolumeClaim:
+        claimName: {{ include "apitestrig.reportsClaimName" . }}
+      {{- else }}
+      emptyDir: {}
+      {{- end }}
+    {{- if .Values.apitestrig.configLocal.enabled }}
+    - name: config-local
+      secret:
+        secretName: {{ include "apitestrig.configLocalSecretName" . }}
+        defaultMode: 256
+        items:
+          - key: {{ .Values.apitestrig.configLocal.existingSecretKey }}
+            path: config.local.json
+    {{- end }}
+    {{- if .Values.apitestrig.configOverride }}
+    - name: custom-config
+      configMap:
+        name: {{ include "common.names.fullname" . }}-config
+    {{- end }}
+    {{- if .Values.apitestrig.conformancePlanConfig.enabled }}
+    - name: conformance-plan-config
+      secret:
+        secretName: {{ include "apitestrig.conformancePlanConfigSecretName" . }}
+        defaultMode: 0400
+    {{- end }}
+{{- end -}}

--- a/helm/esignet-apitestrig/templates/configmap-config.yaml
+++ b/helm/esignet-apitestrig/templates/configmap-config.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.apitestrig.configOverride }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  config.json: |
+    {{- .Values.apitestrig.configOverride | nindent 4 }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/cronjob.yaml
+++ b/helm/esignet-apitestrig/templates/cronjob.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.triggerKind "cronjob" }}
+apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
+kind: CronJob
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.crontime | quote }}
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+      template:
+        {{- include "apitestrig.podTemplate" . | nindent 8 }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/extra-list.yaml
+++ b/helm/esignet-apitestrig/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/job.yaml
+++ b/helm/esignet-apitestrig/templates/job.yaml
@@ -1,0 +1,21 @@
+{{- if eq .Values.triggerKind "job" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  ## Suffixed with the revision so `helm upgrade`/CI re-runs don't collide
+  ## with the previous run's immutable Job name.
+  name: {{ include "common.names.fullname" . }}-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+  template:
+    {{- include "apitestrig.podTemplate" . | nindent 4 }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/pvc.yaml
+++ b/helm/esignet-apitestrig/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.reports.persistence.enabled (not .Values.reports.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "apitestrig.reportsClaimName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.reports.persistence.storageClass }}
+  {{- if eq "-" .Values.reports.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.reports.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+  accessModes:
+    {{- range .Values.reports.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.reports.persistence.size | quote }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/secret-config-local.yaml
+++ b/helm/esignet-apitestrig/templates/secret-config-local.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.apitestrig.configLocal.enabled (not .Values.apitestrig.configLocal.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "apitestrig.configLocalSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{ .Values.apitestrig.configLocal.existingSecretKey }}: {{ .Values.apitestrig.configLocal.data | default "{}" | quote }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/secret-conformance-plan.yaml
+++ b/helm/esignet-apitestrig/templates/secret-conformance-plan.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.apitestrig.conformancePlanConfig.enabled (not .Values.apitestrig.conformancePlanConfig.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "apitestrig.conformancePlanConfigSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- range $filename, $content := .Values.apitestrig.conformancePlanConfig.files }}
+  {{ $filename }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/secret-env.yaml
+++ b/helm/esignet-apitestrig/templates/secret-env.yaml
@@ -1,0 +1,25 @@
+{{- $hasValue := false }}
+{{- range $key, $value := .Values.apitestrig.extraEnvVarsSecret }}
+{{- if $value }}{{ $hasValue = true }}{{- end }}
+{{- end }}
+{{- if $hasValue }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "apitestrig.envSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.apitestrig.extraEnvVarsSecret }}
+  {{- if $value }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/secret-s3.yaml
+++ b/helm/esignet-apitestrig/templates/secret-s3.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.reports.s3.enabled (not .Values.reports.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "apitestrig.s3SecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{ .Values.reports.s3.existingSecretAccessKeyKey }}: {{ required "reports.s3.accessKey is required when reports.s3.enabled and no existingSecret is set" .Values.reports.s3.accessKey | quote }}
+  {{ .Values.reports.s3.existingSecretSecretKeyKey }}: {{ required "reports.s3.secretKey is required when reports.s3.enabled and no existingSecret is set" .Values.reports.s3.secretKey | quote }}
+{{- end }}

--- a/helm/esignet-apitestrig/templates/service-account.yaml
+++ b/helm/esignet-apitestrig/templates/service-account.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "apitestrig.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/helm/esignet-apitestrig/values.yaml
+++ b/helm/esignet-apitestrig/values.yaml
@@ -1,0 +1,387 @@
+## Global Docker image parameters
+## Please note this will override the image parameters, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+## Add labels to all the deployed resources
+##
+commonLabels:
+  app.kubernetes.io/component: mosip
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
+image:
+  registry: docker.io
+  repository: mosipdev/apitest-esignet
+  tag: develop-go
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  pullPolicy: Always
+  ## Optionally specify an array of imagePullSecrets.
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## ---------------------------------------------------------------------------
+## How the rig is triggered
+## ---------------------------------------------------------------------------
+
+## cronjob: scheduled, recurring runs (the usual "nightly regression" model)
+## job:     a single on-demand run, e.g. triggered by `helm install`/`helm
+##          upgrade` from CI, or `kubectl create job --from=cronjob/...`
+##
+triggerKind: cronjob   # cronjob | job
+
+## Only used when triggerKind: cronjob
+##
+crontime: "0 3 * * *"    ## run every day at 3 AM
+
+concurrencyPolicy: Forbid
+successfulJobsHistoryLimit: 1
+failedJobsHistoryLimit: 1
+backoffLimit: 0
+## How long a run is allowed to take before Kubernetes kills the Job/pod.
+## The harness itself has no internal timeout, so this is the real ceiling.
+##
+activeDeadlineSeconds: 3600
+
+## ---------------------------------------------------------------------------
+## Test-rig configuration
+## ---------------------------------------------------------------------------
+apitestrig:
+  ## Path INSIDE THE IMAGE to the plugin config to run. run-all.sh's Dockerfile
+  ## already bakes in data/config/config.{mock,mosip,sunbird}.json, so picking
+  ## one of those needs no ConfigMap at all -- just point -c at it.
+  ##   /app/data/config/config.mock.json
+  ##   /app/data/config/config.mosip.json
+  ##   /app/data/config/config.sunbird.json
+  ##
+  configFile: /app/data/config/config.mosip.json
+
+  ## Set this to run a config that is NOT baked into the image (e.g. a
+  ## deployment-specific variant). When non-empty, it is rendered into a
+  ## ConfigMap, mounted at /app/custom-config/config.json, and configFile
+  ## above is ignored in favor of that mounted path.
+  ##
+  configOverride: ""
+  # configOverride: |
+  #   {
+  #     "plugin": "mosip",
+  #     "run": { "surfaces": ["api", "e2e"], "report_dir": "/app/out" },
+  #     ...
+  #   }
+
+  ## Narrow which surfaces run, overriding the config file's run.surfaces for
+  ## this deployment. Leave empty to use whatever the selected config already
+  ## specifies. Comma list, e.g. "api,e2e" or "conformance,api,e2e".
+  ##
+  surfaces: ""
+
+  ## config.local.json overlay -- credentials that must NOT sit in values.yaml
+  ## or a ConfigMap. Mounted at runtime and pointed to via CONFIG_LOCAL so it
+  ## is found regardless of where configFile/configOverride lives.
+  ##
+  configLocal:
+    enabled: true
+    ## Preferred: reference a Secret you manage out-of-band (sealed-secrets,
+    ## external-secrets, vault-injector, ...) containing a config.local.json key.
+    existingSecret: ""
+    existingSecretKey: config.local.json
+    ## Convenience/dev fallback: inline JSON, rendered into a Helm-managed
+    ## Secret. Still ends up readable via `helm get values`, so prefer
+    ## existingSecret for anything beyond local testing.
+    # data: |
+    #   { "keycloak": { "client_secret": "changeme" } }
+    data: ""
+
+  ## Private plan config for the `conformance` surface (OpenID Conformance
+  ## Suite plan files, containing a private JWKS -- treat as a long-lived
+  ## credential). The harness looks for these at the exact relative path
+  ## named in the selected config's plans[].config_file, always under
+  ## conformance-suite-private/ -- mounting here needs no other config
+  ## change. See https://github.com/mosip/esignet/issues/2434 §5a and
+  ## api-test/docs/conformance-suite.md.
+  ##
+  conformancePlanConfig:
+    enabled: false
+    ## Preferred: reference a Secret you manage out-of-band, containing one
+    ## key per plan file (e.g. esignet-config.json, esignet-fapi2-config.json)
+    ## -- key names must match plans[].config_file's basename exactly.
+    existingSecret: ""
+    ## Convenience/dev fallback: inline file contents, rendered into a
+    ## Helm-managed Secret when existingSecret is empty. Still ends up
+    ## readable via `helm get values`, so prefer existingSecret for anything
+    ## beyond local testing.
+    files: {}
+      # esignet-config.json: |
+      #   { ... }
+      # esignet-fapi2-config.json: |
+      #   { ... }
+
+  ## Runs the OpenID Conformance Suite (mongodb + server + nginx) as regular
+  ## containers in THIS pod, so CONFORMANCE_BASE_URL can point at
+  ## https://localhost.emobix.co.uk:8443 (which already resolves to 127.0.0.1
+  ## via public DNS) and just work -- no separate Deployment/Service needed.
+  ## Pod containers share a network namespace regardless of container type,
+  ## so this DNS fix needs nothing beyond that -- no K8s version requirement.
+  ##
+  ## Images/env are taken directly from api-test/docker-compose.yml's own
+  ## working local-dev recipe (server + httpd tags travel together).
+  ##
+  ## The one real wrinkle: mongodb/server/httpd are long-running processes
+  ## that never exit on their own, and a Job only completes once EVERY
+  ## container in the pod exits -- so left alone, they'd block every run
+  ## from ever completing. Fixed with shareProcessNamespace: true plus a
+  ## small "conformance-reaper" container that waits for the same
+  ## completion marker report-uploader already watches for
+  ## (reports.mountPath/.rig-complete), then kills the suite's processes by
+  ## name so their containers exit and the Job can finish. This is a
+  ## well-established pattern from before native sidecars existed, and
+  ## works on any Kubernetes version.
+  ##
+  ## shareProcessNamespace does mean every container in this pod can see and
+  ## signal every other container's processes -- acceptable here since this
+  ## pod is a single-purpose, ephemeral test rig running only images this
+  ## chart already controls, but worth knowing if you're auditing it.
+  ##
+  ## Three details below are ASSUMED, not yet verified against a real
+  ## cluster: the server's internal port (guessed 8080, Spring Boot
+  ## default), whether the httpd image's baked-in nginx.conf proxies to
+  ## hostnames "server"/"mongodb" (Compose's automatic per-service DNS --
+  ## hostAliases in the pod spec maps both to 127.0.0.1 to cover this, but
+  ## it's inferred from Compose convention, not confirmed against the image
+  ## itself), and the suite's/mongo's actual process names as reported by
+  ## `ps` (guessed "java", "mongod", "nginx" -- standard for these images,
+  ## but not confirmed). Test before relying on this in a real run.
+  ##
+  conformanceSuite:
+    enabled: false
+
+    ## Shared between server and httpd images below (they're versioned
+    ## together upstream, same as api-test's own SUITE_IMAGE_TAG).
+    imageTag: release-v5.1.42
+
+    mongodb:
+      image:
+        registry: docker.io
+        repository: mongo
+        tag: "6.0.13"
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+    server:
+      image:
+        registry: registry.gitlab.com
+        repository: openid/conformance-suite
+        pullPolicy: IfNotPresent
+        # tag: conformanceSuite.imageTag (above)
+      springProfile: dev
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi
+
+    httpd:
+      image:
+        registry: registry.gitlab.com
+        repository: openid/conformance-suite/nginx
+        pullPolicy: IfNotPresent
+        # tag: conformanceSuite.imageTag (above)
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
+
+    ## The small watcher-and-killer container. busybox because it reliably
+    ## ships `ps` and `kill` applets without needing anything installed.
+    reaper:
+      image:
+        registry: docker.io
+        repository: busybox
+        tag: "1.36"
+        pullPolicy: IfNotPresent
+      ## Process names to kill (matched against `ps -A -o comm`) once the
+      ## completion marker appears. Adjust here if these images report
+      ## different process names in practice.
+      processNames:
+        - mongod
+        - java
+        - nginx
+
+  ## Plain (non-secret) environment variables layered on top of both config
+  ## files, mirroring api-test/.env.example. Rendered as literal env values.
+  ##
+  extraEnvVars:
+    MOSIP_ESIGNET_BASE_URL: ""
+    KEYCLOAK_TOKEN_URL: ""
+    INDIVIDUAL_ID: ""
+    ID_TYPE: ""
+    TEST_PROFILE: ""
+    ## Point at the OpenID Conformance Suite already running in-cluster, e.g.
+    ## http://openid-conformance-suite.<namespace>.svc.cluster.local:8443
+    CONFORMANCE_BASE_URL: ""
+    CONFORMANCE_TLS_VERIFY: "false"
+    ESIGNET_TLS_VERIFY: "true"
+    API_TLS_VERIFY: "true"
+    SUITE_WAIT_SECONDS: "150"
+
+  ## Secret environment variables (e.g. KEYCLOAK_CLIENT_SECRET). Rendered into
+  ## a Secret and wired up via secretKeyRef -- never landing in a ConfigMap or
+  ## in extraEnvVars above.
+  ##
+  extraEnvVarsSecret:
+    KEYCLOAK_CLIENT_SECRET: ""
+
+  ## Existing ConfigMaps/Secrets in the namespace to pull additional env from
+  ## (envFrom), for parity with cluster-wide config the way helm/esignet does
+  ## (e.g. a shared `esignet-global` configmap).
+  ##
+  extraEnvVarsCM: []
+  extraEnvVarsSecretRefs: []
+
+## Command/args for the container. The image's own ENTRYPOINT is
+## ["./run-all.sh"], so leave `command` empty to keep using it -- args below
+## are appended to it. Templates fill in -c/-s from apitestrig.* above; only
+## override this block if you need something entirely different.
+##
+command: []
+args: []
+
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  limits:
+    cpu: "1"
+    memory: 2Gi
+  requests:
+    cpu: 200m
+    memory: 512Mi
+
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## Enabled by default: api-test/Dockerfile confirms this image's own USER is
+## apitest:apitest (uid/gid 1001), so this is a known-safe, verified value
+## for the apitestrig container specifically. NOT extended by default to the
+## report-uploader/conformance-suite containers below (minio/mc, mongo, the
+## conformance-suite server/nginx, busybox) since their expected non-root
+## uids aren't verified here -- e.g. the official mongo image's entrypoint
+## has its own uid expectations, and forcing 1001 onto it blind risks
+## breaking it. Set per-container securityContext values yourself for those
+## once you've confirmed the right uid for each image.
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## Enabled by default: the image runs as uid/gid 1001 (see Dockerfile), and
+## PVC/emptyDir volumes are created owned by root unless fsGroup is set --
+## without this, the harness's own write to the reports volume at
+## reports.mountPath fails with a permission error. See
+## https://github.com/mosip/esignet/issues/2434 §7.
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+
+istio:
+  sidecarInject: false
+
+## Deployment pod host aliases
+##
+hostAliases: []
+
+## Node affinity/anti-affinity/selector/tolerations, evaluated as templates.
+##
+podAffinityPreset: ""
+podAntiAffinityPreset: soft
+nodeAffinityPreset:
+  type: ""
+  key: ""
+  values: []
+affinity: {}
+nodeSelector: {}
+tolerations: []
+
+## Pod extra labels/annotations
+##
+podLabels: {}
+podAnnotations: {}
+
+## Specifies whether a ServiceAccount should be created
+##
+serviceAccount:
+  create: true
+  name: ""
+
+## ---------------------------------------------------------------------------
+## Reports
+## ---------------------------------------------------------------------------
+reports:
+  ## REPORT_DIR inside the container. run-all.sh writes the consolidated HTML
+  ## report and every surface's envelope here.
+  mountPath: /app/out
+  persistence:
+    ## When false, the reports volume is an emptyDir instead of a PVC --
+    ## useful when reports.s3.enabled is the only place you want them kept.
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 100Mi
+    existingClaim: ""
+
+  ## Push the consolidated report to S3-compatible storage (AWS S3, MinIO,
+  ## etc.) after each run. Works alongside or instead of the PVC above.
+  ## Implemented as a second container in the same pod: it waits for the
+  ## main container to finish (a completion marker file on the shared
+  ## reports volume, since run-all.sh itself has no S3 awareness), then
+  ## uploads via `mc cp`. Works against MinIO or real AWS S3.
+  s3:
+    enabled: false
+    image:
+      registry: docker.io
+      repository: minio/mc
+      tag: RELEASE.2025-05-21T01-59-54Z
+      pullPolicy: IfNotPresent
+    ## e.g. https://s3.amazonaws.com or http://minio.minio:9000
+    endpoint: ""
+    ## Set true for a self-signed cert or a plain-http endpoint.
+    insecure: false
+    bucket: ""
+    ## Each run lands under <pathPrefix>/<UTC timestamp>/ in the bucket.
+    pathPrefix: "apitestrig"
+    ## Preferred: reference a Secret you manage out-of-band containing
+    ## these two keys.
+    existingSecret: ""
+    existingSecretAccessKeyKey: accessKey
+    existingSecretSecretKeyKey: secretKey
+    ## Convenience/dev fallback: rendered into a Helm-managed Secret. Still
+    ## ends up readable via `helm get values`, so prefer existingSecret for
+    ## anything beyond local testing.
+    accessKey: ""
+    secretKey: ""


### PR DESCRIPTION
Replaces the old Java-testrig deploy/esignet-apitestrig scripts (which installed the published mosip/apitestrig chart, unrelated to this branch's Go rewrite) with a purpose-built setup for the Go api-test harness:

helm/esignet-apitestrig/ (new chart; named esignet-apitestrig rather than apitestrig to avoid colliding with mosip-functional-tests' own published apitestrig chart, which is structurally incompatible -- Java, one image per module, vs this harness's single Go binary):
  - CronJob or Job trigger, config-file selection (config.mock/mosip/sunbird.json), configurable surfaces (api,e2e | conformance,api,e2e)
  - Report storage: PVC and/or S3-compatible push via a report-uploader sidecar (bucket auto-created if missing, IST timestamped run folders)
  - Conformance support: private plan config Secret (existingSecret or Helm-rendered from inline values), and an optional in-pod OpenID Conformance Suite (mongodb + server + nginx as regular containers, shareProcessNamespace + a reaper container so the Job can still complete -- no Kubernetes version requirement)
  - podSecurityContext (fsGroup 1001) enabled by default for the image's non-root user

deploy/esignet-apitestrig/ (rewritten):
  - install.sh: two prompts (eSignet base URL, values.yaml confirmation) -- everything else lives in values.yaml (tracked, generalized with UPDATE markers for anything environment-specific) and values.secret.yaml (gitignored; values.secret.yaml.example is the tracked template)
  - Installs by chart name/version from the published mosip-helm repo (helm repo add/update + helm upgrade --install mosip/esignet-apitestrig --version $CHART_VERSION), matching ../esignet/install.sh's own pattern -- requires this chart to be merged and published there first
  - Fixes several issues found via live testing against real MOSIP environments: a bash 3.2 (macOS) incompatibility, a Helm --set comma-escaping issue, a missing /auth prefix in the default Keycloak token URL, and several required-but-missing env vars identified against mosip/esignet#2434 (OTP_WS_URL, PMS_BASE_URL, AUTH_PARTNER_ID, AUTH_POLICY_ID, KEYCLOAK_CLIENT_ID)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm-based deployment for the eSignet API test harness.
  * Supports scheduled CronJob runs and one-time test Jobs.
  * Added configurable test surfaces, conformance plans, credentials, and runtime settings.
  * Added persistent report storage with optional S3-compatible uploads.
  * Added optional OpenID Conformance Suite execution and report collection.
  * Added centralized configuration through values files and simplified installation and cleanup scripts.

* **Documentation**
  * Added guidance for installation, configuration, execution, report handling, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->