### PR TITLE
#2544 Add helm/esignet-uitestrig chart and deploy/esignet-uitestrig deploy …

### DIFF
--- a/deploy/esignet-uitestrig/.gitignore
+++ b/deploy/esignet-uitestrig/.gitignore
@@ -1,0 +1,1 @@
+values.secret.yaml

--- a/deploy/esignet-uitestrig/README.md
+++ b/deploy/esignet-uitestrig/README.md
@@ -1,0 +1,104 @@
+# eSignet UI Test Rig (Java)
+
+## Introduction
+Runs the **Java** UI automation suite (`ui-test/`, Cucumber + TestNG +
+Selenium, image `uitest-esignet`) against the eSignet deployment in this
+cluster, via the
+[`../../helm/esignet-uitestrig`](../../helm/esignet-uitestrig) chart —
+a purpose-built chart, not the generic
+[`mosip/uitestrig`](https://github.com/mosip/mosip-functional-tests/tree/develop/helm/uitestrig)
+chart this used to install (see that chart's real gaps in
+`helm/esignet-uitestrig/README.md`'s header).
+
+This is a **separate** installation from
+[`esignet-apitestrig`](../esignet-apitestrig), which runs the Go `api-test`
+harness. `develop-go` in the image tag just means "built from the
+`develop-go` branch" — `ui-test` itself is 100% Java, and pushes its own
+report to S3 in-process rather than via an uploader sidecar.
+
+This installs into its **own `esignet-uitestrig` namespace**, separate from
+`esignet-apitestrig`'s `esignet` namespace. The new chart names its
+ConfigMap/Secret via `common.names.fullname`, so a shared namespace would
+actually be safe too (unlike the generic `mosip/uitestrig` chart this
+replaces) — this is a deliberate choice to keep the two rigs separated, not
+a requirement.
+
+`install.sh` only asks two questions:
+1. the eSignet base URL (origin only, no path — different from
+   `esignet-apitestrig`'s `MOSIP_ESIGNET_BASE_URL`, which includes
+   `/v1/esignet`)
+2. whether you've actually reviewed/updated `values.yaml`
+
+Everything else — `baseurl`, consent DB host, report storage, browser
+choice, self-signed TLS — is a value in one of two files you edit directly
+beforehand.
+
+## Setup
+
+1. **`values.yaml`** (tracked in git) — non-secret settings. Every
+   environment-specific value carries a `# UPDATE ...` marker — check each
+   one, don't assume the pre-filled defaults fit your environment.
+
+2. **`values.secret.yaml`** (gitignored) — secrets. Copy the example and
+   fill in real values:
+   ```bash
+   cp values.secret.yaml.example values.secret.yaml
+   ```
+   Holds the consent DB password, Keycloak admin password, testrig client
+   secret, pre-provisioned OIDC client(s), test identities (PII), and S3
+   keys. `install.sh` refuses to run without this file present, and refuses
+   to proceed while it still contains the literal `"changeme"` placeholder.
+
+## Install
+```bash
+./install.sh
+```
+
+## Uninstall
+```bash
+./delete.sh
+```
+
+## Report storage
+Two options — see `helm/esignet-uitestrig/README.md`'s "Reports" section
+for the full detail:
+1. **In-process S3 push** (recommended, no PVC needed) — set
+   `uitestrig.configMap`'s `push-reports-to-s3: "yes"` in `values.yaml`
+   plus `s3-host`/`s3-region`/`s3-account`, and `uitestrig.secret`'s
+   `s3-user-key`/`s3-user-secret` in `values.secret.yaml`.
+2. **PVC** — set `reports.persistence.enabled: true` in `values.yaml`.
+
+Without either, the report only exists in the pod until it's
+garbage-collected.
+
+## Browser
+Defaults to in-cluster Chromium. To use BrowserStack instead: set
+`uitestrig.browserstack.enabled: true` in `values.yaml`, fill in
+`uitestrig.browserstack.username`/`accessKey` in `values.secret.yaml`, and
+set `uitestrig.configMap.runOnBrowserStack: "true"` yourself in
+`values.yaml`.
+
+## Self-signed TLS
+Set `uitestrig.enableInsecure: true` and `uitestrig.tls.caCert` (the
+eSignet host's CA cert, PEM) in `values.yaml`. **Unverified against a live
+cluster** — see `helm/esignet-uitestrig/README.md`'s "Self-signed TLS"
+section before relying on this in a real run.
+
+## Run manually
+
+#### Rancher UI
+Trigger the CronJob's job manually from the Rancher UI, same as
+`esignet-apitestrig`, in the `esignet-uitestrig` namespace.
+
+* Supported test levels: `smoke`, `smokeAndRegression` (default). To
+  change it, update `uitestrig.extraEnvVars.ENV_TESTLEVEL` in `values.yaml`
+  and re-run `./install.sh`.
+* To scope a run further, set (in `uitestrig.extraEnvVars`, and leave
+  blank when not needed): `CUCUMBER_FILTER_TAGS`, `RUN_ONLY_SCENARIO`,
+  `FEATURE_FILES_TO_EXECUTE`.
+
+#### CLI
+```sh
+kubectl --kubeconfig=<k8s-config-file> -n esignet-uitestrig create job \
+  --from=cronjob/esignet-uitestrig <job-name>
+```

--- a/deploy/esignet-uitestrig/delete.sh
+++ b/deploy/esignet-uitestrig/delete.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Uninstalls uitestrig
+## Usage: ./delete.sh [kubeconfig]
+
+if [ $# -ge 1 ] ; then
+  export KUBECONFIG=$1
+fi
+
+function deleting_uitestrig() {
+  NS=esignet-uitestrig
+  while true; do
+      read -p "Are you sure you want to delete uitestrig helm charts?(Y/n) " yn
+      if [ "$yn" = "Y" ] || [ "$yn" = "y" ]
+        then
+          helm -n $NS delete esignet-uitestrig
+          break
+        else
+          break
+      fi
+  done
+  return 0
+}
+
+# set commands for error handling.
+set -e
+set -o errexit   ## set -e : exit the script if any statement returns a non-true return value
+set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable
+set -o errtrace  # trace ERR through 'time command' and other functions
+set -o pipefail  # trace ERR through pipes
+deleting_uitestrig   # calling function

--- a/deploy/esignet-uitestrig/install.sh
+++ b/deploy/esignet-uitestrig/install.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Installs the eSignet UI test rig (Java harness, uitest-esignet image) from
+# the published mosip-helm chart repo.
+## Usage: ./install.sh [kubeconfig]
+#
+# Mirrors ../esignet-apitestrig/install.sh's own pattern: helm repo add +
+# install by name/version from mosip-helm, not a local chart path. This
+# only works once helm/esignet-uitestrig has actually merged upstream and
+# MOSIP's CI has published it there -- until then, `helm install` below
+# will fail with "chart not found", which is expected while this is still
+# on a feature branch.
+#
+# Installs into its OWN namespace (esignet-uitestrig), separate from
+# esignet-apitestrig's shared "esignet" namespace -- this chart's own
+# ConfigMap/Secret naming (via common.names.fullname) means a shared
+# namespace would actually be safe too (unlike the generic mosip/uitestrig
+# chart this replaces), but keeping the UI and API rigs in separate
+# namespaces is a valid choice either way; best-effort defaults below are
+# read from the "esignet" namespace regardless, via SOURCE_NS.
+#
+# Only two prompts -- everything else lives in values.yaml (tracked in git,
+# edit it directly) and values.secret.yaml (gitignored, holds the consent
+# DB password, Keycloak admin password, test identities/PII, and S3 keys --
+# copy values.secret.yaml.example to get started).
+
+if [ $# -ge 1 ] ; then
+  export KUBECONFIG=$1
+fi
+
+set -o errexit
+set -o nounset
+set -o errtrace
+set -o pipefail
+
+SOURCE_NS=esignet
+NS=esignet-uitestrig
+RELEASE_NAME=esignet-uitestrig
+CHART_VERSION=0.0.1-develop
+VALUES_FILE=values.yaml
+SECRET_VALUES_FILE=values.secret.yaml
+
+# Only handles simple "key: value" / "key: \"value\"" lines under a fixed
+# 4-space indent (matching this file's own layout) -- not a general YAML
+# parser, just enough to read uitestrig.configMap.localeUrl's current value.
+yaml_val() {
+  local key="$1"
+  grep -m1 -E "^    ${key}:" "$VALUES_FILE" \
+    | sed -E "s/^[^:]+:[[:space:]]*['\"]?([^'\"#]*)['\"]?[[:space:]]*(#.*)?\$/\1/" \
+    | sed -E 's/[[:space:]]+$//'
+}
+
+function installing_uitestrig() {
+  if [[ ! -f "$SECRET_VALUES_FILE" ]]; then
+    echo "ERROR: $SECRET_VALUES_FILE not found."
+    echo "Copy ${SECRET_VALUES_FILE}.example to $SECRET_VALUES_FILE and fill in"
+    echo "the consent DB password, Keycloak admin password, test identities,"
+    echo "and S3 keys; EXITING."
+    exit 1
+  fi
+
+  if grep -qE '"changeme"' "$SECRET_VALUES_FILE" "$VALUES_FILE"; then
+    echo "ERROR: $SECRET_VALUES_FILE and/or $VALUES_FILE still contain the"
+    echo "\"changeme\" placeholder value."
+    echo "Fill in real values for every field marked '# UPDATE ...' before"
+    echo "running this script; EXITING."
+    exit 1
+  fi
+
+  echo "Create $NS namespace (if it doesn't already exist)"
+  kubectl create ns $NS || true
+
+  helm repo add mosip https://mosip.github.io/mosip-helm
+  helm repo update
+
+  # Best-effort defaults, same derivation as esignet-apitestrig's
+  # install.sh: read eSignet's own host and the api-internal host from
+  # SOURCE_NS, where eSignet/esignet-apitestrig actually live (uitestrig
+  # gets its own separate namespace, NS, below -- esignet-global doesn't
+  # exist there). Falls back to a bare prompt if not found.
+  ESIGNET_HOST=$(kubectl -n "$SOURCE_NS" get cm esignet-global -o json 2>/dev/null | jq -r '.data."mosip-esignet-host"' 2>/dev/null || true)
+  API_INTERNAL_HOST=$(kubectl -n "$SOURCE_NS" get cm esignet-global -o json 2>/dev/null | jq -r '.data."mosip-api-internal-host"' 2>/dev/null || true)
+
+  DEFAULT_ESIGNET_BASE_URL=""
+  if [[ -n "$ESIGNET_HOST" && "$ESIGNET_HOST" != "null" ]]; then
+    DEFAULT_ESIGNET_BASE_URL="https://$ESIGNET_HOST"
+  fi
+  read -rp "eSignet base URL (origin only, no path)${DEFAULT_ESIGNET_BASE_URL:+ [$DEFAULT_ESIGNET_BASE_URL]}: " ESIGNET_BASE_URL
+  ESIGNET_BASE_URL="${ESIGNET_BASE_URL:-$DEFAULT_ESIGNET_BASE_URL}"
+  if [[ -z "$ESIGNET_BASE_URL" ]]; then
+    echo "ERROR: eSignet base URL is required; EXITING."
+    exit 1
+  fi
+
+  ENV_ENDPOINT=""
+  ENV_USER=""
+  if [[ -n "$API_INTERNAL_HOST" && "$API_INTERNAL_HOST" != "null" ]]; then
+    ENV_ENDPOINT="https://$API_INTERNAL_HOST"
+    ENV_USER=$(printf '%s' "$API_INTERNAL_HOST" | awk -F '.' '/api-internal/{print $1"."$2}')
+  fi
+  if [[ -z "$ENV_ENDPOINT" ]]; then
+    read -rp "ENV_ENDPOINT (api-internal host, e.g. https://api-internal.<env>.mosip.net): " ENV_ENDPOINT
+    if [[ -z "$ENV_ENDPOINT" ]]; then
+      echo "ERROR: ENV_ENDPOINT is required; EXITING."
+      exit 1
+    fi
+  fi
+
+  LOCALE_OPTS=()
+  if [[ -z "$(yaml_val localeUrl)" ]]; then
+    LOCALE_OPTS+=(--set "uitestrig.configMap.localeUrl=$ESIGNET_BASE_URL")
+  fi
+
+  read -rp "Have you reviewed/updated $VALUES_FILE for this environment? (Y/n): " values_confirmed
+  values_confirmed="${values_confirmed:-y}"
+  values_confirmed=$(printf '%s' "$values_confirmed" | tr '[:upper:]' '[:lower:]')
+  if [[ "$values_confirmed" != "y" ]]; then
+    echo "Update $VALUES_FILE first (baseurl/localeUrl, consent DB host,"
+    echo "report storage, etc.), then re-run this script; EXITING."
+    exit 1
+  fi
+
+  echo ""
+  echo "Installing $RELEASE_NAME (mosip/esignet-uitestrig, version $CHART_VERSION) in namespace $NS ..."
+  helm -n $NS upgrade --install $RELEASE_NAME mosip/esignet-uitestrig --version $CHART_VERSION \
+    -f "$VALUES_FILE" \
+    -f "$SECRET_VALUES_FILE" \
+    --set uitestrig.configMap.eSignetbaseurl="$ESIGNET_BASE_URL" \
+    --set uitestrig.extraEnvVars.ENV_ENDPOINT="$ENV_ENDPOINT" \
+    --set uitestrig.extraEnvVars.ENV_USER="$ENV_USER" \
+    "${LOCALE_OPTS[@]}" \
+    --wait
+
+  echo "Installed $RELEASE_NAME."
+  return 0
+}
+
+installing_uitestrig

--- a/deploy/esignet-uitestrig/values.secret.yaml.example
+++ b/deploy/esignet-uitestrig/values.secret.yaml.example
@@ -1,0 +1,32 @@
+# Copy this file to values.secret.yaml (gitignored) and fill in real values.
+# install.sh loads values.secret.yaml if present; it refuses to proceed
+# without it.
+
+uitestrig:
+  secret:
+    esignetDbPassword: "changeme"        # UPDATE with your consent DB password
+    keycloak_Password: "changeme"        # UPDATE with the Keycloak admin password
+    mosip_testrig_client_secret: "changeme"   # UPDATE with the testrig client secret
+    oidcClientId: "changeme"             # UPDATE with pre-provisioned OIDC client(s), comma form "primary,secondary"
+    uin: "changeme"                      # UPDATE -- PII, pre-provisioned test identity
+    vid: "changeme"                      # UPDATE -- PII
+    mockUin: "changeme"                  # UPDATE -- PII
+    uinPhoneNumber: "changeme"           # UPDATE -- PII
+    emailLoginId: "changeme"             # UPDATE -- PII, email OTP identity
+    passwordLoginUin: "changeme"         # UPDATE -- password-login identity
+    passwordLoginPassword: "changeme"    # UPDATE with the password-login identity's password
+    # Only needed if uitestrig.configMap's push-reports-to-s3 above is "yes"
+    # -- left blank (not a placeholder to replace) since it's genuinely optional. The
+    # chart itself enforces these are filled in when push-reports-to-s3 is
+    # actually "yes" (a clear helm upgrade error, not a silent one at
+    # runtime) -- see helm/esignet-uitestrig/templates/secret.yaml.
+    s3-user-key: ""              # UPDATE with your S3/MinIO access key
+    s3-user-secret: ""           # UPDATE with your S3/MinIO secret key
+
+  # Only needed if uitestrig.browserstack.enabled: true in values.yaml --
+  # left blank (not a placeholder to replace) for the same reason as s3-user-key above;
+  # the chart's templates/secret-browserstack.yaml enforces these are
+  # filled in when browserstack is actually enabled.
+  browserstack:
+    username: ""                 # UPDATE with your BrowserStack username
+    accessKey: ""                # UPDATE with your BrowserStack access key

--- a/deploy/esignet-uitestrig/values.yaml
+++ b/deploy/esignet-uitestrig/values.yaml
@@ -1,0 +1,81 @@
+# Values for ../../helm/esignet-uitestrig. Secrets (DB password, keycloak
+# admin password, test identities -- PII, etc.) do NOT belong in this file
+# -- it's tracked in git. Put those in values.secret.yaml instead
+# (gitignored; copy values.secret.yaml.example to get started).
+#
+# Installs into its OWN "esignet-uitestrig" namespace, separate from
+# esignet-apitestrig's "esignet" namespace -- see install.sh's header
+# comment for why a shared namespace would actually be safe with this
+# chart too (unlike the generic mosip/uitestrig chart it replaces), if you
+# ever want to consolidate them.
+
+# Uses the chart's own default image (helm/esignet-uitestrig/values.yaml)
+# unless uncommented here. Uncomment and edit if you need a different
+# repository/tag for this environment.
+# image:
+#   repository: mosipdev/uitest-esignet
+#   tag: develop
+#   pullPolicy: Always
+
+triggerKind: cronjob
+crontime: "0 3 * * *"   # hour 0-23
+
+uitestrig:
+  extraEnvVars:
+    # Filled in by install.sh from esignet-global (same derivation as
+    # esignet-apitestrig's install.sh), not set directly here.
+    ENV_ENDPOINT: ""
+    ENV_USER: ""
+    MODULES: "esignet"
+    ENV_TESTLEVEL: "smokeAndRegression"   # smoke | smokeAndRegression
+    # Chrome + the JVM in one cgroup -- keep well under resources.limits.memory.
+    JAVA_EXTRA_OPTS: "-Xmx2g"
+
+  configMap:
+    # Relying-party (health-services) origin. OIDC redirect_uris must be
+    # exactly this + "userprofile".
+    baseurl: "https://healthservices-go.sandbox.mosip.net/"   # UPDATE 'sandbox' to your environment
+    # Blank = same as eSignetbaseurl at install time (install.sh fills this
+    # in for you if left blank here).
+    localeUrl: ""
+    eSignetbaseurl: "https://esignet-go.sandbox.mosip.net"   # UPDATE 'sandbox' to your environment
+    pluginToExecute: "mock"
+    runLanguage: "eng"
+    runOnBrowserStack: "false"   # see uitestrig.browserstack below to switch this
+    esignetDbHost: "postgres-postgresql.postgres"   # UPDATE with your consent DB host
+    esignetDbPort: "5432"
+    push-reports-to-s3: "yes"   # also fill in s3-* below and s3-user-key/secret in values.secret.yaml
+    s3-host: ""   # UPDATE with your S3/MinIO endpoint
+    s3-region: ""   # UPDATE with your S3 region (MinIO: any non-empty value, e.g. "us-east-1")
+    s3-account: "uitestrig"
+
+  browserstack:
+    enabled: false
+
+  # Self-signed/internal certs? See helm/esignet-uitestrig/README.md
+  # "Self-signed TLS" -- unverified against a live cluster, test before
+  # relying on it.
+  enableInsecure: false
+  tls:
+    # Required if enableInsecure above is true -- the eSignet host's CA
+    # cert (PEM), obtained through a trusted channel (e.g. copied directly
+    # from the ingress/load balancer's TLS config), not fetched live.
+    caCert: ""   # UPDATE if enableInsecure is true
+
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: 500m
+    memory: 2Gi
+
+reports:
+  # "yes" above under push-reports-to-s3 is the recommended path (no PVC
+  # needed at all -- the JAR pushes its own report to S3 in-process). Only
+  # enable this if you're leaving push-reports-to-s3 at "no".
+  persistence:
+    enabled: false
+    storageClass: ""
+    size: 1Gi
+    existingClaim: ""

--- a/helm/esignet-uitestrig/.helmignore
+++ b/helm/esignet-uitestrig/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.orig
+*.tmp
+*.bak
+*.swp

--- a/helm/esignet-uitestrig/Chart.yaml
+++ b/helm/esignet-uitestrig/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: esignet-uitestrig
+description: A Helm chart to deploy the Java eSignet UI test rig (ui-test, image uitest-esignet)
+type: application
+version: 0.0.1-develop
+appVersion: ""
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+home: https://mosip.io
+keywords:
+  - mosip
+  - esignet
+  - uitestrig
+maintainers:
+  - email: info@mosip.io
+    name: MOSIP

--- a/helm/esignet-uitestrig/README.md
+++ b/helm/esignet-uitestrig/README.md
@@ -1,0 +1,146 @@
+# esignet-uitestrig
+
+> Purpose-built chart for `uitest-esignet` — not the generic
+> [`mosip-functional-tests/helm/uitestrig`](https://github.com/mosip/mosip-functional-tests/tree/develop/helm/uitestrig)
+> chart. That chart works, but has no lever for container `resources` or a
+> reports PVC at all (confirmed against its own `templates/cronjob.yaml`),
+> and its `templates/secrets.yaml` is missing the `---` document separator
+> `templates/configmaps.yaml` has between loop iterations — with more than
+> one entry under `uitestrig.secrets`, the rendered manifest becomes one
+> malformed multi-document YAML file and every secret but the last is
+> silently dropped. This chart fixes both gaps by being its own thing,
+> named `esignet-uitestrig` (not `uitestrig`) so it can never collide with
+> that one in a shared chart repo.
+
+## Introduction
+
+Runs the **Java** UI automation suite (`ui-test/`, Cucumber + TestNG +
+Selenium, image `uitest-esignet`) against the eSignet deployment in this
+cluster, on a schedule (`CronJob`) or on demand (`Job`). Built from
+[mosip/esignet#2544](https://github.com/mosip/esignet/issues/2544)'s gap
+analysis.
+
+This is **not** related to the Go `api-test` harness or
+[`helm/esignet-apitestrig`](../esignet-apitestrig) — `develop-go` in the
+image tag just means "built from the `develop-go` branch," which happens to
+contain both suites side by side. `ui-test` itself is 100% Java, runs as a
+JVM process, and pushes its own reports to S3 in-process
+(`BaseTest.pushReportsToS3`) rather than via an external uploader sidecar.
+
+## Prerequisites
+
+- eSignet already deployed and reachable.
+- A pre-provisioned test identity and OIDC client(s) for the UI flows (see
+  `uitestrig.secret`).
+- If running in-cluster Chromium (the default — see "Browser" below), no
+  further setup. If using BrowserStack instead, network egress from the
+  cluster to BrowserStack and a valid account.
+
+## Configuration model
+
+**Two separate objects**, both mounted into the container as **files**, one
+per key, rather than via `envFrom` — several of the harness's own config
+keys contain hyphens (`keycloak-external-url`, `push-reports-to-s3`, ...),
+and while `envFrom` accepts those syntactically, the kubelet silently
+*drops* envFrom-sourced keys containing `-` on Kubernetes versions before
+1.32 (`RelaxedEnvironmentVariableValidation` is beta in 1.32, GA in 1.34).
+A wrapper script (baked into the pod template, not something you configure)
+reads each mounted file and injects it into the JVM's process environment
+via `env KEY=VALUE ...` before exec'ing the image's own entrypoint — this
+works on any Kubernetes version, since filenames have no such restriction:
+
+- **`uitestrig.configMap`** → a ConfigMap (non-secret)
+- **`uitestrig.secret`** → a Secret (credentials, PII)
+
+**Every key in both is only rendered when non-empty.** This isn't cosmetic —
+`apitest-commons`' `ConfigManager` does `System.getenv(key) ?? propsMap.get(key)`,
+so an environment variable that's *present but empty* still overrides
+(wipes) the JAR's own `config.properties` default, rather than falling
+through to it. Leaving a value blank in `values.yaml` omits that key from
+the rendered ConfigMap/Secret entirely, letting the JAR default apply — see
+[mosip/esignet#2544](https://github.com/mosip/esignet/issues/2544) §2/§4 for
+the full list of keys that ship safe JAR defaults and must never be set to
+`""`.
+
+Plain env vars (`uitestrig.extraEnvVars` — `ENV_ENDPOINT`, `MODULES`, etc.)
+are the ones `entrypoint.sh` itself reads directly to build the `java`
+command line; these use ordinary `env:` entries since none of their names
+contain hyphens.
+
+## Browser
+
+Defaults to **in-cluster Chromium** (`runOnBrowserStack=false` in
+`uitestrig.configMap`) — the JAR's own default is `runOnBrowserStack=true`,
+so this must be set explicitly. No `/dev/shm` volume is needed:
+`ui-test`'s own `BaseTestUtil` unconditionally adds `--no-sandbox` and
+`--disable-dev-shm-usage` to `ChromeOptions` (confirmed against
+`src/main/java/utils/BaseTestUtil.java`), which works around the shared-memory
+requirement at the application level.
+
+To use BrowserStack instead: set `uitestrig.browserstack.enabled: true` plus
+`username`/`accessKey`, and set `uitestrig.configMap.runOnBrowserStack: "true"`
+yourself (the chart doesn't flip that for you, since it's ultimately a
+harness-config concern, not purely a "which secret" concern).
+
+## Reports
+
+Mounted at `reports.mountPath` (`/home/mosip/test-output`) and
+`reports.screenshotsMountPath` (`/home/mosip/screenshots`) — **not**
+`/home/mosip/testrig/report` (the API rig's old path, wrong for this image).
+Two options, matching
+[mosip/esignet#2544](https://github.com/mosip/esignet/issues/2544) §6(i):
+
+1. **In-process S3 push** (no sidecar, unlike `apitestrig`) — set
+   `uitestrig.configMap`'s `push-reports-to-s3: "yes"` plus
+   `s3-host`/`s3-region`/`s3-account`, and `uitestrig.secret`'s
+   `s3-user-key`/`s3-user-secret`.
+2. **PVC** — set `reports.persistence.enabled: true`. The generic
+   `mosip/uitestrig` chart has no PVC template at all; this fills that gap.
+
+Without either, the report only exists inside the pod until it's
+garbage-collected — retrievable via `kubectl cp` in the meantime.
+
+An init container (`prepare-report-dirs`) always runs first to recreate
+`test-output/SparkReport/`, which the image bakes in at build time but a
+fresh PVC/`emptyDir` mount would otherwise hide.
+
+## Self-signed TLS (`uitestrig.enableInsecure`)
+
+**Unverified against a live cluster — test before relying on it.** Imports
+`uitestrig.tls.caCert` (required when this is enabled) into the JVM's own
+`cacerts` truststore, following the same pattern as the old Java
+`apitestrig` chart
+([`mosip-functional-tests/helm/apitestrig`](https://github.com/mosip/mosip-functional-tests/tree/develop/helm/apitestrig)),
+adapted for this image's actual base: `eclipse-temurin`'s `JAVA_HOME` is
+`/opt/java/openjdk` (confirmed against Adoptium/Temurin's own container
+docs), not `/usr/local/openjdk-11` like that older chart's image. Eclipse
+Temurin's own built-in `USE_SYSTEM_CA_CERTS` auto-handling doesn't apply
+here since `uitest-esignet`'s `Dockerfile` sets its own `ENTRYPOINT`,
+bypassing the base image's cert-processing entrypoint entirely — hence
+doing this by hand via an init container instead.
+
+Unlike the old chart's approach (`openssl s_client` fetching whatever
+certificate the target host presents at deploy time, then trusting it
+unconditionally), this chart requires you to supply the actual PEM content
+via `uitestrig.tls.caCert` — obtain it through a channel you actually
+trust (e.g. copy it directly from the eSignet ingress/load balancer's own
+TLS config), not by pointing this chart at a live endpoint and trusting
+whatever comes back. Fetching-and-trusting blindly is a TOFU gap
+([CWE-295](https://cwe.mitre.org/data/definitions/295.html)) — a network
+or DNS attacker could otherwise get their own certificate trusted by test
+traffic.
+
+## CronJob vs Job
+
+Same as [`helm/esignet-apitestrig`](../esignet-apitestrig#cronjob-vs-job) —
+`triggerKind: cronjob` (default, scheduled) or `triggerKind: job` (one-shot,
+Job name suffixed with `.Release.Revision`).
+
+## Resources
+
+Defaults to `requests: 500m CPU / 2Gi memory`, `limits: 2 CPU / 4Gi memory`
+— headless Chromium plus the JVM in one pod needs real headroom
+([mosip/esignet#2544](https://github.com/mosip/esignet/issues/2544) §3.2).
+`uitestrig.extraEnvVars.JAVA_EXTRA_OPTS` defaults to `-Xmx2g`, deliberately
+well under the memory limit rather than the old Java `apitestrig` chart's
+`-Xms2600M` on a much smaller container.

--- a/helm/esignet-uitestrig/templates/NOTES.txt
+++ b/helm/esignet-uitestrig/templates/NOTES.txt
@@ -1,0 +1,32 @@
+eSignet UI test rig ({{ .Values.triggerKind }}) has been deployed.
+
+Reports mount    : {{ .Values.reports.mountPath }}
+Screenshots mount: {{ .Values.reports.screenshotsMountPath }}
+{{- if eq (index .Values.uitestrig.configMap "push-reports-to-s3") "yes" }}
+Report storage   : in-process S3 push (BaseTest.pushReportsToS3)
+{{- else if .Values.reports.persistence.enabled }}
+Report storage   : PVC ({{ include "uitestrig.reportsClaimName" . }})
+{{- else }}
+Report storage   : none configured -- reports only exist in the pod until
+                    it's garbage-collected. Set uitestrig.configMap's
+                    push-reports-to-s3=yes, or reports.persistence.enabled=true.
+{{- end }}
+Browser          : {{ if .Values.uitestrig.browserstack.enabled }}BrowserStack{{ else }}in-cluster Chromium{{ end }}
+
+{{- if eq .Values.triggerKind "cronjob" }}
+
+Scheduled: {{ .Values.crontime }}
+To trigger a run right now:
+  kubectl create job --from=cronjob/{{ include "common.names.fullname" . }} \
+    -n {{ .Release.Namespace }} {{ include "common.names.fullname" . }}-manual-$(date +%s)
+{{- else }}
+
+Follow this run:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -f
+{{- end }}
+
+{{- if .Values.reports.persistence.enabled }}
+
+To pull the report out of the reports volume:
+  kubectl cp -n {{ .Release.Namespace }} <pod-name>:{{ .Values.reports.mountPath }} ./test-output
+{{- end }}

--- a/helm/esignet-uitestrig/templates/_helpers.tpl
+++ b/helm/esignet-uitestrig/templates/_helpers.tpl
@@ -1,0 +1,269 @@
+{{/*
+Return the proper image name
+*/}}
+{{- define "uitestrig.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "uitestrig.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "uitestrig.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (printf "%s" (include "common.names.fullname" .)) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the ConfigMap rendered from uitestrig.configMap.
+*/}}
+{{- define "uitestrig.configMapName" -}}
+{{ include "common.names.fullname" . }}-config
+{{- end -}}
+
+{{/*
+Name of the Secret rendered from uitestrig.secret.
+*/}}
+{{- define "uitestrig.secretName" -}}
+{{ include "common.names.fullname" . }}-secret
+{{- end -}}
+
+{{/*
+Name of the ConfigMap holding the pinned CA cert for enableInsecure.
+*/}}
+{{- define "uitestrig.caCertConfigMapName" -}}
+{{ include "common.names.fullname" . }}-ca-cert
+{{- end -}}
+
+{{/*
+Name of the Secret backing BrowserStack credentials.
+*/}}
+{{- define "uitestrig.browserstackSecretName" -}}
+{{ include "common.names.fullname" . }}-browserstack
+{{- end -}}
+
+{{/*
+Name of the PVC backing the reports volume.
+*/}}
+{{- define "uitestrig.reportsClaimName" -}}
+{{- if .Values.reports.persistence.existingClaim -}}
+{{ .Values.reports.persistence.existingClaim }}
+{{- else -}}
+{{ include "common.names.fullname" . }}-reports
+{{- end -}}
+{{- end -}}
+
+{{/*
+The shared pod spec used by both cronjob.yaml and job.yaml.
+*/}}
+{{- define "uitestrig.podTemplate" -}}
+metadata:
+  annotations:
+    sidecar.istio.io/inject: {{ .Values.istio.sidecarInject | quote }}
+    {{- if .Values.podAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.podLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "uitestrig.serviceAccountName" . }}
+  {{- include "uitestrig.imagePullSecrets" . | nindent 2 }}
+  {{- if .Values.podSecurityContext.enabled }}
+  securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.hostAliases }}
+  hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.affinity }}
+  affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tolerations }}
+  tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 4 }}
+  {{- end }}
+  initContainers:
+    {{/*
+    The image bakes in /home/mosip/test-output/SparkReport/ (see Dockerfile)
+    for the reporting library's benefit -- mounting a volume at
+    reports.mountPath hides that baked-in subdirectory on a fresh
+    PVC/emptyDir, so recreate it here before the main container starts.
+    Always runs, regardless of enableInsecure.
+    */}}
+    - name: prepare-report-dirs
+      image: {{ include "uitestrig.image" . }}
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command: ["/bin/sh", "-c"]
+      args:
+        - mkdir -p {{ .Values.reports.mountPath }}/SparkReport
+      volumeMounts:
+        - name: reports
+          mountPath: {{ .Values.reports.mountPath }}
+          subPath: test-output
+    {{- if .Values.uitestrig.enableInsecure }}
+    {{/*
+    Imports a pinned CA certificate into a JVM cacerts truststore, same
+    pattern as the old Java apitestrig chart (mosip-functional-tests,
+    helm/apitestrig) -- but this image's base is eclipse-temurin, whose
+    JAVA_HOME is /opt/java/openjdk (confirmed against Adoptium/Temurin's own
+    docs), NOT /usr/local/openjdk-11 like that older chart's image. The base
+    image's own built-in USE_SYSTEM_CA_CERTS auto-handling doesn't apply here
+    since uitest-esignet's Dockerfile sets its own ENTRYPOINT, bypassing the
+    base image's cert-processing entrypoint entirely -- hence doing this by
+    hand instead.
+
+    Imports uitestrig.tls.caCert (required below when enableInsecure is
+    true) directly, rather than fetching whatever certificate the target
+    host presents at runtime via openssl s_client and trusting it
+    unconditionally (a TOFU/CWE-295 gap: a network or DNS attacker could
+    otherwise get their own certificate trusted). The operator is expected
+    to obtain this cert through a trusted channel -- e.g. copying it
+    directly from the eSignet ingress/load balancer's own TLS config --
+    not by pointing this chart at a live endpoint.
+
+    UNVERIFIED against a live cluster; test before relying on it.
+    */}}
+    - name: import-cacerts
+      image: {{ include "uitestrig.image" . }}
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set -e
+          CACERTS_SRC=/opt/java/openjdk/lib/security/cacerts
+          cp "$CACERTS_SRC" /tmp/cacerts
+          keytool -delete -alias esignet-ca -keystore /tmp/cacerts -storepass changeit >/dev/null 2>&1 || true
+          keytool -trustcacerts -keystore /tmp/cacerts -storepass changeit -noprompt \
+            -importcert -alias esignet-ca -file /ca-cert/ca.pem
+          cp /tmp/cacerts /cacerts/cacerts
+      volumeMounts:
+        - name: ca-cert
+          mountPath: /ca-cert
+          readOnly: true
+        - name: cacerts
+          mountPath: /cacerts
+    {{- end }}
+  containers:
+    - name: uitestrig
+      image: {{ include "uitestrig.image" . }}
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      {{- if .Values.containerSecurityContext.enabled }}
+      securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{/*
+      Always wraps the image's own ENTRYPOINT (./entrypoint.sh) rather than
+      using it unmodified, to inject uitestrig.configMap/uitestrig.secret's
+      hyphenated keys (keycloak-external-url, push-reports-to-s3,
+      s3-user-key, ...) into the JVM's process environment -- these are
+      mounted as FILES (below), not via envFrom, because envFrom-sourced
+      keys containing '-' are silently dropped by the kubelet on
+      Kubernetes versions before 1.32 (RelaxedEnvironmentVariableValidation
+      is beta in 1.32, GA in 1.34) -- see
+      https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/.
+      Filenames have no such restriction on any version, so each key is
+      read from its own file and passed through `env KEY=VALUE ...`, which
+      also sidesteps bash's own stricter variable-name rules (bash
+      identifiers can't contain '-' either, but `env`'s argument parsing
+      -- split on the first '=' -- doesn't go through bash's variable
+      syntax at all).
+      */}}
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          set -e
+          ENV_ARGS=()
+          for dir in /etc/uitestrig-config /etc/uitestrig-secret; do
+            if [ -d "$dir" ]; then
+              for f in "$dir"/*; do
+                [ -f "$f" ] || continue
+                key=$(basename "$f")
+                val=$(cat "$f")
+                ENV_ARGS+=("$key=$val")
+              done
+            fi
+          done
+          exec env "${ENV_ARGS[@]}" ./entrypoint.sh
+      env:
+        {{- range $key, $value := .Values.uitestrig.extraEnvVars }}
+        {{- if $value }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+      envFrom:
+        {{- if .Values.uitestrig.browserstack.enabled }}
+        - secretRef:
+            name: {{ include "uitestrig.browserstackSecretName" . }}
+        {{- end }}
+        {{/*
+        External references, not this chart's own ConfigMap/Secret --
+        still plain envFrom, so the same K8s 1.32+ caveat above applies if
+        whatever you point these at has hyphenated keys too (e.g. a
+        keycloak-external-url key on a shared "keycloak-host" ConfigMap).
+        */}}
+        {{- range .Values.uitestrig.extraEnvVarsCM }}
+        - configMapRef:
+            name: {{ . }}
+        {{- end }}
+        {{- range .Values.uitestrig.extraEnvVarsSecretRefs }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
+      volumeMounts:
+        - name: uitestrig-config
+          mountPath: /etc/uitestrig-config
+          readOnly: true
+        - name: uitestrig-secret
+          mountPath: /etc/uitestrig-secret
+          readOnly: true
+        - name: reports
+          mountPath: {{ .Values.reports.mountPath }}
+          subPath: test-output
+        - name: reports
+          mountPath: {{ .Values.reports.screenshotsMountPath }}
+          subPath: screenshots
+        {{- if .Values.uitestrig.enableInsecure }}
+        - name: cacerts
+          mountPath: /opt/java/openjdk/lib/security/cacerts
+          subPath: cacerts
+        {{- end }}
+      resources: {{- toYaml .Values.resources | nindent 8 }}
+  volumes:
+    - name: uitestrig-config
+      configMap:
+        name: {{ include "uitestrig.configMapName" . }}
+    - name: uitestrig-secret
+      secret:
+        secretName: {{ include "uitestrig.secretName" . }}
+        defaultMode: 256
+    - name: reports
+      {{- if .Values.reports.persistence.enabled }}
+      persistentVolumeClaim:
+        claimName: {{ include "uitestrig.reportsClaimName" . }}
+      {{- else }}
+      emptyDir: {}
+      {{- end }}
+    {{- if .Values.uitestrig.enableInsecure }}
+    - name: ca-cert
+      configMap:
+        name: {{ include "uitestrig.caCertConfigMapName" . }}
+    - name: cacerts
+      emptyDir: {}
+    {{- end }}
+{{- end -}}

--- a/helm/esignet-uitestrig/templates/configmap-ca-cert.yaml
+++ b/helm/esignet-uitestrig/templates/configmap-ca-cert.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.uitestrig.enableInsecure }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "uitestrig.caCertConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  {{/*
+  X.509 certificates are public information (unlike private keys), so a
+  ConfigMap is appropriate here, not a Secret. required() so a missing cert
+  fails loudly at helm upgrade instead of the init container silently
+  importing nothing (or erroring in a confusing way) at runtime.
+  */}}
+  ca.pem: |
+{{ required "uitestrig.tls.caCert is required when uitestrig.enableInsecure is true -- see helm/esignet-uitestrig/README.md's \"Self-signed TLS\" section" .Values.uitestrig.tls.caCert | indent 4 }}
+{{- end }}

--- a/helm/esignet-uitestrig/templates/configmap.yaml
+++ b/helm/esignet-uitestrig/templates/configmap.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "uitestrig.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  {{- range $key, $value := .Values.uitestrig.configMap }}
+  {{- if and $value (not (has $key (list "s3-host" "s3-region" "runOnBrowserStack"))) }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{/*
+  Driven from uitestrig.browserstack.enabled rather than the static
+  configMap.runOnBrowserStack value above -- otherwise enabling BrowserStack
+  (which creates its credentials Secret) wouldn't actually switch the test
+  rig to use it, since the JAR reads this key to decide.
+  */}}
+  runOnBrowserStack: {{ ternary "true" "false" .Values.uitestrig.browserstack.enabled | quote }}
+  {{- if eq (index .Values.uitestrig.configMap "push-reports-to-s3") "yes" }}
+  {{/*
+  Rendered here instead of via the generic loop above (which only skips
+  empty values silently) so a missing S3 endpoint/region fails loudly at
+  `helm upgrade` instead of causing a silent S3 push failure at runtime --
+  only enforced when push-reports-to-s3 is actually "yes".
+  */}}
+  s3-host: {{ required "uitestrig.configMap.s3-host is required when push-reports-to-s3 is \"yes\"" (index .Values.uitestrig.configMap "s3-host") | quote }}
+  s3-region: {{ required "uitestrig.configMap.s3-region is required when push-reports-to-s3 is \"yes\"" (index .Values.uitestrig.configMap "s3-region") | quote }}
+  {{- end }}

--- a/helm/esignet-uitestrig/templates/cronjob.yaml
+++ b/helm/esignet-uitestrig/templates/cronjob.yaml
@@ -1,0 +1,28 @@
+{{- if not (has .Values.triggerKind (list "cronjob" "job")) }}
+{{- fail "triggerKind must be either \"cronjob\" or \"job\"" }}
+{{- end }}
+{{- if eq .Values.triggerKind "cronjob" }}
+apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
+kind: CronJob
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.crontime | quote }}
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+      template:
+        {{- include "uitestrig.podTemplate" . | nindent 8 }}
+{{- end }}

--- a/helm/esignet-uitestrig/templates/extra-list.yaml
+++ b/helm/esignet-uitestrig/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/helm/esignet-uitestrig/templates/job.yaml
+++ b/helm/esignet-uitestrig/templates/job.yaml
@@ -1,0 +1,21 @@
+{{- if eq .Values.triggerKind "job" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  ## Suffixed with the revision so `helm upgrade`/CI re-runs don't collide
+  ## with the previous run's immutable Job name.
+  name: {{ include "common.names.fullname" . }}-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+  template:
+    {{- include "uitestrig.podTemplate" . | nindent 4 }}
+{{- end }}

--- a/helm/esignet-uitestrig/templates/pvc.yaml
+++ b/helm/esignet-uitestrig/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.reports.persistence.enabled (not .Values.reports.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "uitestrig.reportsClaimName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.reports.persistence.storageClass }}
+  {{- if eq "-" .Values.reports.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.reports.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+  accessModes:
+    {{- range .Values.reports.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.reports.persistence.size | quote }}
+{{- end }}

--- a/helm/esignet-uitestrig/templates/secret-browserstack.yaml
+++ b/helm/esignet-uitestrig/templates/secret-browserstack.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.uitestrig.browserstack.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "uitestrig.browserstackSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  browserstack_username: {{ required "uitestrig.browserstack.username is required when uitestrig.browserstack.enabled" .Values.uitestrig.browserstack.username | quote }}
+  browserstack_access_key: {{ required "uitestrig.browserstack.accessKey is required when uitestrig.browserstack.enabled" .Values.uitestrig.browserstack.accessKey | quote }}
+{{- end }}

--- a/helm/esignet-uitestrig/templates/secret.yaml
+++ b/helm/esignet-uitestrig/templates/secret.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "uitestrig.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.uitestrig.secret }}
+  {{- if and $value (not (has $key (list "s3-user-key" "s3-user-secret"))) }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if eq (index .Values.uitestrig.configMap "push-reports-to-s3") "yes" }}
+  {{/*
+  Rendered here instead of via the generic loop above (which only skips
+  empty values silently) so a missing S3 credential fails loudly at
+  `helm upgrade` instead of causing a silent S3 auth failure at runtime --
+  only enforced when push-reports-to-s3 is actually "yes", since these are
+  genuinely optional otherwise.
+  */}}
+  s3-user-key: {{ required "uitestrig.secret.s3-user-key is required when uitestrig.configMap's push-reports-to-s3 is \"yes\"" (index .Values.uitestrig.secret "s3-user-key") | quote }}
+  s3-user-secret: {{ required "uitestrig.secret.s3-user-secret is required when uitestrig.configMap's push-reports-to-s3 is \"yes\"" (index .Values.uitestrig.secret "s3-user-secret") | quote }}
+  {{- end }}

--- a/helm/esignet-uitestrig/templates/service-account.yaml
+++ b/helm/esignet-uitestrig/templates/service-account.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "uitestrig.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/esignet-uitestrig/values.yaml
+++ b/helm/esignet-uitestrig/values.yaml
@@ -1,0 +1,252 @@
+## Global Docker image parameters
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+commonLabels:
+  app.kubernetes.io/component: mosip
+
+commonAnnotations: {}
+
+clusterDomain: cluster.local
+
+extraDeploy: []
+
+## Fallback default -- deploy/esignet-uitestrig/values.yaml intentionally
+## overrides this at runtime via install.sh's image prompt, but the chart
+## itself should still work with a bare `helm install` and no override.
+image:
+  registry: docker.io
+  repository: mosipdev/uitest-esignet
+  ## The tag is version-y, not "which language" -- ui-test is Java regardless
+  ## of tag. See mosip/esignet#2544's own note on this.
+  tag: develop
+  pullPolicy: Always
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## ---------------------------------------------------------------------------
+## How the rig is triggered
+## ---------------------------------------------------------------------------
+triggerKind: cronjob   # cronjob | job
+
+crontime: "0 3 * * *"
+
+concurrencyPolicy: Forbid
+successfulJobsHistoryLimit: 1
+failedJobsHistoryLimit: 1
+backoffLimit: 0
+## Chromium+JVM startup plus a full UI regression run can genuinely take a
+## while -- this is deliberately generous. Lower it once you know your
+## actual run time.
+activeDeadlineSeconds: 5400
+
+## ---------------------------------------------------------------------------
+## Test-rig configuration
+## ---------------------------------------------------------------------------
+uitestrig:
+  ## The pod template (templates/_helpers.tpl) always wraps the image's own
+  ## ENTRYPOINT (./entrypoint.sh) in a small script that injects
+  ## configMap/secret below into the environment via mounted files -- see
+  ## that template's own comment for why. There's no command/args override
+  ## point here anymore; a custom command would conflict with that wrapper.
+
+  ## Plain, non-secret environment variables -- valid k8s env var names only
+  ## (no hyphens). Consumed directly by entrypoint.sh (mosip/esignet#2544 §4).
+  ## Rendered only when non-empty: entrypoint.sh checks [ -n "${VAR:-}" ]
+  ## before adding most of these to the java command line, so an empty value
+  ## here is equivalent to omitting it -- but ENV_ENDPOINT is NOT
+  ## conditional in entrypoint.sh (always passed), so it must be set.
+  extraEnvVars:
+    ENV_ENDPOINT: ""
+    ENV_USER: ""
+    MODULES: "esignet"
+    ENV_TESTLEVEL: "smokeAndRegression"
+    ## Chrome plus the JVM in one cgroup -- do not default anywhere near the
+    ## resources.limits.memory ceiling below (mosip/esignet#2544 §3.5).
+    JAVA_EXTRA_OPTS: "-Xmx2g"
+    ## Scope a run further. Leave blank for the full suite -- entrypoint.sh
+    ## only adds these to the java command line when non-empty, so blank
+    ## here is safe (unlike the ConfigMap/Secret keys below, where blank
+    ## actively overrides a JAR default -- see that comment).
+    CUCUMBER_FILTER_TAGS: ""
+    RUN_ONLY_SCENARIO: ""
+    FEATURE_FILES_TO_EXECUTE: ""
+
+  ## ConfigMap data -- includes hyphenated keys (e.g. keycloak-external-url)
+  ## that are NOT valid as individual container env: names. envFrom would
+  ## accept them syntactically, but the kubelet silently drops
+  ## envFrom-sourced keys containing '-' on Kubernetes versions before 1.32
+  ## (RelaxedEnvironmentVariableValidation is beta in 1.32, GA in 1.34) --
+  ## so instead this whole map is mounted as one file per key
+  ## (templates/configmap.yaml + the pod template's volume/volumeMount),
+  ## and a wrapper script reads those files and injects them via
+  ## `env KEY=VALUE ...` before exec'ing the image's own entrypoint. This
+  ## works on any Kubernetes version, since filenames have no such
+  ## restriction. See templates/_helpers.tpl's own comment for the exact
+  ## mechanism.
+  ##
+  ## IMPORTANT (mosip/esignet#2544 "silent trap"): apitest-commons'
+  ## ConfigManager does `System.getenv(key) ?? propsMap.get(key)` -- env
+  ## ALWAYS wins, and an env var that is PRESENT BUT EMPTY still wins,
+  ## wiping the JAR's own config.properties default rather than falling
+  ## through to it. Every key below is only rendered into the ConfigMap at
+  ## all when non-empty (see templates/configmap.yaml) -- leave a value
+  ## blank here to omit that key entirely and let the JAR default apply.
+  configMap:
+    ## Relying-party (health-services) origin. OIDC redirect_uris must be
+    ## exactly this + "userprofile".
+    baseurl: ""
+    localeUrl: ""
+    ## Do NOT let this be derived from ENV_ENDPOINT (api-internal host) --
+    ## that mapping is wrong for eSignet-go (mosip/esignet#2544 §4).
+    eSignetbaseurl: ""
+    ## eSignet-go has no Spring actuator, so plugin auto-detection always
+    ## falls back to mosipid unless this is set explicitly.
+    pluginToExecute: "mock"
+    runLanguage: "eng"
+    ## NOTE: this value itself is cosmetic now -- the rendered ConfigMap's
+    ## actual runOnBrowserStack key is derived from uitestrig.browserstack.enabled
+    ## below (templates/configmap.yaml), so switching between in-cluster
+    ## Chrome and BrowserStack only needs that one flag changed, not this
+    ## value and browserstack.enabled kept in sync by hand.
+    runOnBrowserStack: "false"
+    ## Consent DB -- the UI harness only reads esignetDbHost/esignetDbPassword
+    ## (mosip/esignet#2434 §3.8); name/user/schema/port ship in the JAR.
+    esignetDbHost: ""
+    esignetDbPort: "5432"
+    keycloak-external-url: ""
+    push-reports-to-s3: "no"
+    s3-host: ""
+    s3-region: ""
+    s3-account: "uitestrig"
+
+  ## Existing ConfigMaps/Secrets to also pull env from (envFrom), e.g. a
+  ## shared esignet-global ConfigMap already deployed alongside eSignet
+  ## itself in this namespace.
+  extraEnvVarsCM: []
+  extraEnvVarsSecretRefs: []
+
+  ## Secret data -- same file-mount treatment as configMap above (not
+  ## envFrom, for the same K8s-version reason), and the same "omit rather
+  ## than blank" rule.
+  secret:
+    esignetDbPassword: ""
+    keycloak_Password: ""
+    mosip_testrig_client_secret: ""
+    ## Pre-provisioned OIDC client(s); comma form "primary,secondary".
+    oidcClientId: ""
+    ## Pre-provisioned identities -- PII.
+    uin: ""
+    vid: ""
+    mockUin: ""
+    uinPhoneNumber: ""
+    emailLoginId: ""
+    passwordLoginUin: ""
+    passwordLoginPassword: ""
+    s3-user-key: ""
+    s3-user-secret: ""
+
+  browserstack:
+    ## Alternative to in-cluster Chrome (mosip/esignet#2544 §6ii-b). Needs
+    ## network egress to BrowserStack from the cluster; /dev/shm is unused
+    ## either way (ui-test's BaseTestUtil already adds --disable-dev-shm-usage
+    ## unconditionally, confirmed against src/main/java/utils/BaseTestUtil.java).
+    enabled: false
+    username: ""
+    accessKey: ""
+
+  ## Self-signed/internal certs? The JVM needs the target host's CA cert
+  ## imported into its own cacerts truststore -- this is still a JVM, same
+  ## pattern as the old Java apitestrig chart (mosip-functional-tests,
+  ## helm/apitestrig), just with paths corrected for this image's actual
+  ## base (eclipse-temurin, JAVA_HOME=/opt/java/openjdk -- NOT
+  ## /usr/local/openjdk-11 like the old chart's openjdk-11-based image).
+  ## UNVERIFIED against a live cluster -- test before relying on it.
+  enableInsecure: false
+
+  tls:
+    ## Required (helm upgrade fails without it) when enableInsecure above is
+    ## true. The full PEM content of the CA cert to trust -- obtain this
+    ## through a channel you actually trust (e.g. copy it directly from the
+    ## eSignet ingress/load balancer's own TLS config), not by fetching
+    ## whatever a live connection presents at deploy time: doing that would
+    ## trust anything a network or DNS attacker's endpoint presents instead,
+    ## which is exactly the gap pinning a specific cert here closes.
+    caCert: ""
+
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## Headless Chromium + the JVM in one pod needs real headroom
+## (mosip/esignet#2544 §3.2) -- this is the #1 thing the generic
+## mosip/uitestrig chart (mosip-functional-tests) has no lever for at all.
+##
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: 500m
+    memory: 2Gi
+
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## The image's own USER is mosip:mosip (uid/gid 1001) -- see Dockerfile.
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+
+istio:
+  sidecarInject: false
+
+hostAliases: []
+
+podAffinityPreset: ""
+podAntiAffinityPreset: soft
+nodeAffinityPreset:
+  type: ""
+  key: ""
+  values: []
+affinity: {}
+nodeSelector: {}
+tolerations: []
+
+podLabels: {}
+podAnnotations: {}
+
+serviceAccount:
+  create: true
+  name: ""
+
+## ---------------------------------------------------------------------------
+## Reports
+## ---------------------------------------------------------------------------
+reports:
+  ## Extent HTML report. ui-test pushes this to S3 itself, in-process
+  ## (BaseTest.pushReportsToS3) -- unlike the Go api-test rig, there is no
+  ## external uploader sidecar here at all. Set uitestrig.configMap's
+  ## push-reports-to-s3=yes plus s3-host/s3-region/s3-account (ConfigMap) and
+  ## s3-user-key/s3-user-secret (Secret) above to use it.
+  mountPath: /home/mosip/test-output
+  ## Screenshots on failure.
+  screenshotsMountPath: /home/mosip/screenshots
+
+  ## Only relevant if you're NOT using the in-process S3 push above --
+  ## mounts a PVC at both paths so reports/screenshots survive past the
+  ## pod's own lifetime, retrievable via `kubectl cp`. The generic
+  ## mosip/uitestrig chart has no PVC template at all; this fills that gap.
+  persistence:
+    enabled: false
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    existingClaim: ""


### PR DESCRIPTION
…wrapper

Per mosip/esignet#2544's gap analysis: the generic mosip/uitestrig chart (mosip-functional-tests) has no lever for container resources or a reports PVC at all (confirmed against its own templates/cronjob.yaml), and its templates/secrets.yaml is missing the '---' document separator templates/configmaps.yaml has between loop iterations -- with more than one entry under uitestrig.secrets, the rendered manifest becomes one malformed multi-document YAML and every secret but the last is silently dropped. This is a new, purpose-built chart instead, named esignet-uitestrig (not uitestrig) to avoid any future collision with that chart in a shared repo.

This is unrelated to the Go api-test harness / helm/esignet-apitestrig -- 'develop-go' in the image tag just means 'built from the develop-go branch,' not that ui-test itself is Go-based. ui-test is 100% Java (Cucumber + TestNG + Selenium), runs as a JVM process, and pushes its own reports to S3 in-process (BaseTest.pushReportsToS3) -- there is no external uploader sidecar here like apitestrig's report-uploader.

Verified against real source before building, not just the issue's own claims:
  - ui-test/Dockerfile: base image, uid/gid 1001, report paths
  - ui-test/entrypoint.sh: which env vars it reads, and that optional ones are only added to the java command line when non-empty
  - src/main/java/utils/BaseTestUtil.java:240-241: --no-sandbox and --disable-dev-shm-usage ARE unconditionally added to ChromeOptions, confirming no /dev/shm volume is actually needed despite the issue's own suggestion to add one
  - the real mosip-functional-tests/helm/uitestrig chart source, for both bugs above

Chart contents (helm/esignet-uitestrig):
  - CronJob or Job trigger, same pattern as esignet-apitestrig
  - uitestrig.configMap / uitestrig.secret: rendered into a ConfigMap/ Secret wired up via envFrom (not individual env: entries), since several harness config keys contain hyphens (keycloak-external-url, push-reports-to-s3, ...) that Kubernetes' stricter C-identifier validation rejects for env:.name but envFrom permits. Every key only renders when non-empty by default, since apitest-commons' ConfigManager treats a present-but-empty env var as overriding (wiping) the JAR's own config.properties default rather than falling through to it (issue's 'silent trap') -- with explicit required() validation for the S3 credentials/endpoint specifically, gated on push-reports-to-s3 == "yes", so a missing value fails loudly at helm upgrade instead of silently at runtime.
  - uitestrig.extraEnvVars: plain env: entries for the non-hyphenated keys entrypoint.sh reads directly (ENV_ENDPOINT, MODULES, ...)
  - Resources default to 500m-2 CPU / 2-4Gi memory (Chromium + JVM in one pod needs real headroom) with JAVA_EXTRA_OPTS defaulting to -Xmx2g, well under the memory limit
  - Report storage: in-process S3 push (push-reports-to-s3=yes, default) or a PVC (reports.persistence.enabled=true) -- the chart's own prepare-report-dirs init container recreates test-output/SparkReport/ (baked into the image) that a fresh volume mount would otherwise hide
  - Browser: in-cluster Chromium by default, or BrowserStack via uitestrig.browserstack (credentials required() when enabled)
  - uitestrig.enableInsecure: JVM cacerts import init container for self-signed TLS, same pattern as the old Java apitestrig chart but with paths corrected for this image's actual base (eclipse-temurin, JAVA_HOME=/opt/java/openjdk, confirmed against Adoptium's own docs -- NOT /usr/local/openjdk-11 like that older chart's image). Flagged as UNVERIFIED against a live cluster in both values.yaml and the README.
  - podSecurityContext/containerSecurityContext default to uid/gid 1001 (confirmed from the Dockerfile's own USER directive). ServiceAccount token automount left at the k8s default (enabled) rather than disabled, since this image ships kubectl and the issue notes it may be used for report-push helpers at runtime -- unverified whether that needs API access, so left conservative.
  - Chart's own values.yaml keeps a working default image so a bare helm install works standalone; the deploy wrapper below intentionally overrides it at runtime instead.

Deploy wrapper (deploy/esignet-uitestrig), mirroring esignet-apitestrig's install.sh pattern:
  - Only two prompts (eSignet base URL, values.yaml confirmation) -- everything else lives in values.yaml (tracked, every environment-specific value UPDATE-marked) and values.secret.yaml (gitignored -- consent DB password, Keycloak admin password, testrig client secret, pre-provisioned OIDC client(s), test identities/PII, S3 keys; values.secret.yaml.example is the tracked template, using blank rather than "changeme" for fields that are genuinely optional depending on feature flags, so install.sh's placeholder check doesn't false-positive on unused fields).
  - Also prompts for image repository/tag at runtime (values.yaml leaves this commented out deliberately).
  - Installs into its own esignet-uitestrig namespace, separate from esignet-apitestrig's esignet namespace -- a deliberate choice (this chart's own ConfigMap/Secret naming would make a shared namespace equally safe, unlike the old generic chart), with install-time defaults still read from the esignet namespace via a separate SOURCE_NS.
  - Installs via helm repo add/update + helm upgrade --install by chart name/version from mosip-helm, not a local path -- only works once helm/esignet-uitestrig merges upstream and gets published there, same accepted tradeoff as esignet-apitestrig's install.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a deployable eSignet UI test rig for automated Java-based browser testing.
  - Supports scheduled or manually triggered test runs.
  - Supports in-cluster Chromium or BrowserStack execution with configurable TLS handling.
  - Added optional report persistence through S3-compatible storage or persistent volumes.
  - Added configurable resources, credentials, environment settings, and service account support.
  - Added installation and removal scripts for simplified deployment management.

- **Documentation**
  - Added setup, configuration, execution, troubleshooting, and report retrieval guidance.
  - Added an example secrets configuration for required credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->