### PR TITLE
#2315 Fix: Added optional ConfigMap volume mount to allow external flow YAML override without image rebuild.

### DIFF
--- a/helm/esignet/templates/deployment.yaml
+++ b/helm/esignet/templates/deployment.yaml
@@ -194,6 +194,10 @@ spec:
           - name: {{ .Values.persistence.volume_name }}
             mountPath: {{ .Values.persistence.mountDir }}
           {{- end }}
+          - name: flow-config-volume
+            mountPath: /home/mosip/data/flows/flow-esignet.yaml
+            subPath: flow-esignet.yaml
+            readOnly: true
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
@@ -207,3 +211,10 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default .Values.persistence.pvc_claim_name  }}
       {{ end }}
+      - name: flow-config-volume
+        configMap:
+          name: esignet-flow-config
+          optional: true
+          items:
+            - key: flow-esignet.yaml
+              path: flow-esignet.yaml


### PR DESCRIPTION
**Related Issue:** #2315 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment configuration to optionally provide an external flow configuration for eSignet.
  - Existing deployments remain unaffected when the configuration is not supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->