### PR TITLE
#2598 updated install.sh and values.yaml

### DIFF
--- a/deploy/esignet/install.sh
+++ b/deploy/esignet/install.sh
@@ -214,7 +214,7 @@ function installing_esignet() {
     elif [[ "$plugin_no" == "3" ]]; then
       plugin_name="sunbird"
       read -p "Provide the URL for Sunbird registry: " sunbird_registry_url
-      extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL\": \"$sunbird_registry_url\""$'\n'
+      extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL\": \"$sunbird_registry_url/api/v1/Insurance/\""$'\n'
       extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL\": \"$sunbird_registry_url/api/v1/Insurance/search\""$'\n'
       extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_DEFAULT_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD\": \"\${mosip.esignet.authenticator.sunbird-rc.auth-factor.kbi.individual-id-field}\""$'\n'
       extra_env_vars_additional+="  \"MOSIP_ESIGNET_AUTHENTICATOR_DEFAULT_AUTH_FACTOR_KBI_FIELD_DETAILS\": \"\${mosip.esignet.authenticator.sunbird-rc.auth-factor.kbi.field-details}\""$'\n'

--- a/helm/esignet/values.yaml
+++ b/helm/esignet/values.yaml
@@ -254,7 +254,6 @@ extraEnvVars:
       configMapKeyRef:
         name: keycloak-host
         key: keycloak-external-url
-  MOSIP_ESIGNET_AUTHN_PROVIDER: mosip
   MOSIP_API_INTERNAL_HOST:
     valueFrom:
       configMapKeyRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sunbird registry requests now use the expected `/api/v1/Insurance/` API path during eSignet installation.

- **Configuration**
  - Removed the default `mosip` authentication provider setting from the Helm chart. Deployments must now determine or provide the authentication provider through their configured environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->