### PR TITLE
Re-add ui-test CI jobs to push-trigger.yml

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -122,6 +122,85 @@ jobs:
       RELEASE_DOCKER_HUB: ${{ secrets.RELEASE_DOCKER_HUB }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
+  build-maven-uitest-esignet:
+    uses: mosip/kattu/.github/workflows/maven-build.yml@master-java21
+    with:
+      SERVICE_LOCATION: ./ui-test
+      BUILD_ARTIFACT: uitest-esignet
+    secrets:
+      OSSRH_USER: ${{ secrets.OSSRH_USER }}
+      OSSRH_SECRET: ${{ secrets.OSSRH_SECRET }}
+      OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+      GPG_SECRET: ${{ secrets.GPG_SECRET }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
+  build-uitest-esignet-local:
+    needs: build-maven-uitest-esignet
+    runs-on: ubuntu-latest
+    env:
+      SERVICE_LOCATION: ui-test
+      BUILD_ARTIFACT: uitest-esignet-local
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          server-id: ossrh
+          settings-path: ${{ github.workspace }}
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup the settings file for ossrh server
+        run: echo "<settings> <servers>  <server>  <id>ossrh</id>    <username>${{secrets.ossrh_user}}</username> <password>${{secrets.ossrh_secret}}</password> </server> </servers> <profiles> <profile>     <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation>  <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.gpg_secret}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id>       <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository>        <id>snapshots-repo</id> <url>https://central.sonatype.com/repository/maven-snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository>  <repository>         <id>releases-repo</id>  <url>https://central.sonatype.com/api/v1/publisher</url>         <releases><enabled>true</enabled></releases>         <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> <repository> <id>nexus-snapshots</id> <url>https://oss.sonatype.org/content/repositories/snapshots</url> </repository> </repositories>  </profile> <profile> <id>sonar</id> <properties>  <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url>  </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml
+
+      - name: Build ui-test with Maven
+        run: |
+          cd ${{ env.SERVICE_LOCATION}}
+          mvn -U -B package -DskipTests -Dgpg.skip=true -Dmaven.gitcommitid.skip=true -Dmaven.wagon.http.retryHandler.count=2 --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
+
+      - name: Ready the springboot artifacts
+        if: ${{ !contains(github.ref, 'master') || !contains(github.ref, 'main') }}
+        run: |
+          find ${{ env.SERVICE_LOCATION }} -path '*/target/*' -name '*.jar'  -type f -exec zip ${{ env.BUILD_ARTIFACT }}.zip {} +
+
+      - name: Upload the springboot jars
+        if: ${{ !contains(github.ref, 'master') || !contains(github.ref, 'main') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: ${{ env.BUILD_ARTIFACT }}.zip
+
+  build-dockers-uitest-esignet:
+    needs: build-uitest-esignet-local
+    strategy:
+      matrix:
+        include:
+          - SERVICE_LOCATION: 'ui-test'
+            SERVICE_NAME: 'uitest-esignet'
+            BUILD_ARTIFACT: 'uitest-esignet-local'
+            PLATFORMS: "linux/amd64"
+      fail-fast: false
+    name: ${{ matrix.SERVICE_NAME }}
+    uses: mosip/kattu/.github/workflows/docker-build.yml@master-java21
+    with:
+      SERVICE_LOCATION: ${{ matrix.SERVICE_LOCATION }}
+      SERVICE_NAME: ${{ matrix.SERVICE_NAME }}
+      BUILD_ARTIFACT: ${{ matrix.BUILD_ARTIFACT }}
+      PLATFORMS: ${{ matrix.PLATFORMS }}
+    secrets:
+      DEV_NAMESPACE_DOCKER_HUB: ${{ secrets.DEV_NAMESPACE_DOCKER_HUB }}
+      ACTOR_DOCKER_HUB: ${{ secrets.ACTOR_DOCKER_HUB }}
+      RELEASE_DOCKER_HUB: ${{ secrets.RELEASE_DOCKER_HUB }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
   # api-test: two Go modules (stdlib-only parent + nested api/, godog+gjson) in
   # one directory, so this stays a plain build/vet job rather than the
   # single-module go-build.yml reusable workflow (mirrors build_maven_apitest_esignet

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -127,6 +127,7 @@ jobs:
     with:
       SERVICE_LOCATION: ./ui-test
       BUILD_ARTIFACT: uitest-esignet
+      MAVEN_NON_EXEC_ARTIFACTS: "uitest-esignet.jar"
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}
       OSSRH_SECRET: ${{ secrets.OSSRH_SECRET }}
@@ -134,58 +135,14 @@ jobs:
       GPG_SECRET: ${{ secrets.GPG_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
-  build-uitest-esignet-local:
-    needs: build-maven-uitest-esignet
-    runs-on: ubuntu-latest
-    env:
-      SERVICE_LOCATION: ui-test
-      BUILD_ARTIFACT: uitest-esignet-local
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          server-id: ossrh
-          settings-path: ${{ github.workspace }}
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Setup the settings file for ossrh server
-        run: echo "<settings> <servers>  <server>  <id>ossrh</id>    <username>${{secrets.ossrh_user}}</username> <password>${{secrets.ossrh_secret}}</password> </server> </servers> <profiles> <profile>     <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation>  <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.gpg_secret}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id>       <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository>        <id>snapshots-repo</id> <url>https://central.sonatype.com/repository/maven-snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository>  <repository>         <id>releases-repo</id>  <url>https://central.sonatype.com/api/v1/publisher</url>         <releases><enabled>true</enabled></releases>         <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> <repository> <id>nexus-snapshots</id> <url>https://oss.sonatype.org/content/repositories/snapshots</url> </repository> </repositories>  </profile> <profile> <id>sonar</id> <properties>  <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url>  </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml
-
-      - name: Build ui-test with Maven
-        run: |
-          cd ${{ env.SERVICE_LOCATION}}
-          mvn -U -B package -DskipTests -Dgpg.skip=true -Dmaven.gitcommitid.skip=true -Dmaven.wagon.http.retryHandler.count=2 --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
-
-      - name: Ready the springboot artifacts
-        if: ${{ !contains(github.ref, 'master') || !contains(github.ref, 'main') }}
-        run: |
-          find ${{ env.SERVICE_LOCATION }} -path '*/target/*' -name '*.jar'  -type f -exec zip ${{ env.BUILD_ARTIFACT }}.zip {} +
-
-      - name: Upload the springboot jars
-        if: ${{ !contains(github.ref, 'master') || !contains(github.ref, 'main') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.BUILD_ARTIFACT }}
-          path: ${{ env.BUILD_ARTIFACT }}.zip
-
   build-dockers-uitest-esignet:
-    needs: build-uitest-esignet-local
+    needs: build-maven-uitest-esignet
     strategy:
       matrix:
         include:
           - SERVICE_LOCATION: 'ui-test'
             SERVICE_NAME: 'uitest-esignet'
-            BUILD_ARTIFACT: 'uitest-esignet-local'
+            BUILD_ARTIFACT: 'uitest-esignet'
             PLATFORMS: "linux/amd64"
       fail-fast: false
     name: ${{ matrix.SERVICE_NAME }}


### PR DESCRIPTION
## Summary
- `release-2.0.x`'s `push-trigger.yml` has no jobs for `ui-test`, so pushes to this branch never build or publish its docker image, unlike every other service wired up in this workflow.
- Re-adds `build-maven-uitest-esignet`, `build-uitest-esignet-local`, and `build-dockers-uitest-esignet`, matching how `MOSIP-45488-uitest-combined` already has them.
- These jobs were originally part of #2587 but were deliberately reverted there before merge so that PR wouldn't touch `.github/workflows`. This PR re-adds just that piece, on its own, as a minimal single-file change.

## Test plan
- [ ] Confirm `build-maven-uitest-esignet`, `build-uitest-esignet-local`, and `build-dockers-uitest-esignet` run and pass on a push to `release-2.0.x` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build workflows for the UI test service.
  * Added packaging and artifact upload support for non-main branches.
  * Added automated Docker image builds and publishing for Linux AMD64 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->