### PR TITLE
api-test: select the PMS OIDC-client registration endpoint by config

### DIFF
--- a/api-test/cmd/cfg/main.go
+++ b/api-test/cmd/cfg/main.go
@@ -100,6 +100,7 @@ func exports(c *config.Config) string {
 	kv("PMS_BASE_URL", c.Esignet.PMS.BaseURL)
 	kv("AUTH_PARTNER_ID", c.Esignet.PMS.AuthPartnerID)
 	kv("AUTH_POLICY_ID", c.Esignet.PMS.PolicyID)
+	kv("PMS_CLIENT_API", c.Esignet.PMS.ClientAPI)
 
 	kv("KEYCLOAK_TOKEN_URL", c.Keycloak.TokenURL)
 	kv("KEYCLOAK_CLIENT_ID", c.Keycloak.ClientID)

--- a/api-test/cmd/e2e/main.go
+++ b/api-test/cmd/e2e/main.go
@@ -134,6 +134,7 @@ func main() {
 		PMSBaseURL:         es.PMS.BaseURL,
 		AuthPartnerID:      es.PMS.AuthPartnerID,
 		PolicyID:           es.PMS.PolicyID,
+		PMSClientAPI:       es.PMS.ClientAPI,
 	}
 
 	rows := runner.Run(ctx, spec)

--- a/api-test/data/config/config.example.json
+++ b/api-test/data/config/config.example.json
@@ -141,7 +141,7 @@
     "credentials": { "username": "", "password": "", "biometric": "" },
     "knowledge": { "full_name": "", "dob": "" },
     "otp": { "source": "static", "value": "111111", "ws_url": "", "recipient_email": "" },
-    "pms": { "base_url": "", "auth_partner_id": "", "policy_id": "" }
+    "pms": { "base_url": "", "auth_partner_id": "", "policy_id": "", "client_api": "oidc-clients" }
   },
 
   "api": {

--- a/api-test/data/config/config.mosip.json
+++ b/api-test/data/config/config.mosip.json
@@ -64,7 +64,7 @@
     "identity": { "individual_id": "", "id_type": "uin" },
     "credentials": { "username": "", "password": "", "biometric": "" },
     "otp": { "source": "dynamic", "ws_url": "", "recipient_email": "" },
-    "pms": { "base_url": "", "auth_partner_id": "", "policy_id": "" }
+    "pms": { "base_url": "", "auth_partner_id": "", "policy_id": "", "client_api": "oidc-clients" }
   },
 
   "api": {

--- a/api-test/docs/configuration.md
+++ b/api-test/docs/configuration.md
@@ -152,7 +152,7 @@ override**, so a container needing to change those must mount the config file it
 | `KBI_FULL_NAME` / `KBI_DOB` | `esignet.knowledge.*` | | `API_TLS_VERIFY` | `api.tls_verify` |
 | `OTP_SOURCE` / `TEST_OTP` | `esignet.otp.*` | | `E2E_SPEC` | `e2e.spec` |
 | `OTP_WS_URL` / `OTP_RECIPIENT_EMAIL` | `esignet.otp.*` | | `E2E_AUTH_FACTORS` | `e2e.auth_factors` |
-| `PMS_BASE_URL` / `AUTH_PARTNER_ID` / `AUTH_POLICY_ID` | `esignet.pms.*` | | `E2E_INCLUDE` / `E2E_EXCLUDE` | `e2e.*` |
+| `PMS_BASE_URL` / `AUTH_PARTNER_ID` / `AUTH_POLICY_ID` / `PMS_CLIENT_API` | `esignet.pms.*` | | `E2E_INCLUDE` / `E2E_EXCLUDE` | `e2e.*` |
 
 > **`MOSIP_ESIGNET_BASE_URL` and `MOSIP_ESIGNET_AUTHN_PROVIDER` are deliberately the same names
 > eSignet itself reads** (`server.public_url` and the provider selector — see

--- a/api-test/docs/mosip-id.md
+++ b/api-test/docs/mosip-id.md
@@ -62,8 +62,26 @@ so no additional credentials are needed.
 
 Or as environment variables: `PMS_BASE_URL`, `AUTH_PARTNER_ID`, `AUTH_POLICY_ID`.
 
-> Note the asymmetry: the config field is `policy_id`, but its environment override is
-> `AUTH_POLICY_ID`.
+### Which PMS registration endpoint is used
+
+PMS deployments differ in where OIDC clients are registered. Builds from **1.2.2.x serve only
+`{base}/oauth/client`** and answer **404** for `{base}/oidc-clients`; current builds serve both.
+`client_api` selects which one the harness posts to — `oidc-clients` (the default) or
+`oauth-client`.
+
+**Both endpoints take the identical request body**, so the setting changes the path and nothing
+else. That was verified live against both a 1.2.2.3 and a current PMS: `/oidc-clients` validates the
+wrapper `id` and rejects a wrong one with `PMS_REQUEST_ERROR_002`, while `/oauth/client` registers
+the client regardless — it ignores the `id`/`version`/`metadata` members entirely.
+
+Leave it at the default on any deployment that serves `/oidc-clients`. A client registered there is
+the one IDA is known to authenticate, whereas `/oauth/client` registrations have been seen refused
+at login — which only a full login reveals, so no create-and-read-back test catches it. Set
+`oauth-client` when the deployment is old enough not to serve `/oidc-clients` at all; registration
+then fails with an HTTP 404 that names this setting.
+
+> Note this is **not** auto-detected. A deployment whose PMS is upgraded or replaced needs this
+> setting revisited, or e2e registration fails with that 404.
 
 Leave `pms.base_url` unset and the PMS-backed scenarios report as not-run rather than failing, so a
 partial setup is visible in the report instead of looking like a test failure.
@@ -119,6 +137,7 @@ change when extraction stops finding a code. It is off by default and never set 
 | `esignet.pms.base_url` | `PMS_BASE_URL` | partner-management-service base URL |
 | `esignet.pms.auth_partner_id` | `AUTH_PARTNER_ID` | Onboarded partner id |
 | `esignet.pms.policy_id` | `AUTH_POLICY_ID` | Published policy id |
+| `esignet.pms.client_api` | `PMS_CLIENT_API` | `oidc-clients` (default) \| `oauth-client` — which registration endpoint PMS serves |
 | `esignet.otp.source` | `OTP_SOURCE` | `static` or `dynamic` |
 | `esignet.otp.value` | `TEST_OTP` | The OTP, when `source: static` |
 | `esignet.otp.ws_url` | `OTP_WS_URL` | Mock SMTP WebSocket URL, when `source: dynamic` |

--- a/api-test/internal/config/config.go
+++ b/api-test/internal/config/config.go
@@ -130,9 +130,13 @@ type Esignet struct {
 
 // PMS holds partner-management-service settings used only by the mosip(id) plugin.
 type PMS struct {
-	BaseURL       string `json:"base_url"`        // PMS base, e.g. https://host/v1/partnermanagement; {base}/oauth/client is the create endpoint
+	BaseURL       string `json:"base_url"`        // PMS base, e.g. https://host/v1/partnermanager
 	AuthPartnerID string `json:"auth_partner_id"` // onboarded Auth partner id -> becomes the client's relying-party id
 	PolicyID      string `json:"policy_id"`       // published auth policy id -> governs allowed claims/ACRs
+	// ClientAPI selects the registration endpoint under BaseURL: oidc-clients (default) or oauth-client.
+	// Both take the same request body; they differ only in which PMS build serves them. PMS 1.2.2.x has
+	// only {base}/oauth/client and answers 404 for {base}/oidc-clients, which current builds do serve.
+	ClientAPI string `json:"client_api"`
 }
 
 type Identity struct {
@@ -481,6 +485,7 @@ func (c *Config) applyEnv() (int, error) {
 	envStr(&c.Esignet.PMS.BaseURL, "PMS_BASE_URL", &n)
 	envStr(&c.Esignet.PMS.AuthPartnerID, "AUTH_PARTNER_ID", &n)
 	envStr(&c.Esignet.PMS.PolicyID, "AUTH_POLICY_ID", &n)
+	envStr(&c.Esignet.PMS.ClientAPI, "PMS_CLIENT_API", &n)
 
 	envStr(&c.Keycloak.TokenURL, "KEYCLOAK_TOKEN_URL", &n)
 	envStr(&c.Keycloak.ClientID, "KEYCLOAK_CLIENT_ID", &n)
@@ -596,6 +601,7 @@ func (c *Config) defaults() {
 	// Normalize the enum-valued fields once, so every downstream comparison agrees about casing.
 	c.Esignet.Provider = strings.ToLower(strings.TrimSpace(c.Esignet.Provider))
 	c.Esignet.OTP.Source = strings.ToLower(strings.TrimSpace(c.Esignet.OTP.Source))
+	c.Esignet.PMS.ClientAPI = strings.ToLower(strings.TrimSpace(c.Esignet.PMS.ClientAPI))
 	c.Run.Profile = strings.ToLower(strings.TrimSpace(c.Run.Profile))
 	if len(c.Run.Surfaces) == 0 {
 		c.Run.Surfaces = []string{SurfaceConformance, SurfaceAPI, SurfaceE2E}
@@ -640,6 +646,9 @@ func (c *Config) defaults() {
 	}
 	if c.Esignet.OTP.Value == "" {
 		c.Esignet.OTP.Value = "111111"
+	}
+	if c.Esignet.PMS.ClientAPI == "" {
+		c.Esignet.PMS.ClientAPI = "oidc-clients"
 	}
 	// full, not smoke: a run that silently grades a curated subset and reports
 	// it as "conformance" overstates what was checked. Only oidcc-test-plan
@@ -696,6 +705,13 @@ func (c *Config) validate() error {
 		}
 	default:
 		return fmt.Errorf("unknown otp.source %q (want static|dynamic)", c.Esignet.OTP.Source)
+	}
+
+	switch c.Esignet.PMS.ClientAPI {
+	case "oidc-clients", "oauth-client":
+		// Both are real PMS endpoints; which one a deployment serves is what this selects.
+	default:
+		return fmt.Errorf("unknown pms.client_api %q (want oidc-clients|oauth-client)", c.Esignet.PMS.ClientAPI)
 	}
 
 	switch c.Run.Profile {

--- a/api-test/internal/e2e/e2e.go
+++ b/api-test/internal/e2e/e2e.go
@@ -249,6 +249,8 @@ type Runner struct {
 	PMSBaseURL    string
 	AuthPartnerID string
 	PolicyID      string
+	// PMSClientAPI selects which registration endpoint under PMSBaseURL to use; see pmsClientPath.
+	PMSClientAPI string
 
 	acr    []string // registered ACRs, set from the spec in Run
 	client *http.Client
@@ -695,7 +697,27 @@ func (r *Runner) createClientViaClientMgmt(ctx context.Context, calls *[]result.
 // errPMSForbidden marks the one registration failure that is an environment gap rather than a defect: PMS refused the bearer for lack of a role.
 var errPMSForbidden = errors.New("PMS create client forbidden (KER-ATH-403)")
 
-// createClientViaPMS registers the test client through partner-management-service /oidc-clients — NOT /oauth/client, which IDA then refuses to authenticate (visible only by driving a login); the bearer needs the AUTH_PARTNER realm role, which a client_credentials service account does not carry (KER-ATH-403).
+// pmsClientAPIPaths maps the esignet.pms.client_api values to PMS's two OIDC-client registration endpoints.
+//
+// Deployments differ in which they serve: PMS 1.2.2.x has only /oauth/client and answers 404 for /oidc-clients, while current builds serve both. The setting selects a path and nothing else — both endpoints take the identical request body. That was verified live against both a 1.2.2.3 and a current PMS: /oidc-clients validates the wrapper id and rejects a wrong one with PMS_REQUEST_ERROR_002, whereas /oauth/client registers the client regardless, so the id/version/metadata members are simply ignored there.
+//
+// /oidc-clients is the default, and is what a deployment that has it should keep using: a client registered there is the one IDA is known to authenticate, whereas /oauth/client registrations have been seen refused at login (visible only by driving a login, so no create-and-read-back test catches it).
+var pmsClientAPIPaths = map[string]string{
+	"oidc-clients": "/oidc-clients",
+	"oauth-client": "/oauth/client",
+}
+
+const pmsClientAPIDefault = "oidc-clients"
+
+// pmsClientPath is the registration endpoint this run is configured to use. An unset or unrecognised value takes the default; config validation has already rejected anything else by the time a run starts.
+func (r *Runner) pmsClientPath() string {
+	if p, ok := pmsClientAPIPaths[strings.ToLower(strings.TrimSpace(r.PMSClientAPI))]; ok {
+		return p
+	}
+	return pmsClientAPIPaths[pmsClientAPIDefault]
+}
+
+// createClientViaPMS registers the test client through partner-management-service — NOT eSignet client-mgmt, whose clients IDA then refuses to authenticate; the bearer needs the AUTH_PARTNER realm role, which a client_credentials service account does not carry (KER-ATH-403).
 func (r *Runner) createClientViaPMS(ctx context.Context, calls *[]result.HTTPCall, cl *testClient, spec Spec) (string, error) {
 	if r.PMSBaseURL == "" || r.AuthPartnerID == "" || r.PolicyID == "" {
 		return "", fmt.Errorf("mosip client registration needs PMS_BASE_URL, AUTH_PARTNER_ID and AUTH_POLICY_ID")
@@ -728,15 +750,21 @@ func (r *Runner) createClientViaPMS(ctx context.Context, calls *[]result.HTTPCal
 	if err != nil {
 		return "", fmt.Errorf("marshal PMS request: %w", err)
 	}
-	url := strings.TrimRight(r.PMSBaseURL, "/") + "/oidc-clients"
+	url := strings.TrimRight(r.PMSBaseURL, "/") + r.pmsClientPath()
 	// PMS reads the admin token from a cookie named Authorization and rejects the Bearer header with KER-ATH-401, unlike eSignet's own client-mgmt.
 	status, rb, err := r.do(ctx, calls, "create client (PMS)", http.MethodPost, url,
 		map[string]string{"Content-Type": "application/json", "Cookie": "Authorization=" + r.AdminToken}, string(body))
 	if err != nil {
 		return "", fmt.Errorf("create client via PMS: %w", err)
 	}
+	// A 404 is the signature of a PMS that does not serve this endpoint at all — 1.2.2.x has no /oidc-clients controller — so name the setting that switches it rather than reporting a bare Not Found.
+	if status == http.StatusNotFound {
+		return "", fmt.Errorf("PMS create client failed (HTTP 404): %s is not served by this PMS — "+
+			"set esignet.pms.client_api (PMS_CLIENT_API) to one of oidc-clients|oauth-client to match the deployment "+
+			"(1.2.2.x serves oauth-client only)", url)
+	}
 	if code := firstErrorCode(rb); code != "" {
-		// The one rejection worth naming: /oidc-clients alone is gated on the AUTH_PARTNER realm role.
+		// The one rejection worth naming: PMS registration is gated on the AUTH_PARTNER realm role.
 		if code == "KER-ATH-403" {
 			return "", fmt.Errorf("%w: %s needs the AUTH_PARTNER realm role, "+
 				"which the client_credentials grant for keycloak.client_id does not carry — grant it that role, "+

--- a/api-test/internal/e2e/pms_client_api_test.go
+++ b/api-test/internal/e2e/pms_client_api_test.go
@@ -1,0 +1,134 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mosip/esignet/api-test/internal/result"
+)
+
+// pmsPathStub records which registration endpoint a run actually posted to, and
+// what wrapper it sent. Registrations here are unhardened, so nothing reaches
+// eSignet client-mgmt and no /client-mgmt route is needed.
+type pmsPathStub struct {
+	hits    map[string]int
+	wrapper map[string]any // the last wrapper received, whichever path took it
+}
+
+func newPMSPathStub(t *testing.T, serve ...string) (*pmsPathStub, *Runner, func()) {
+	t.Helper()
+	st := &pmsPathStub{hits: map[string]int{}}
+	mux := http.NewServeMux()
+	// Only the named paths are registered, so anything else gets ServeMux's 404 —
+	// exactly what PMS 1.2.2.x answers for /oidc-clients.
+	for _, path := range serve {
+		mux.HandleFunc(path, func(w http.ResponseWriter, req *http.Request) {
+			st.hits[req.URL.Path]++
+			body, _ := io.ReadAll(req.Body)
+			var wrapper map[string]any
+			_ = json.Unmarshal(body, &wrapper)
+			st.wrapper = wrapper
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"response":{"clientId":"cid-1","status":"ACTIVE"}}`)
+		})
+	}
+	srv := httptest.NewServer(mux)
+	r := &Runner{Base: srv.URL, PMSBaseURL: srv.URL, AuthPartnerID: "p1", PolicyID: "pol1", AdminToken: "t"}
+	return st, r, srv.Close
+}
+
+func registerViaPMS(t *testing.T, r *Runner) (string, error) {
+	t.Helper()
+	priv, err := generateRSA()
+	if err != nil {
+		t.Fatalf("generateRSA: %v", err)
+	}
+	cl := &testClient{priv: priv, kid: "test-kid", cfg: ClientConfig{}} // unhardened: no additionalConfig patch follows
+	return r.createClientViaPMS(context.Background(), &[]result.HTTPCall{}, cl, Spec{RedirectURI: "https://example.org/callback"})
+}
+
+func TestPMSClientPath_DefaultsToOIDCClients(t *testing.T) {
+	for _, unset := range []string{"", "   ", "nonsense"} {
+		r := &Runner{PMSClientAPI: unset}
+		if got := r.pmsClientPath(); got != "/oidc-clients" {
+			t.Errorf("pmsClientPath(%q) = %q, want /oidc-clients — an unset or unrecognised value must not silently change the endpoint", unset, got)
+		}
+	}
+}
+
+func TestPMSClientPath_SelectsTheConfiguredEndpoint(t *testing.T) {
+	for api, want := range map[string]string{"oidc-clients": "/oidc-clients", "oauth-client": "/oauth/client"} {
+		if got := (&Runner{PMSClientAPI: api}).pmsClientPath(); got != want {
+			t.Errorf("pmsClientPath(%q) = %q, want %q", api, got, want)
+		}
+		// Config normalises casing before a run starts; the runner must not depend on that having happened.
+		if got := (&Runner{PMSClientAPI: "  " + api + "  "}).pmsClientPath(); got != want {
+			t.Errorf("pmsClientPath(padded %q) = %q, want %q", api, got, want)
+		}
+	}
+}
+
+// The default must keep hitting exactly the endpoint, and sending exactly the wrapper,
+// that deployments serving /oidc-clients already receive.
+func TestCreateClientViaPMS_DefaultPostsTheWrappedEnvelopeToOIDCClients(t *testing.T) {
+	st, r, closeSrv := newPMSPathStub(t, "/oidc-clients", "/oauth/client")
+	defer closeSrv()
+
+	if _, err := registerViaPMS(t, r); err != nil {
+		t.Fatalf("createClientViaPMS: %v", err)
+	}
+	if st.hits["/oidc-clients"] != 1 || st.hits["/oauth/client"] != 0 {
+		t.Fatalf("hits = %v, want one on /oidc-clients only", st.hits)
+	}
+	for k, want := range map[string]any{"id": "mosip.pms.create.oidc.client.post", "version": "1.0"} {
+		if st.wrapper[k] != want {
+			t.Errorf("wrapper[%q] = %v, want %v", k, st.wrapper[k], want)
+		}
+	}
+	if _, ok := st.wrapper["metadata"]; !ok {
+		t.Errorf("wrapper has no metadata: %v", st.wrapper)
+	}
+}
+
+// /oauth/client ignores id/version/metadata — verified live against both a 1.2.2.3 and a
+// current PMS — so the harness sends one body shape and only the path changes.
+func TestCreateClientViaPMS_OAuthClientGetsTheSameBodyAtTheLegacyPath(t *testing.T) {
+	st, r, closeSrv := newPMSPathStub(t, "/oauth/client") // no /oidc-clients route: PMS 1.2.2.x
+	defer closeSrv()
+	r.PMSClientAPI = "oauth-client"
+
+	id, err := registerViaPMS(t, r)
+	if err != nil {
+		t.Fatalf("createClientViaPMS: %v", err)
+	}
+	if id != "cid-1" {
+		t.Fatalf("clientID = %q, want cid-1", id)
+	}
+	if st.hits["/oauth/client"] != 1 {
+		t.Fatalf("hits = %v, want one on /oauth/client", st.hits)
+	}
+	if st.wrapper["id"] != "mosip.pms.create.oidc.client.post" || st.wrapper["requestTime"] == nil {
+		t.Errorf("legacy path got a different body shape than /oidc-clients: %v", st.wrapper)
+	}
+}
+
+// Without a probe, a 404 is all the operator gets — so it has to name the setting that fixes it.
+func TestCreateClientViaPMS_A404NamesTheSettingThatSwitchesEndpoint(t *testing.T) {
+	_, r, closeSrv := newPMSPathStub(t, "/oauth/client") // default config points at the absent /oidc-clients
+	defer closeSrv()
+
+	_, err := registerViaPMS(t, r)
+	if err == nil {
+		t.Fatal("want an error when the configured endpoint is absent, got nil")
+	}
+	for _, want := range []string{"404", "client_api", "oauth-client"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("404 error %q does not mention %q", err, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The e2e harness hardcoded `{pms}/oidc-clients` as the client-registration endpoint. **PMS 1.2.2.x has no such controller** and answers HTTP 404 for it, so on a deployment running that build every e2e scenario failed at client registration, before any flow was driven:

```
PMS create client failed (HTTP 404): {"status":404,"error":"Not Found",
"path":"/v1/partnermanager/oidc-clients"}
```

## Change

`esignet.pms.client_api` (`PMS_CLIENT_API`) selects the endpoint:

| value | endpoint |
|---|---|
| `oidc-clients` | `{pms}/oidc-clients` — **default**, existing deployments unaffected |
| `oauth-client` | `{pms}/oauth/client` — the only one PMS 1.2.2.x serves |

**Both endpoints take the identical request body**, so the setting changes the path and nothing else — there is no second body shape to maintain.

## Why no auto-detection

A 404 fallback was considered and deliberately rejected: a deployment whose PMS is upgraded or replaced should have this setting revisited rather than silently switching endpoints underneath the run. To keep that discoverable, a 404 from the configured endpoint now names the setting that fixes it instead of reporting a bare Not Found.

`oidc-clients` remains the default because a client registered there is the one IDA is known to authenticate; `/oauth/client` registrations have been seen refused at login — visible only by driving a full login, so no create-and-read-back test catches it.

## Verification

Measured live against **three** PMS builds, using a garbage wrapper `id` as the control:

| | `/oidc-clients` | `/oauth/client` |
|---|---|---|
| PMS 1.2.2.3 (`released`) | **404** — no controller | 200, client created |
| current PMS (`qajava21`, `dev`) | 200 | 200, client created |
| wrapper `id`/`version`/`metadata` | **validated** — wrong id rejected `PMS_REQUEST_ERROR_002`, echoed back in the response | **ignored** — registers with a garbage id, echoes `id`/`version` as `null` |

Driven end to end through `createClientViaPMS` itself, not a stub: with `client_api: oauth-client` it registered a real client on the 1.2.2.3 deployment; with the default it produced the new 404 message.

## Compatibility

No behaviour change for any deployment serving `/oidc-clients` — same URL, same body, same single call. A config with no `client_api` key resolves to the default. Existing `TestCreateClientViaPMS_*` tests pass untouched; 5 new tests cover the default, both configured values, the body shape at each path, and the 404 message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable PMS client-registration endpoints, supporting both `oidc-clients` and the legacy `oauth-client` path.
  - Added the `PMS_CLIENT_API` environment variable and `client_api` configuration option.
  - Added validation, endpoint-specific error guidance, and a default selection of `oidc-clients`.

- **Documentation**
  - Documented endpoint compatibility, configuration, selection guidance, and troubleshooting steps.

- **Tests**
  - Added coverage for endpoint selection, request handling, defaults, and configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->