### PR TITLE
[issue:2581] add captcha provider and validator URL props to eSignet

### DIFF
--- a/deploy/esignet/install.sh
+++ b/deploy/esignet/install.sh
@@ -373,6 +373,8 @@ function installing_esignet() {
     extra_env_vars_additional+="      secretKeyRef:"$'\n'
     extra_env_vars_additional+="        name: esignet-captcha"$'\n'
     extra_env_vars_additional+="        key: esignet-captcha-site-key"$'\n'
+    extra_env_vars_additional+="  \"MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER\": \"google-recaptcha\""$'\n'
+    extra_env_vars_additional+="  \"MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL\": \"http://captcha.captcha/v1/captcha/validatecaptcha\""$'\n'
   else
     extra_env_vars_additional+="  \"MOSIP_ESIGNET_CAPTCHA_SITE_KEY\": \"\""$'\n'
   fi

--- a/deploy/esignet/values.yaml
+++ b/deploy/esignet/values.yaml
@@ -15,6 +15,10 @@
 #      secretKeyRef:
 #        name: esignet-captcha
 #        key: esignet-captcha-site-key
+#  - name: MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER
+#    value: google-recaptcha
+#  - name: MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL
+#    value: http://captcha.captcha/v1/captcha/validatecaptcha
 #  - name: MOSIP_ESIGNET_CAPTCHA_MODULE_NAME
 #    value: esignet
 #  - name: IDA_AUTHENTICATOR_ENV


### PR DESCRIPTION
Fixes #2581

### Problem

eSignet 2.0.x reads the captcha widget provider from `MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER` (`esignet-service/data/flows/flow-esignet.yaml`) and validates captcha tokens against `MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL` (`esignet-service/internal/config/app.go`).

`deploy/esignet/install.sh` only passed `MOSIP_ESIGNET_CAPTCHA_SITE_KEY`. The flow file is expanded with `os.ExpandEnv`, so the provider came through as an empty string. With no validator URL, the service accepts captcha tokens unverified (see `esignet-service/.env.example`). Both props had to be added to the deployment by hand, and the issue thread confirms that adding them makes captcha work.

### Changes

**`deploy/esignet/install.sh`**
- when the `esignet-captcha` secret exists, also pass:
  - `MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER=google-recaptcha` (`deploy/captcha/install.sh` collects reCAPTCHA v2 keys)
  - `MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL=http://captcha.captcha/v1/captcha/validatecaptcha` (the `captcha` release in the `captcha` namespace)
- installs without the secret are unchanged, so validation is never pointed at a captcha service that isn't deployed

**`deploy/esignet/values.yaml`**
- list the two props in the commented examples

### Verification

- `bash -n install.sh` passes
- running the captcha block of `install.sh` verbatim, with `kubectl` stubbed, produces a values file that parses as YAML both with and without the `esignet-captcha` secret
- `helm template` of the published `mosip/esignet` `2.0.0-develop` chart (the version `install.sh` pins):
  - without the secret, the env is unchanged: only `MOSIP_ESIGNET_CAPTCHA_SITE_KEY` with `value: ""`
  - with the secret, each variable renders exactly once, with no collision against chart defaults:

```
- name: MOSIP_ESIGNET_CAPTCHA_SITE_KEY
  valueFrom:
    secretKeyRef:
      key: esignet-captcha-site-key
      name: esignet-captcha
- name: MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER
  value: "google-recaptcha"
- name: MOSIP_ESIGNET_CAPTCHA_VALIDATOR_URL
  value: "http://captcha.captcha/v1/captcha/validatecaptcha"
```

### Note

The same change is raised against both branches that carry the eSignet 2.0.x deployment scripts:
- `release-2.0.x`
- `develop-go`

`develop` is not included. It holds the Java eSignet, whose `install.sh` sets no captcha env and which does not read `MOSIP_ESIGNET_CAPTCHA_SITE_PROVIDER`.

`AUTHORIZE_ENDPOINT` from the original issue body is left out. As noted in the issue thread, eSignet serves `/oauth2/authorize` itself, and the prop belongs to `mock-relying-party-ui`.
